### PR TITLE
Refresh caches on any SDK-driven creates or deletes

### DIFF
--- a/pyatlan/cache/classification_cache.py
+++ b/pyatlan/cache/classification_cache.py
@@ -15,7 +15,7 @@ class ClassificationCache:
     deleted_names: set[str] = set()
 
     @classmethod
-    def _refresh_cache(cls) -> None:
+    def refresh_cache(cls) -> None:
         from pyatlan.client.atlan import AtlanClient
 
         client = AtlanClient.get_default_client()
@@ -41,7 +41,7 @@ class ClassificationCache:
         cls_id = cls.map_name_to_id.get(name)
         if not cls_id and name not in cls.deleted_names:
             # If not found, refresh the cache and look again (could be stale)
-            cls._refresh_cache()
+            cls.refresh_cache()
             cls_id = cls.map_name_to_id.get(name)
             if not cls_id:
                 # If still not found after refresh, mark it as deleted (could be
@@ -58,7 +58,7 @@ class ClassificationCache:
         cls_name = cls.map_id_to_name.get(idstr)
         if not cls_name and idstr not in cls.deleted_ids:
             # If not found, refresh the cache and look again (could be stale)
-            cls._refresh_cache()
+            cls.refresh_cache()
             cls_name = cls.map_id_to_name.get(idstr)
             if not cls_name:
                 # If still not found after refresh, mark it as deleted (could be

--- a/pyatlan/cache/custom_metadata_cache.py
+++ b/pyatlan/cache/custom_metadata_cache.py
@@ -35,7 +35,7 @@ class CustomMetadataCache:
     types_by_asset: dict[str, set[type]] = dict()
 
     @classmethod
-    def _refresh_cache(cls) -> None:
+    def refresh_cache(cls) -> None:
         from pyatlan.model.core import CustomMetadata, to_snake_case
 
         client = AtlanClient.get_default_client()
@@ -98,7 +98,7 @@ class CustomMetadataCache:
         if cm_id := cls.map_name_to_id.get(name):
             return cm_id
         # If not found, refresh the cache and look again (could be stale)
-        cls._refresh_cache()
+        cls.refresh_cache()
         return cls.map_name_to_id.get(name)
 
     @classmethod
@@ -109,14 +109,14 @@ class CustomMetadataCache:
         if cm_name := cls.map_id_to_name.get(idstr):
             return cm_name
         # If not found, refresh the cache and look again (could be stale)
-        cls._refresh_cache()
+        cls.refresh_cache()
         return cls.map_id_to_name.get(idstr)
 
     @classmethod
     def get_type_for_id(cls, idstr: str) -> Optional[type]:
         if cm_type := cls.map_id_to_type.get(idstr):
             return cm_type
-        cls._refresh_cache()
+        cls.refresh_cache()
         return cls.map_id_to_type.get(idstr)
 
     @classmethod
@@ -129,7 +129,7 @@ class CustomMetadataCache:
         of each of those attributes).
         """
         if len(cls.cache_by_id) == 0 or force_refresh:
-            cls._refresh_cache()
+            cls.refresh_cache()
         m = {}
         for type_id, cm in cls.cache_by_id.items():
             type_name = cls.get_name_for_id(type_id)
@@ -165,7 +165,7 @@ class CustomMetadataCache:
                 # If found, return straight away
                 return attr_id
             # Otherwise, refresh the cache and look again (could be stale)
-            cls._refresh_cache()
+            cls.refresh_cache()
             if sub_map := cls.map_attr_name_to_id.get(set_id):
                 return sub_map.get(attr_name)
         return None
@@ -180,7 +180,7 @@ class CustomMetadataCache:
             attr_name = sub_map.get(attr_id)
             if attr_name:
                 return attr_name
-            cls._refresh_cache()
+            cls.refresh_cache()
             if sub_map := cls.map_attr_id_to_name.get(set_id):
                 return sub_map.get(attr_id)
         return None
@@ -200,7 +200,7 @@ class CustomMetadataCache:
         if set_id := cls.get_id_for_name(set_name):
             if dot_names := cls._get_attributes_for_search_results(set_id):
                 return dot_names
-            cls._refresh_cache()
+            cls.refresh_cache()
             return cls._get_attributes_for_search_results(set_id)
         return None
 

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -77,7 +77,6 @@ from pyatlan.model.typedef import (
     TypeDefResponse,
 )
 from pyatlan.utils import HTTPStatus, get_logger
-from pyatlan.cache import CustomMetadataCache, ClassificationCache
 
 LOGGER = get_logger()
 T = TypeVar("T", bound=Referenceable)
@@ -484,8 +483,10 @@ class AtlanClient(BaseSettings):
             CREATE_TYPE_DEFS, request_obj=payload, exclude_unset=False
         )
         if isinstance(typedef, ClassificationDef):
+            from pyatlan.cache.classification_cache import ClassificationCache
             ClassificationCache.refresh_cache()
         if isinstance(typedef, CustomMetadataDef):
+            from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
             CustomMetadataCache.refresh_cache()
         return TypeDefResponse(**raw_json)
 
@@ -493,6 +494,8 @@ class AtlanClient(BaseSettings):
         self._call_api(DELETE_TYPE_DEF_BY_NAME.format_path_with_params(internal_name))
         # TODO: if we know which kind of typedef is being purged, we only need
         #  to refresh that particular cache
+        from pyatlan.cache.classification_cache import ClassificationCache
+        from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
         ClassificationCache.refresh_cache()
         CustomMetadataCache.refresh_cache()
 


### PR DESCRIPTION
- Forces a cache refresh any time a new custom metadata or classification typedef is created or deleted
- Renames `_refresh_cache` methods within the caches to `refresh_cache`, since they're no longer private