### PR TITLE
DVX-51: Add JSON formatter to the logger

### DIFF
--- a/pyatlan/logging.conf
+++ b/pyatlan/logging.conf
@@ -5,7 +5,7 @@ keys=root,pyatlan,urllib3
 keys=consoleHandler,fileHandler
 
 [formatters]
-keys=simpleFormatter
+keys=json
 
 [logger_root]
 level=INFO
@@ -25,14 +25,15 @@ propagate=0
 
 [handler_consoleHandler]
 class=StreamHandler
-formatter=simpleFormatter
+formatter=json
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=DEBUG
-formatter=simpleFormatter
+formatter=json
 args=('/tmp/pyatlan.log',)
 
-[formatter_simpleFormatter]
+[formatter_json]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+class=pyatlan.utils.JsonFormatter

--- a/pyatlan/logging.conf
+++ b/pyatlan/logging.conf
@@ -2,10 +2,10 @@
 keys=root,pyatlan,urllib3
 
 [handlers]
-keys=consoleHandler,fileHandler
+keys=consoleHandler,fileHandler,jsonHandler
 
 [formatters]
-keys=json
+keys=simpleFormatter,jsonFormatter
 
 [logger_root]
 level=INFO
@@ -13,27 +13,36 @@ handlers=consoleHandler
 
 [logger_pyatlan]
 level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,fileHandler,jsonHandler
 qualname=pyatlan
 propagate=0
 
 [logger_urllib3]
 level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,fileHandler,jsonHandler
 qualname=urllib3
 propagate=0
 
 [handler_consoleHandler]
 class=StreamHandler
-formatter=json
+formatter=simpleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=DEBUG
-formatter=json
+formatter=simpleFormatter
 args=('/tmp/pyatlan.log',)
 
-[formatter_json]
+[handler_jsonHandler]
+class=FileHandler
+level=DEBUG
+formatter=jsonFormatter
+args=('/tmp/pyatlan.json',)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+
+[formatter_jsonFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 class=pyatlan.utils.JsonFormatter

--- a/pyatlan/utils.py
+++ b/pyatlan/utils.py
@@ -343,19 +343,20 @@ class AuthorizationFilter(logging.Filter):
 
 class JsonFormatter(logging.Formatter):
     """
-    A custom log formatter that converts dictionary messages to JSON format.
+    A custom JSON log formatter
     """
 
     def format(self, record: logging.LogRecord) -> str:
         """
-        Format the log record.
+        Format the log record
 
-        Args:
-            record (logging.LogRecord): The log record to be formatted.
-
-        Returns:
-            str: The formatted log message.
+        :param record: The log record to be formatted
+        :returns: The formatted log message
         """
-        if isinstance(record.msg, dict):
-            record.msg = json.dumps(record.msg, ensure_ascii=False)
-        return super(JsonFormatter, self).format(record)
+        log_record = {
+            "asctime": self.formatTime(record, self.datefmt),
+            "name": record.name,
+            "levelname": record.levelname,
+            "message": record.msg if isinstance(record.msg, dict) else record.getMessage(),
+        }
+        return json.dumps(log_record, ensure_ascii=False)

--- a/pyatlan/utils.py
+++ b/pyatlan/utils.py
@@ -3,6 +3,7 @@
 # Based on original code from https://github.com/apache/atlas (under Apache-2.0 license)
 import datetime
 import enum
+import json
 import logging
 import re
 import time
@@ -338,3 +339,23 @@ class AuthorizationFilter(logging.Filter):
                     arg["headers"]["authorization"] = "***REDACTED***"
 
         return True
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    A custom log formatter that converts dictionary messages to JSON format.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Format the log record.
+
+        Args:
+            record (logging.LogRecord): The log record to be formatted.
+
+        Returns:
+            str: The formatted log message.
+        """
+        if isinstance(record.msg, dict):
+            record.msg = json.dumps(record.msg, ensure_ascii=False)
+        return super(JsonFormatter, self).format(record)


### PR DESCRIPTION
### Before

```
2023-11-22 15:19:32,329 - pyatlan.client.atlan - DEBUG - {'totalRecord': 5, 'filterRecord': 1, 'records': [{'alias': 'Admins', 'attributes': {'alias': ['Admins'], 'createdAt': ['1691010302538'], 'createdBy': ['<hidden>'], 'isDefault': ['true'], 'updatedAt': ['1691016077625'], 'updatedBy': ['chris']}, 'id': '<hidden>', 'name': 'admins', 'path': '/admins', 'personas': [{'id': '<hidden>', 'name': 'Business Definitions', 'displayName': 'Business Definitions', 'qualifiedName': '<hidden>'}, {'id': '<hidden>', 'name': 'Data Assets', 'displayName': 'Data Assets', 'qualifiedName': '<hidden>'}], 'purposes': [{'guid': '<hidden>', 'name': 'Known Issues', 'qualifiedName': '<hidden>'}], 'userCount': 8}]}
```

### After

```
2023-11-22 15:16:47,514 - pyatlan.client.atlan - DEBUG - {"totalRecord": 5, "filterRecord": 1, "records": [{"alias": "Admins", "attributes": {"alias": ["Admins"], "createdAt": ["1691010302538"], "createdBy": ["<>"], "isDefault": ["true"], "updatedAt": ["1691016077625"], "updatedBy": ["chris"]}, "id": "<>", "name": "admins", "path": "/admins", "personas": [{"id": "<hidden>", "name": "Business Definitions", "displayName": "Business Definitions", "qualifiedName": "<hidden>"}, {"id": "<hidden>", "name": "Data Assets", "displayName": "Data Assets", "qualifiedName": "<hidden>"}], "purposes": [{"guid": "<hidden>", "name": "Known Issues", "qualifiedName": "<hidden>"}], "userCount": 8}]}
```

💡 There is one well-maintained package I found while working on this: [python-json-logger](https://github.com/madzak/python-json-logger) for some advanced customization with JSON formatting using Python logger.