### PR TITLE
fix: invalid default argument

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -713,7 +713,7 @@ class AtlanClient(BaseSettings):
         self,
         name: str,
         connector_type: AtlanConnectorType,
-        attributes: list[str] = None,
+        attributes: list[str] = [],
     ) -> list[Connection]:
         query = (
             Term.with_state("ACTIVE")


### PR DESCRIPTION
Current default value for parameter `attributes` causes error:
>  none is not an allowed value (type=type_error.none.not_allowed)