### PR TITLE
Adds a creation-only semantic operation, and renames upsert to save

### DIFF
--- a/pyatlan/events/atlan_event_handler.py
+++ b/pyatlan/events/atlan_event_handler.py
@@ -152,4 +152,4 @@ class AtlanEventHandler(ABC):  # noqa: B024
         """
         # TODO: Migrate to an AssetBatch once implemented
         for one in changed_assets:
-            self.client.upsert_merging_cm(one)
+            self.client.save_merging_cm(one)

--- a/tests/integration/connection_test.py
+++ b/tests/integration/connection_test.py
@@ -18,7 +18,7 @@ def create_connection(
     to_create = Connection.create(
         name=name, connector_type=connector_type, admin_roles=[admin_role_guid]
     )
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     result = response.assets_created(asset_type=Connection)[0]
     return client.get_asset_by_guid(result.guid, asset_type=Connection)
 

--- a/tests/integration/custom_metadata_test.py
+++ b/tests/integration/custom_metadata_test.py
@@ -763,7 +763,7 @@ def test_update_replacing_cm(
         qualified_name=term.qualified_name, name=term.name, glossary_guid=glossary.guid
     )
     to_update.set_custom_metadata(custom_metadata=raci)
-    response = client.upsert_replacing_cm(to_update, replace_atlan_tagss=False)
+    response = client.update_replacing_cm(to_update, replace_atlan_tags=False)
     assert response
     assert len(response.assets_deleted(asset_type=AtlasGlossaryTerm)) == 0
     assert len(response.assets_created(asset_type=AtlasGlossaryTerm)) == 0
@@ -980,7 +980,7 @@ def test_add_badge_cm_dq(
     )
     badge.user_description = "How many data quality checks ran against this asset."
     assert badge.status == EntityStatus.ACTIVE
-    response = client.upsert(badge)
+    response = client.save(badge)
     assert (badges := response.assets_created(asset_type=Badge))
     assert len(badges) == 1
     client.purge_entity_by_guid(badges[0].guid)

--- a/tests/integration/file_test.py
+++ b/tests/integration/file_test.py
@@ -45,7 +45,7 @@ def file(client: AtlanClient, connection: Connection) -> Generator[File, None, N
         file_type=FileType.PDF,
     )
     to_create.file_path = "https://www.example.com"
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     result = response.assets_created(asset_type=File)[0]
     yield result
     delete_asset(client, guid=result.guid, asset_type=File)

--- a/tests/integration/lineage_test.py
+++ b/tests/integration/lineage_test.py
@@ -64,7 +64,7 @@ def create_database(client, connection, database_name: str):
     to_create = Database.create(
         name=database_name, connection_qualified_name=connection.qualified_name
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     return result.assets_created(asset_type=Database)[0]
 
 
@@ -77,7 +77,7 @@ def schema(
     to_create = Schema.create(
         name=SCHEMA_NAME, database_qualified_name=database.qualified_name
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     sch = result.assets_created(asset_type=Schema)[0]
     yield sch
     delete_asset(client, guid=sch.guid, asset_type=Schema)
@@ -93,7 +93,7 @@ def table(
     to_create = Table.create(
         name=TABLE_NAME, schema_qualified_name=schema.qualified_name
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     tbl = result.assets_created(asset_type=Table)[0]
     yield tbl
     delete_asset(client, guid=tbl.guid, asset_type=Table)
@@ -109,7 +109,7 @@ def mview(
     to_create = MaterialisedView.create(
         name=MVIEW_NAME, schema_qualified_name=schema.qualified_name
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     mv = result.assets_created(asset_type=MaterialisedView)[0]
     yield mv
     delete_asset(client, guid=mv.guid, asset_type=MaterialisedView)
@@ -123,7 +123,7 @@ def view(
     schema: Schema,
 ) -> Generator[View, None, None]:
     to_create = View.create(name=VIEW_NAME, schema_qualified_name=schema.qualified_name)
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     v = result.assets_created(asset_type=View)[0]
     yield v
     delete_asset(client, guid=v.guid, asset_type=View)
@@ -143,7 +143,7 @@ def column1(
         parent_qualified_name=table.qualified_name,
         order=1,
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     c = result.assets_created(asset_type=Column)[0]
     yield c
     delete_asset(client, guid=c.guid, asset_type=Column)
@@ -163,7 +163,7 @@ def column2(
         parent_qualified_name=table.qualified_name,
         order=2,
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     c = result.assets_created(asset_type=Column)[0]
     yield c
     delete_asset(client, guid=c.guid, asset_type=Column)
@@ -183,7 +183,7 @@ def column3(
         parent_qualified_name=mview.qualified_name,
         order=1,
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     c = result.assets_created(asset_type=Column)[0]
     yield c
     delete_asset(client, guid=c.guid, asset_type=Column)
@@ -203,7 +203,7 @@ def column4(
         parent_qualified_name=mview.qualified_name,
         order=2,
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     c = result.assets_created(asset_type=Column)[0]
     yield c
     delete_asset(client, guid=c.guid, asset_type=Column)
@@ -223,7 +223,7 @@ def column5(
         parent_qualified_name=view.qualified_name,
         order=1,
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     c = result.assets_created(asset_type=Column)[0]
     yield c
     delete_asset(client, guid=c.guid, asset_type=Column)
@@ -243,7 +243,7 @@ def column6(
         parent_qualified_name=view.qualified_name,
         order=2,
     )
-    result = client.upsert(to_create)
+    result = client.save(to_create)
     c = result.assets_created(asset_type=Column)[0]
     yield c
     delete_asset(client, guid=c.guid, asset_type=Column)
@@ -266,7 +266,7 @@ def lineage_start(
         inputs=[Table.ref_by_guid(table.guid)],
         outputs=[MaterialisedView.ref_by_guid(mview.guid)],
     )
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     ls = response.assets_created(asset_type=Process)[0]
     yield ls
     delete_asset(client, guid=ls.guid, asset_type=Process)
@@ -315,7 +315,7 @@ def lineage_end(
         inputs=[MaterialisedView.ref_by_guid(mview.guid)],
         outputs=[View.ref_by_guid(view.guid)],
     )
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     ls = response.assets_created(asset_type=Process)[0]
     yield ls
     delete_asset(client, guid=ls.guid, asset_type=Process)
@@ -686,7 +686,7 @@ def test_restore_lineage(
         lineage_start.qualified_name, lineage_start.name
     )
     to_restore.status = EntityStatus.ACTIVE
-    client.upsert(to_restore)
+    client.save(to_restore)
     restored = client.get_asset_by_guid(lineage_start.guid, asset_type=Process)
     assert restored
     count = 0

--- a/tests/integration/persona_test.py
+++ b/tests/integration/persona_test.py
@@ -50,7 +50,7 @@ def persona(
     glossary: AtlasGlossary,
 ) -> Generator[Persona, None, None]:
     to_create = Persona.create(name=MODULE_NAME)
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     p = response.assets_created(asset_type=Persona)[0]
     yield p
     delete_asset(client, guid=p.guid, asset_type=Persona)
@@ -86,7 +86,7 @@ def test_update_persona(
         AssetSidebarTab.RELATIONS.value,
         AssetSidebarTab.QUERIES.value,
     }
-    response = client.upsert(to_update)
+    response = client.save(to_update)
     assert response
     updated = response.assets_updated(asset_type=Persona)
     assert updated
@@ -146,7 +146,7 @@ def test_add_policies_to_persona(
         actions={PersonaGlossaryAction.CREATE, PersonaGlossaryAction.UPDATE},
         resources={f"entity:{glossary.qualified_name}"},
     )
-    response = client.upsert([metadata, data, glossary_policy])
+    response = client.save([metadata, data, glossary_policy])
     assert response
     personas = response.assets_updated(asset_type=Persona)
     assert personas

--- a/tests/integration/purpose_test.py
+++ b/tests/integration/purpose_test.py
@@ -37,7 +37,7 @@ def purpose(
     atlan_tag: AtlanTagDef,
 ) -> Generator[Purpose, None, None]:
     to_create = Purpose.create(name=MODULE_NAME, atlan_tags=[atlan_tag.display_name])
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     p = response.assets_created(asset_type=Purpose)[0]
     yield p
     delete_asset(client, guid=p.guid, asset_type=Purpose)
@@ -69,7 +69,7 @@ def test_update_purpose(
         AssetSidebarTab.RELATIONS.value,
         AssetSidebarTab.QUERIES.value,
     }
-    response = client.upsert(to_update)
+    response = client.save(to_update)
     assert response
     updated = response.assets_updated(asset_type=Purpose)
     assert updated
@@ -117,7 +117,7 @@ def test_add_policies_to_purpose(
         all_users=True,
     )
     data.policy_mask_type = DataMaskingType.HASH
-    response = client.upsert([metadata, data])
+    response = client.save([metadata, data])
     assert response
     purposes = response.assets_updated(asset_type=Purpose)
     assert purposes

--- a/tests/integration/s3_asset_test.py
+++ b/tests/integration/s3_asset_test.py
@@ -37,7 +37,7 @@ def bucket(
         connection_qualified_name=connection.qualified_name,
         aws_arn=BUCKET_ARN,
     )
-    response = client.upsert(to_create)
+    response = client.save(to_create)
     result = response.assets_created(asset_type=S3Bucket)[0]
     yield result
     delete_asset(client, guid=result.guid, asset_type=S3Bucket)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -232,7 +232,7 @@ def test_get_asset_by_guid_bad_with_non_existent_guid_raises_not_found_error(
 
 
 def test_upsert_when_no_changes(client: AtlanClient, glossary: AtlasGlossary):
-    response = client.upsert(glossary)
+    response = client.save(glossary)
     assert not response.guid_assignments
     assert not response.mutated_entities
 

--- a/tests/integration/test_sql_assets.py
+++ b/tests/integration/test_sql_assets.py
@@ -27,7 +27,7 @@ def upsert(client: AtlanClient):
     guids: list[str] = []
 
     def _upsert(asset: Asset) -> AssetMutationResponse:
-        _response = client.upsert(asset)
+        _response = client.save(asset)
         if (
             _response
             and _response.mutated_entities
@@ -332,7 +332,7 @@ class TestColumn:
             parent_type=Table,
             order=1,
         )
-        response = client.upsert(column)
+        response = client.save(column)
         assert (columns := response.assets_created(asset_type=Column))
         assert len(columns) == 1
         column = client.get_asset_by_guid(asset_type=Column, guid=columns[0].guid)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -112,7 +112,7 @@ def test_append_with_valid_guid_when_no_terms_present_returns_asset_with_given_t
     ) as mock_methods:
         table = Table()
         mock_methods["get_asset_by_guid"].return_value = table
-        mock_methods["upsert"].return_value.assets_updated.return_value = [table]
+        mock_methods["save"].return_value.assets_updated.return_value = [table]
         client = AtlanClient()
         guid = "123"
         terms = [AtlasGlossaryTerm()]
@@ -137,7 +137,7 @@ def test_append_with_valid_guid_when_deleted_terms_present_returns_asset_with_gi
         term.relationship_status = "DELETED"
         table.attributes.meanings = [term]
         mock_methods["get_asset_by_guid"].return_value = table
-        mock_methods["upsert"].return_value.assets_updated.return_value = [table]
+        mock_methods["save"].return_value.assets_updated.return_value = [table]
         client = AtlanClient()
         guid = "123"
         terms = [AtlasGlossaryTerm()]
@@ -161,7 +161,7 @@ def test_append_with_valid_guid_when_terms_present_returns_asset_with_combined_t
         exisiting_term = AtlasGlossaryTerm()
         table.attributes.meanings = [exisiting_term]
         mock_methods["get_asset_by_guid"].return_value = table
-        mock_methods["upsert"].return_value.assets_updated.return_value = [table]
+        mock_methods["save"].return_value.assets_updated.return_value = [table]
         client = AtlanClient()
         guid = "123"
 
@@ -242,7 +242,7 @@ def test_replace_terms(
     ) as mock_methods:
         table = Table()
         mock_methods["get_asset_by_guid"].return_value = table
-        mock_methods["upsert"].return_value.assets_updated.return_value = [table]
+        mock_methods["save"].return_value.assets_updated.return_value = [table]
         client = AtlanClient()
         guid = "123"
         terms = [AtlasGlossaryTerm()]
@@ -330,7 +330,7 @@ def test_remove_with_valid_guid_when_terms_present_returns_asset_with_terms_remo
         other_term.guid = "b267858d-8316-4c41-a56a-6e9b840cef4a"
         table.attributes.meanings = [exisiting_term, other_term]
         mock_methods["get_asset_by_guid"].return_value = table
-        mock_methods["upsert"].return_value.assets_updated.return_value = [table]
+        mock_methods["save"].return_value.assets_updated.return_value = [table]
         client = AtlanClient()
         guid = "123"
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -108,7 +108,7 @@ def test_append_with_valid_guid_when_no_terms_present_returns_asset_with_given_t
     monkeypatch.setenv("ATLAN_API_KEY", "abkj")
     asset_type = Table
     with patch.multiple(
-        AtlanClient, get_asset_by_guid=DEFAULT, upsert=DEFAULT
+        AtlanClient, get_asset_by_guid=DEFAULT, save=DEFAULT
     ) as mock_methods:
         table = Table()
         mock_methods["get_asset_by_guid"].return_value = table
@@ -130,7 +130,7 @@ def test_append_with_valid_guid_when_deleted_terms_present_returns_asset_with_gi
     monkeypatch.setenv("ATLAN_API_KEY", "abkj")
     asset_type = Table
     with patch.multiple(
-        AtlanClient, get_asset_by_guid=DEFAULT, upsert=DEFAULT
+        AtlanClient, get_asset_by_guid=DEFAULT, save=DEFAULT
     ) as mock_methods:
         table = Table(attributes=Table.Attributes())
         term = AtlasGlossaryTerm()
@@ -155,7 +155,7 @@ def test_append_with_valid_guid_when_terms_present_returns_asset_with_combined_t
     monkeypatch.setenv("ATLAN_API_KEY", "abkj")
     asset_type = Table
     with patch.multiple(
-        AtlanClient, get_asset_by_guid=DEFAULT, upsert=DEFAULT
+        AtlanClient, get_asset_by_guid=DEFAULT, save=DEFAULT
     ) as mock_methods:
         table = Table(attributes=Table.Attributes())
         exisiting_term = AtlasGlossaryTerm()
@@ -238,7 +238,7 @@ def test_replace_terms(
     monkeypatch.setenv("ATLAN_API_KEY", "abkj")
     asset_type = Table
     with patch.multiple(
-        AtlanClient, get_asset_by_guid=DEFAULT, upsert=DEFAULT
+        AtlanClient, get_asset_by_guid=DEFAULT, save=DEFAULT
     ) as mock_methods:
         table = Table()
         mock_methods["get_asset_by_guid"].return_value = table
@@ -321,7 +321,7 @@ def test_remove_with_valid_guid_when_terms_present_returns_asset_with_terms_remo
     monkeypatch.setenv("ATLAN_API_KEY", "abkj")
     asset_type = Table
     with patch.multiple(
-        AtlanClient, get_asset_by_guid=DEFAULT, upsert=DEFAULT
+        AtlanClient, get_asset_by_guid=DEFAULT, save=DEFAULT
     ) as mock_methods:
         table = Table(attributes=Table.Attributes())
         exisiting_term = AtlasGlossaryTerm()

--- a/tests/unit/test_search_model.py
+++ b/tests/unit/test_search_model.py
@@ -86,18 +86,18 @@ INCOMPATIPLE_QUERY: dict[type, set[TermAttributes]] = {
     [
         (
             {},
-            "Term.__init__() missing 2 required positional arguments: 'field' and 'value'",
+            "__init__() missing 2 required positional arguments: 'field' and 'value'",
         ),
         (
             [
                 {"field": "bob"},
-                "Term.__init__() missing 1 required positional argument: 'value'",
+                "__init__() missing 1 required positional argument: 'value'",
             ]
         ),
         (
             [
                 {"value": "bob"},
-                "Term.__init__() missing 1 required positional argument: 'field'",
+                "__init__() missing 1 required positional argument: 'field'",
             ]
         ),
     ],

--- a/tests/unit/test_search_model.py
+++ b/tests/unit/test_search_model.py
@@ -84,17 +84,20 @@ INCOMPATIPLE_QUERY: dict[type, set[TermAttributes]] = {
 @pytest.mark.parametrize(
     "parameters, expected",
     [
-        ({}, "__init__() missing 2 required positional arguments: 'field' and 'value'"),
+        (
+            {},
+            "Term.__init__() missing 2 required positional arguments: 'field' and 'value'",
+        ),
         (
             [
                 {"field": "bob"},
-                "__init__() missing 1 required positional argument: 'value'",
+                "Term.__init__() missing 1 required positional argument: 'value'",
             ]
         ),
         (
             [
                 {"value": "bob"},
-                "__init__() missing 1 required positional argument: 'field'",
+                "Term.__init__() missing 1 required positional argument: 'field'",
             ]
         ),
     ],


### PR DESCRIPTION
- Adds new `update_merging_cm()` and `update_replacing_cm()` operations that strictly update (do not create)
- Renames various `upsert_...()` operations to `save_...()` (including `upsert()` -> `save()`), for two reasons:
    1. Clarity between `upsert` and `update` operations (above) in quickly reading code
    2. Consistency across SDKs

Also took the opportunity to consolidate duplicate code across the various `upsert...()` methods by instead calling each other.

(And added documentation to each of these methods to explain what they do directly in-IDE.)