### PR TITLE
DVX-48: Add support for search log access

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -340,9 +340,7 @@ class AtlanClient(BaseSettings):
             params["params"] = query_params
         if request_obj is not None:
             if isinstance(request_obj, AtlanObject):
-                params["data"] = request_obj.json(
-                    by_alias=True, exclude_unset=exclude_unset
-                )
+                params["data"] = request_obj.json(by_alias=True, exclude_none=True)
             else:
                 params["data"] = json.dumps(request_obj)
         return params

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -340,7 +340,9 @@ class AtlanClient(BaseSettings):
             params["params"] = query_params
         if request_obj is not None:
             if isinstance(request_obj, AtlanObject):
-                params["data"] = request_obj.json(by_alias=True, exclude_none=True)
+                params["data"] = request_obj.json(
+                    by_alias=True, exclude_unset=exclude_unset
+                )
             else:
                 params["data"] = json.dumps(request_obj)
         return params

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -34,6 +34,7 @@ from pyatlan.client.common import CONNECTION_RETRY, HTTP_PREFIX, HTTPS_PREFIX
 from pyatlan.client.constants import PARSE_QUERY, UPLOAD_IMAGE
 from pyatlan.client.group import GroupClient
 from pyatlan.client.role import RoleClient
+from pyatlan.client.search_log import SearchLogClient
 from pyatlan.client.token import TokenClient
 from pyatlan.client.typedef import TypeDefClient
 from pyatlan.client.user import UserClient
@@ -123,6 +124,7 @@ class AtlanClient(BaseSettings):
     _workflow_client: Optional[WorkflowClient] = PrivateAttr(default=None)
     _admin_client: Optional[AdminClient] = PrivateAttr(default=None)
     _audit_client: Optional[AuditClient] = PrivateAttr(default=None)
+    _search_log_client: Optional[SearchLogClient] = PrivateAttr(default=None)
     _group_client: Optional[GroupClient] = PrivateAttr(default=None)
     _role_client: Optional[RoleClient] = PrivateAttr(default=None)
     _asset_client: Optional[AssetClient] = PrivateAttr(default=None)
@@ -177,6 +179,12 @@ class AtlanClient(BaseSettings):
         if self._audit_client is None:
             self._audit_client = AuditClient(client=self)
         return self._audit_client
+
+    @property
+    def search_log(self) -> SearchLogClient:
+        if self._search_log_client is None:
+            self._search_log_client = SearchLogClient(client=self)
+        return self._search_log_client
 
     @property
     def workflow(self) -> WorkflowClient:

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -385,6 +385,10 @@ WORKFLOW_RUN = API(
 )
 AUDIT_API = "entity/auditSearch"
 AUDIT_SEARCH = API(AUDIT_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.ATLAS)
+SEARCH_LOG_API = "search/searchlog"
+SEARCH_LOG = API(
+    SEARCH_LOG_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.ATLAS
+)
 
 TYPES_API = "types/"
 TYPEDEFS_API = f"{TYPES_API}typedefs/"

--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -1,0 +1,89 @@
+from typing import Optional
+
+from pydantic import ValidationError, parse_obj_as
+
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.constants import SEARCH_LOG
+from pyatlan.errors import ErrorCode
+from pyatlan.model.aggregation import Aggregations
+from pyatlan.model.search_log import SearchLogRequest, SearchLogResults, UniqueUsers
+
+UNIQUE_USERS = "uniqueUsers"
+
+
+class SearchLogClient:
+    """
+    This class can be used to configure and run a search against Atlan's searcg log. This class does not need to be
+    instantiated directly but can be obtained through the search_log property of AtlanClient.
+    """
+
+    def __init__(self, client: ApiCaller):
+        if not isinstance(client, ApiCaller):
+            raise ErrorCode.INVALID_PARAMETER_TYPE.exception_with_parameters(
+                "client", "ApiCaller"
+            )
+        self._client = client
+
+    def _get_aggregations(self, raw_json) -> Optional[Aggregations]:
+        if "aggregations" in raw_json:
+            try:
+                aggregations = Aggregations.parse_obj(raw_json["aggregations"])
+            except ValidationError as err:
+                raise ErrorCode.JSON_ERROR.exception_with_parameters(
+                    raw_json, 200, str(err)
+                ) from err
+        else:
+            aggregations = None
+        return aggregations
+
+    def _map_bucket_to_unique_user(self, bucket) -> UniqueUsers:
+        """
+        Maps a bucket from the API response to a search log UniqueUsers instance.
+        """
+        # Handle the case where the bucket is empty or not a dictionary
+        if not bucket or not isinstance(bucket, dict):
+            return None
+
+        return UniqueUsers(
+            name=bucket.get("key", ""),
+            view_count=bucket.get("doc_count", 0),
+            view_timestamp=bucket.get("latest_timestamp", {}).get("value", 0),
+        )
+
+    def search(self, criteria: SearchLogRequest) -> dict:
+        """
+        Search for assets using the provided criteria.
+
+        :param criteria: detailing the search query, parameters, and so on to run
+        :returns: the results of the search
+        :raises AtlanError: on any API communication issue
+        """
+        unique_users = []
+        raw_json = self._client._call_api(
+            SEARCH_LOG,
+            request_obj=criteria,
+        )
+        if UNIQUE_USERS in raw_json["aggregations"]:
+            try:
+                user_buckets = raw_json["aggregations"][UNIQUE_USERS].get("buckets", [])
+                unique_users = parse_obj_as(
+                    list[UniqueUsers],
+                    [self._map_bucket_to_unique_user(user) for user in user_buckets],
+                )
+            except ValidationError as err:
+                raise ErrorCode.JSON_ERROR.exception_with_parameters(
+                    raw_json, 200, str(err)
+                ) from err
+        aggregations = self._get_aggregations(raw_json)
+        total_views = (
+            raw_json["approximateCount"] if "approximateCount" in raw_json else 0
+        )
+        return SearchLogResults(
+            client=self._client,
+            criteria=criteria,
+            start=criteria.dsl.from_,
+            size=criteria.dsl.size,
+            total_views=total_views,
+            unique_users=unique_users,
+            aggregations=aggregations,
+        )

--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -6,7 +6,13 @@ from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import SEARCH_LOG
 from pyatlan.errors import ErrorCode
 from pyatlan.model.aggregation import Aggregations
-from pyatlan.model.search_log import SearchLogRequest, SearchLogResults, UniqueUsers
+from pyatlan.model.search_log import (
+    AssetLog,
+    SearchLogRequest,
+    SearchLogResults,
+    SearchLogViewResults,
+    UniqueUsers,
+)
 
 UNIQUE_USERS = "uniqueUsers"
 
@@ -50,6 +56,24 @@ class SearchLogClient:
             view_timestamp=bucket.get("latest_timestamp", {}).get("value", 0),
         )
 
+    def _map_logs_to_asset_log(self, log) -> AssetLog:
+        """
+        Maps a logs from the API response to a search log AssetLog instance.
+        """
+        # Handle the case where the log is empty or not a dictionary
+        if not log or not isinstance(log, dict):
+            return None
+        return AssetLog(
+            log_host=log.get("host", ""),
+            log_ipaddress=log.get("ipAddress", ""),
+            log_user_agent=log.get("userAgent", ""),
+            log_username=log.get("userName", ""),
+            log_guid=log.get("entityGuidsAll")[0],
+            log_qualified_name=log.get("entityQFNamesAll")[0],
+            log_type_name=log.get("entityTypeNamesAll")[0],
+            log_timestamp=log.get("timestamp", 0),
+        )
+
     def search(self, criteria: SearchLogRequest) -> dict:
         """
         Search for assets using the provided criteria.
@@ -63,7 +87,7 @@ class SearchLogClient:
             SEARCH_LOG,
             request_obj=criteria,
         )
-        if UNIQUE_USERS in raw_json["aggregations"]:
+        if "aggregations" in raw_json and UNIQUE_USERS in raw_json["aggregations"]:
             try:
                 user_buckets = raw_json["aggregations"][UNIQUE_USERS].get("buckets", [])
                 unique_users = parse_obj_as(
@@ -74,16 +98,36 @@ class SearchLogClient:
                 raise ErrorCode.JSON_ERROR.exception_with_parameters(
                     raw_json, 200, str(err)
                 ) from err
-        aggregations = self._get_aggregations(raw_json)
-        total_views = (
-            raw_json["approximateCount"] if "approximateCount" in raw_json else 0
-        )
-        return SearchLogResults(
-            client=self._client,
-            criteria=criteria,
-            start=criteria.dsl.from_,
-            size=criteria.dsl.size,
-            total_views=total_views,
-            unique_users=unique_users,
-            aggregations=aggregations,
-        )
+            self._get_aggregations(raw_json)
+            total_views = (
+                raw_json["approximateCount"] if "approximateCount" in raw_json else 0
+            )
+            # TODO: Let's investigate if we can paginate these results
+            # Currently, it's not giving me the expected results :(
+            return SearchLogViewResults(
+                total_views=total_views,
+                unique_users=unique_users,
+            )
+        # for recent search logs
+        if "logs" in raw_json:
+            try:
+                logs = raw_json.get("logs", [])
+                asset_logs = parse_obj_as(
+                    list[AssetLog], [self._map_logs_to_asset_log(log) for log in logs]
+                )
+            except ValidationError as err:
+                raise ErrorCode.JSON_ERROR.exception_with_parameters(
+                    raw_json, 200, str(err)
+                ) from err
+            count = (
+                raw_json["approximateCount"] if "approximateCount" in raw_json else 0
+            )
+            return SearchLogResults(
+                client=self._client,
+                criteria=criteria,
+                start=criteria.dsl.from_,
+                size=criteria.dsl.size,
+                count=count,
+                asset_logs=asset_logs,
+                aggregations=None,
+            )

--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import ValidationError, parse_obj_as
 
@@ -21,8 +21,9 @@ UNIQUE_ASSETS = "uniqueAssets"
 
 class SearchLogClient:
     """
-    This class can be used to configure and run a search against Atlan's searcg log. This class does not need to be
-    instantiated directly but can be obtained through the search_log property of AtlanClient.
+    This class can be used to configure and run a search against Atlan's searcg log.
+    This class does not need to be instantiated directly but can be obtained
+    through the search_log property of AtlanClient.
     """
 
     def __init__(self, client: ApiCaller):
@@ -44,9 +45,9 @@ class SearchLogClient:
             aggregations = None
         return aggregations
 
-    def _map_bucket_to_user_view(self, bucket) -> UserViews:
+    def _map_bucket_to_user_view(self, bucket) -> Union[UserViews, None]:
         """
-        Maps a bucket from the API response to a search log UniqueUsers instance.
+        Maps a bucket from the API response to a search log UserViews instance.
         """
         # Handle the case where the bucket is empty or not a dictionary
         if not bucket or not isinstance(bucket, dict):
@@ -58,9 +59,9 @@ class SearchLogClient:
             most_recent_view=bucket.get("latest_timestamp", {}).get("value", 0),
         )
 
-    def _map_bucket_to_asset_view(self, bucket) -> AssetViews:
+    def _map_bucket_to_asset_view(self, bucket) -> Union[AssetViews, None]:
         """
-        Maps a bucket from the API response to a search log UniqueUsers instance.
+        Maps a bucket from the API response to a search log AssetViews instance.
         """
         # Handle the case where the bucket is empty or not a dictionary
         if not bucket or not isinstance(bucket, dict):
@@ -72,7 +73,9 @@ class SearchLogClient:
             distinct_users=bucket.get(UNIQUE_USERS, {}).get("value", 0),
         )
 
-    def search(self, criteria: SearchLogRequest) -> dict:
+    def search(
+        self, criteria: SearchLogRequest
+    ) -> Union[SearchLogViewResults, SearchLogResults]:
         """
         Search for assets using the provided criteria.
 
@@ -149,5 +152,5 @@ class SearchLogClient:
             size=criteria.dsl.size,
             count=count,
             log_entries=log_entries,
-            aggregations=None,
+            aggregations={},
         )

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -1856,6 +1856,50 @@ class WorkflowPackage(str, Enum):
     TRINO = "atlan-trino"
 
 
+class UTMTags(str, Enum):
+    # PAGE_ entries indicate where the action was taken.
+    # Search was made from the home page.
+    PAGE_HOME = "page_home"
+    # Search was made from the assets (discovery) page.
+    PAGE_ASSETS = "page_assets"
+    # Asset was viewed from within a glossary.
+    PAGE_GLOSSARY = "page_glossary"
+    # Asset was viewed from within insights.
+    PAGE_INSIGHTS = "page_insights"
+
+    # PROJECT_ entries indicate how (via what application) the action was taken.
+    # Search was made via the webapp (UI).
+    PROJECT_WEBAPP = "project_webapp"
+    # Search was made via the Java SDK.
+    PROJECT_SDK_JAVA = "project_sdk_java"
+    # Search was made via the Python SDK.
+    PROJECT_SDK_PYTHON = "project_sdk_python"
+
+    # ACTION_ entries dictate the specific action that was taken.
+    # Assets were searched.
+    ACTION_SEARCHED = "action_searched"
+    # Search was run through the Cmd-K popup.
+    ACTION_CMD_K = "action_cmd_k"
+    # Search was through changing a filter in the UI (discovery).
+    ACTION_FILTER_CHANGED = "action_filter_changed"
+    # Search was through changing a type filter (pill) in the UI (discovery).
+    ACTION_ASSET_TYPE_CHANGED = "action_asset_type_changed"
+    # Asset was viewed, rather than an explicit search.
+    ACTION_ASSET_VIEWED = "action_asset_viewed"
+
+    # Others indicate any special mechanisms used for the action.
+    # Search was run using the UI popup searchbar.
+    UI_POPUP_SEARCHBAR = "ui_popup_searchbar"
+    # Search was through a UI filter (discovery).
+    UI_FILTERS = "ui_filters"
+    # View was done via the UI's sidebar.
+    UI_SIDEBAR = "ui_sidebar"
+    # View was done of the full asset profile, not only sidebar.
+    UI_PROFILE = "ui_profile"
+    # Listing of assets, usually by a particular type, in the discovery page.
+    UI_MAIN_LIST = "ui_main_list"
+
+
 # **************************************
 # CODE BELOW IS GENERATED NOT MODIFY  **
 # **************************************

--- a/pyatlan/model/search.py
+++ b/pyatlan/model/search.py
@@ -1806,11 +1806,6 @@ class DSL(AtlanObject):
     sort: list[SortItem] = Field(
         alias="sort", default=[SortItem(TermAttributes.GUID.value)]
     )
-    source: Optional[list[str]] = Field(
-        default_factory=list,
-        description="Used by recent search log request",
-        alias="_source",
-    )
 
     class Config:
         json_encoders = {Query: lambda v: v.to_dict(), SortItem: lambda v: v.to_dict()}
@@ -1824,7 +1819,6 @@ class DSL(AtlanObject):
                 "track_total_hits",
                 "sort",
                 "aggregations",
-                "source",
             ]
         )
 

--- a/pyatlan/model/search.py
+++ b/pyatlan/model/search.py
@@ -30,6 +30,7 @@ from pyatlan.model.enums import (
     CertificateStatus,
     ChildScoreMode,
     SortOrder,
+    UTMTags,
 )
 
 SearchFieldType = Union[StrictStr, StrictInt, StrictFloat, StrictBool, datetime]
@@ -1859,6 +1860,17 @@ class IndexSearchRequest(SearchRequest):
         description="Whether to include deleted relationships to this asset (true) or not (false). By default, "
         "this is false and therefore only active (not deleted) relationships will be included.",
         alias="allowDeletedRelations",
+    )
+
+    class Metadata(AtlanObject):
+        save_search_log: bool = True
+        utm_tags: list[str] = []
+
+    request_metadata: Metadata = Field(
+        default_factory=lambda: IndexSearchRequest.Metadata(
+            save_search_log=True,
+            utm_tags=[UTMTags.PROJECT_SDK_PYTHON],
+        ),
     )
 
     def get_dsl_str(self) -> str:

--- a/pyatlan/model/search.py
+++ b/pyatlan/model/search.py
@@ -1875,6 +1875,10 @@ class IndexSearchRequest(SearchRequest):
     class Config:
         json_encoders = {Query: lambda v: v.to_dict(), SortItem: lambda v: v.to_dict()}
 
+    def __init__(__pydantic_self__, **data: Any) -> None:
+        super().__init__(**data)
+        __pydantic_self__.__fields_set__.update(["request_metadata"])
+
 
 def with_active_glossary(name: StrictStr) -> "Bool":
     return (

--- a/pyatlan/model/search.py
+++ b/pyatlan/model/search.py
@@ -1805,6 +1805,11 @@ class DSL(AtlanObject):
     sort: list[SortItem] = Field(
         alias="sort", default=[SortItem(TermAttributes.GUID.value)]
     )
+    source: Optional[list[str]] = Field(
+        default_factory=list,
+        description="Used by recent search log request",
+        alias="_source",
+    )
 
     class Config:
         json_encoders = {Query: lambda v: v.to_dict(), SortItem: lambda v: v.to_dict()}
@@ -1812,7 +1817,14 @@ class DSL(AtlanObject):
     def __init__(__pydantic_self__, **data: Any) -> None:
         super().__init__(**data)
         __pydantic_self__.__fields_set__.update(
-            ["from_", "size", "track_total_hits", "sort", "aggregations"]
+            [
+                "from_",
+                "size",
+                "track_total_hits",
+                "sort",
+                "aggregations",
+                "source",
+            ]
         )
 
     @validator("query", always=True)

--- a/pyatlan/model/search_log.py
+++ b/pyatlan/model/search_log.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Generator, Iterable, Optional
 
-from pydantic import Field
+from pydantic import Field, ValidationError, parse_obj_as
 
 from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import SEARCH_LOG
+from pyatlan.errors import ErrorCode
 from pyatlan.model.aggregation import Aggregation
 from pyatlan.model.core import AtlanObject
 from pyatlan.model.search import (
@@ -25,7 +26,7 @@ class SearchLogUtmTags(str, Enum):
 
 
 class SearchLogRequest(SearchRequest):
-    """Class from which to configure a search against Atlan's activity log."""
+    """Class from which to configure a search against Atlan's search log."""
 
     dsl: DSL
     attributes: list[str] = Field(default_factory=list, alias="attributes")
@@ -54,10 +55,10 @@ class SearchLogRequest(SearchRequest):
         guid: str,
         *,
         size: int = 0,
-        _from: int = 0,
+        from_: int = 0,
         user_size: int = 20,
         start_time: Optional[int] = None,
-        end_time: Optional[int] = None
+        end_time: Optional[int] = None,
     ) -> "SearchLogRequest":
         """
         Create a search log request to retrieve views of an asset by its GUID.
@@ -98,7 +99,7 @@ class SearchLogRequest(SearchRequest):
             )
         dsl = DSL(
             size=size,
-            _from=_from,
+            from_=from_,
             sort=[],
             query=Bool(
                 filter=[Bool(must=query_filters)],
@@ -119,6 +120,52 @@ class SearchLogRequest(SearchRequest):
         )
         return SearchLogRequest(dsl=dsl)
 
+    @classmethod
+    def get_recent_search(
+        cls,
+        usernames: list[str],
+        *,
+        from_: int = 0,
+        size: int = 15,
+    ) -> "SearchLogRequest":
+        """
+        Create a search log request to retrieve recent search logs of an assets.
+
+        :param usernames: list of usernames of whom to retrieve recent search logs
+        :param _from: starting point for paging. Defaults to 0 (very first result) if not overridden.
+        :param max_logs: number of logs to retrieve from the recent search log. Defaults to 15.
+
+        :returns: A SearchLogRequest that can be used to perform the search.
+        """
+        usernames = usernames or []
+        dsl = DSL(
+            size=size,
+            from_=from_,
+            source=[
+                "host",
+                "ipAddress",
+                "userAgent",
+                "userName",
+                "timestamp",
+                "entityGuidsAll",
+                "entityQFNamesAll",
+                "entityTypeNamesAll",
+            ],
+            sort=[SortItem("timestamp", order="desc")],
+            query=Bool(
+                filter=[
+                    Bool(
+                        must=[
+                            Terms(field="userName", values=usernames),
+                            Term(field="utmTags", value="action_asset_viewed"),
+                            Term(field="utmTags", value="ui_profile"),
+                        ]
+                    )
+                ]
+            ),
+        )
+        return SearchLogRequest(dsl=dsl)
+
 
 class UniqueUsers(AtlanObject):
     """
@@ -133,27 +180,45 @@ class UniqueUsers(AtlanObject):
     )
 
 
-class SearchLogResults:
-    """Captures the response from a search against Atlan's search log."""
+class AssetLog(AtlanObject):
+    """
+    Represents an log entry for asset search in the search log.
+    Instances of this class should be treated as immutable.
+    """
+
+    log_host: str = Field(
+        description="The host information associated with the search log."
+    )
+    log_ipaddress: str = Field(
+        description="The IP address associated with the search log."
+    )
+    log_user_agent: str = Field(
+        description="The user agent information associated with the search log."
+    )
+    log_username: str = Field(
+        description="The username of the user who searched for the assets."
+    )
+    log_guid: str = Field(description="The GUID of the search log asset.")
+    log_qualified_name: str = Field(
+        description="The unique name of the search log asset."
+    )
+    log_type_name: str = Field(description="The type name of the search log asset.")
+
+    log_timestamp: datetime = Field(
+        description="The timestamp (epoch) when the search occurred, in milliseconds."
+    )
+
+
+class SearchLogViewResults:
+    """Captures the response from a search against Atlan's search log views."""
 
     def __init__(
         self,
-        client: ApiCaller,
-        criteria: SearchLogRequest,
-        start: int,
-        size: int,
         total_views: int,
         unique_users: list[UniqueUsers],
-        aggregations: dict[str, Aggregation],
     ):
-        self._client = client
-        self._endpoint = SEARCH_LOG
-        self._criteria = criteria
-        self._start = start
-        self._size = size
         self._total_views = total_views
         self._unique_users = unique_users
-        self._aggregations = aggregations
 
     @property
     def total_views(self) -> int:
@@ -162,3 +227,119 @@ class SearchLogResults:
     @property
     def unique_users(self) -> int:
         return self._unique_users
+
+
+class SearchLogResults(Iterable):
+    """Captures the response from a search against Atlan's recent search logs."""
+
+    def __init__(
+        self,
+        client: ApiCaller,
+        criteria: SearchLogRequest,
+        start: int,
+        size: int,
+        count: int,
+        asset_logs: list[AssetLog],
+        aggregations: dict[str, Aggregation],
+    ):
+        self._client = client
+        self._endpoint = SEARCH_LOG
+        self._criteria = criteria
+        self._start = start
+        self._size = size
+        self._count = count
+        self._asset_logs = asset_logs
+        self._aggregations = aggregations
+
+    @property
+    def total_count(self) -> int:
+        return self._count
+
+    def current_page(self) -> list[AssetLog]:
+        """
+        Retrieve the current page of results.
+
+        :returns: list of assets on the current page of results
+        """
+        return self._asset_logs
+
+    def next_page(self, start=None, size=None) -> bool:
+        """
+        Indicates whether there is a next page of results.
+
+        :returns: True if there is a next page of results, otherwise False
+        """
+        self._start = start or self._start + self._size
+        if size:
+            self._size = size
+        return self._get_next_page() if self._asset_logs else False
+
+    def _get_next_page(self):
+        """
+        Fetches the next page of results.
+
+        :returns: True if the next page of results was fetched, False if there was no next page
+        """
+        self._criteria.dsl.from_ = self._start
+        self._criteria.dsl.size = self._size
+        if raw_json := self._get_next_page_json():
+            self._count = (
+                raw_json["approximateCount"] if "approximateCount" in raw_json else 0
+            )
+            return True
+        return False
+
+    def _map_logs_to_asset_log(self, log) -> AssetLog:
+        """
+        Maps a logs from the API response to a search log AssetLog instance.
+        """
+        # Handle the case where the log is empty or not a dictionary
+        if not log or not isinstance(log, dict):
+            return None
+
+        return AssetLog(
+            log_host=log.get("host", ""),
+            log_ipaddress=log.get("ipAddress", ""),
+            log_user_agent=log.get("userAgent", ""),
+            log_username=log.get("userName", ""),
+            log_guid=log.get("entityGuidsAll")[0],
+            log_qualified_name=log.get("entityQFNamesAll")[0],
+            log_type_name=log.get("entityTypeNamesAll")[0],
+            log_timestamp=log.get("timestamp", 0),
+        )
+
+    def _get_next_page_json(self):
+        """
+        Fetches the next page of results and returns the raw JSON of the retrieval.
+
+        :returns: JSON for the next page of results, as-is
+        """
+        raw_json = self._client._call_api(
+            self._endpoint,
+            request_obj=self._criteria,
+        )
+        if "logs" not in raw_json or not raw_json["logs"]:
+            self._asset_logs = []
+            return None
+        try:
+            logs = raw_json.get("logs", [])
+            self._asset_logs = parse_obj_as(
+                list[AssetLog], [self._map_logs_to_asset_log(log) for log in logs]
+            )
+            return raw_json
+        except ValidationError as err:
+            raise ErrorCode.JSON_ERROR.exception_with_parameters(
+                raw_json, 200, str(err)
+            ) from err
+
+    def __iter__(self) -> Generator[AssetLog, None, None]:
+        """
+        Iterates through the results, lazily-fetching each next page until there
+        are no more results.
+
+        :returns: an iterable form of each result, across all pages
+        """
+        while True:
+            yield from self.current_page()
+            if not self.next_page():
+                break

--- a/pyatlan/model/search_log.py
+++ b/pyatlan/model/search_log.py
@@ -17,14 +17,14 @@ class SearchLogRequest(SearchRequest):
 
     dsl: DSL
     attributes: list[str] = Field(default_factory=list, alias="attributes")
-    _EXCLUDE_USERS = [
+    _EXCLUDE_USERS: list[str] = [
         "atlansupport",
         "support",
         "support@atlan.com",
         "atlansupport@atlan.com",
         "hello@atlan.com",
     ]
-    _BASE_QUERY_FILTER = [
+    _BASE_QUERY_FILTER: list[Query] = [
         Term(
             field="utmTags",
             value=UTMTags.ACTION_ASSET_VIEWED.value,
@@ -104,18 +104,17 @@ class SearchLogRequest(SearchRequest):
     def most_recent_viewers(
         cls,
         guid: str,
-        *,
+        max_users: int = 20,
         size: int = 0,
         from_: int = 0,
-        max_users: int = 20,
     ) -> "SearchLogRequest":
         """
         Create a search log request to retrieve views of an asset by its GUID.
 
         :param guid: unique identifier of the asset.
-        :param size: number of changes to retrieve. Defaults to 0.
-        :param _from: starting point for paging. Defaults to 0 (very first result) if not overridden.
         :param max_users: maximum number of recent users to consider. Defaults to 20.
+        :param size: number of results to retrieve per page. Defaults to 0.
+        :param _from: starting point for paging. Defaults to 0 (very first result) if not overridden.
 
         :returns: A SearchLogRequest that can be used to perform the search.
         """
@@ -134,11 +133,21 @@ class SearchLogRequest(SearchRequest):
     def most_viewed_assets(
         cls,
         max_assets: int = 10,
-        *,
+        by_different_user: bool = False,
         size: int = 0,
         from_: int = 0,
-        by_different_user: bool = False,
     ) -> "SearchLogRequest":
+        """
+        Create a search log request to retrieve most viewed assets.
+
+        :param max_assets: maximum number of assets to consider.
+        :param by_different_user: when True, will consider assets viewed by more users as more
+        important than total view count, otherwise will consider total view count most important.
+        :param size: number of results to retrieve per page. Defaults to 20.
+        :param _from: starting point for paging. Defaults to 0 (very first result) if not overridden.
+
+        :returns: A SearchLogRequest that can be used to perform the search.
+        """
         dsl = DSL(
             **cls._get_view_dsl_kwargs(cls, size=size, from_=from_),
             aggregations=cls._get_most_viewed_assets_aggs(
@@ -151,16 +160,15 @@ class SearchLogRequest(SearchRequest):
     def views_by_guid(
         cls,
         guid: str,
-        *,
-        from_: int = 0,
         size: int = 20,
+        from_: int = 0,
     ) -> "SearchLogRequest":
         """
         Create a search log request to retrieve recent search logs of an assets.
 
         :param guid: unique identifier of the asset.
+        :param size: number of results to retrieve per page. Defaults to 20.
         :param _from: starting point for paging. Defaults to 0 (very first result) if not overridden.
-        :param max_logs: number of logs to retrieve from the recent search log. Defaults to 20.
 
         :returns: A SearchLogRequest that can be used to perform the search.
         """

--- a/pyatlan/model/search_log.py
+++ b/pyatlan/model/search_log.py
@@ -15,9 +15,9 @@ from pyatlan.model.search import (
     Query,
     SearchRequest,
     SortItem,
+    SortOrder,
     Term,
     Terms,
-    SortOrder,
 )
 
 
@@ -56,14 +56,15 @@ class SearchLogRequest(SearchRequest):
             size=size,
             from_=from_,
             sort=[SortItem("timestamp", order=SortOrder.ASCENDING)],
-            query=Bool(filter=query_filter + cls._BASE_QUERY_FILTER),
-            must_not=[
-                Terms(
-                    field="userName",
-                    values=cls._EXCLUDE_USERS,
-                ),
-            ],
-            track_total_hits=True,
+            query=Bool(
+                filter=query_filter + cls._BASE_QUERY_FILTER,
+                must_not=[
+                    Terms(
+                        field="userName",
+                        values=cls._EXCLUDE_USERS,
+                    ),
+                ],
+            ),
         )
 
     class Config:
@@ -217,7 +218,7 @@ class UserViews(AtlanObject):
     """
 
     username: str = Field(description="User name of the user who viewed the assets.")
-    view_count: str = Field(description="Number of times the user viewed the asset.")
+    view_count: int = Field(description="Number of times the user viewed the asset.")
     most_recent_view: datetime = Field(
         description="When the user most recently viewed the asset (epoch-style), in milliseconds."
     )

--- a/pyatlan/model/search_log.py
+++ b/pyatlan/model/search_log.py
@@ -1,0 +1,164 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field
+
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.constants import SEARCH_LOG
+from pyatlan.model.aggregation import Aggregation
+from pyatlan.model.core import AtlanObject
+from pyatlan.model.search import (
+    DSL,
+    Bool,
+    Query,
+    Range,
+    SearchRequest,
+    SortItem,
+    Term,
+    Terms,
+)
+
+
+class SearchLogUtmTags(str, Enum):
+    ACTION_ASSET_VIEWED = "action_asset_viewed"
+
+
+class SearchLogRequest(SearchRequest):
+    """Class from which to configure a search against Atlan's activity log."""
+
+    dsl: DSL
+    attributes: list[str] = Field(default_factory=list, alias="attributes")
+
+    class Config:
+        json_encoders = {Query: lambda v: v.to_dict(), SortItem: lambda v: v.to_dict()}
+
+    def _get_dsl_aggs(self, user_size: int) -> dict[str, Aggregation]:
+        return {
+            "uniqueUsers": {
+                "terms": {
+                    "field": "userName",
+                    "size": user_size,
+                    "order": {"latest_timestamp": "desc"},
+                },
+                "aggs": {"latest_timestamp": {"max": {"field": "timestamp"}}},
+            },
+            "totalDistinctUsers": {
+                "cardinality": {"field": "userName", "precision_threshold": 1000}
+            },
+        }
+
+    @classmethod
+    def by_guid(
+        cls,
+        guid: str,
+        *,
+        size: int = 0,
+        _from: int = 0,
+        user_size: int = 20,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None
+    ) -> "SearchLogRequest":
+        """
+        Create a search log request to retrieve views of an asset by its GUID.
+
+        :param guid: unique identifier of the asset.
+        :param size: number of changes to retrieve. Defaults to 0.
+        :param _from: starting point for paging. Defaults to 0 (very first result) if not overridden.
+        :param user_size: number of users to retrieve from the search log. Defaults to 20.
+        :param start_time: start timestamp (epoch) for the search log range filter.
+        :param end_time: end timestamp (epoch) for the search log range filter.
+
+        :returns: A SearchLogRequest that can be used to perform the search.
+        """
+        query_filters = [
+            Terms(
+                field="utmTags",
+                values=[SearchLogUtmTags.ACTION_ASSET_VIEWED],
+            ),
+            Bool(
+                should=[
+                    Term(field="utmTags", value="ui_profile"),
+                    Term(field="utmTags", value="ui_sidebar"),
+                ],
+                minimum_should_match=1,
+            ),
+            Term(
+                field="entityGuidsAll",
+                value=guid,
+            ),
+        ]
+        if start_time and end_time:
+            query_filters.append(
+                Range(
+                    field="timestamp",
+                    gte=start_time,
+                    lte=end_time,
+                )
+            )
+        dsl = DSL(
+            size=size,
+            _from=_from,
+            sort=[],
+            query=Bool(
+                filter=[Bool(must=query_filters)],
+                must_not=[
+                    Terms(
+                        field="userName",
+                        values=[
+                            "atlansupport",
+                            "support",
+                            "support@atlan.com",
+                            "atlansupport@atlan.com",
+                            "hello@atlan.com",
+                        ],
+                    ),
+                ],
+            ),
+            aggregations=cls._get_dsl_aggs(cls, user_size),
+        )
+        return SearchLogRequest(dsl=dsl)
+
+
+class UniqueUsers(AtlanObject):
+    """
+    Represents unique user entry in the search log.
+    Instances of this class should be treated as immutable.
+    """
+
+    name: str = Field(description="User name of the user who viewed the assets.")
+    view_count: str = Field(description="Total view count of the asset for a user.")
+    view_timestamp: datetime = Field(
+        description="Latest view timestamp (epoch) of the viewed asset."
+    )
+
+
+class SearchLogResults:
+    """Captures the response from a search against Atlan's search log."""
+
+    def __init__(
+        self,
+        client: ApiCaller,
+        criteria: SearchLogRequest,
+        start: int,
+        size: int,
+        total_views: int,
+        unique_users: list[UniqueUsers],
+        aggregations: dict[str, Aggregation],
+    ):
+        self._client = client
+        self._endpoint = SEARCH_LOG
+        self._criteria = criteria
+        self._start = start
+        self._size = size
+        self._total_views = total_views
+        self._unique_users = unique_users
+        self._aggregations = aggregations
+
+    @property
+    def total_views(self) -> int:
+        return self._total_views
+
+    @property
+    def unique_users(self) -> int:
+        return self._unique_users

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TestId:
-    from nanoid import generate as generate_nanoid
+    from nanoid import generate as generate_nanoid  # type: ignore
 
     session_id = generate_nanoid(
         alphabet="1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",

--- a/tests/unit/data/search_log_responses/sl_detailed_log_entries.json
+++ b/tests/unit/data/search_log_responses/sl_detailed_log_entries.json
@@ -1,0 +1,216 @@
+{
+  "searchParameters": {
+    "dsl": {
+      "from": 0,
+      "size": 10,
+      "aggregations": {},
+      "track_total_hits": true,
+      "query": {
+        "bool": {
+          "must_not": [
+            {
+              "terms": {
+                "userName": [
+                  "atlansupport",
+                  "support",
+                  "support@atlan.com",
+                  "atlansupport@atlan.com",
+                  "hello@atlan.com"
+                ]
+              }
+            }
+          ],
+          "filter": [
+            {
+              "term": {
+                "entityGuidsAll": {
+                  "value": "test-guid-123",
+                  "case_insensitive": false
+                }
+              }
+            },
+            {
+              "term": {
+                "utmTags": {
+                  "value": "action_asset_viewed"
+                }
+              }
+            },
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "utmTags": {
+                        "value": "ui_profile"
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "utmTags": {
+                        "value": "ui_sidebar"
+                      }
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ]
+        }
+      },
+      "sort": [
+        {
+          "timestamp": {
+            "order": "asc"
+          }
+        }
+      ]
+    },
+    "queryString": "{\"from\":0,\"size\":1,\"aggregations\":{},\"track_total_hits\":true,\"query\":{\"bool\":{\"must_not\":[{\"terms\":{\"userName\":[\"atlansupport\",\"support\",\"support@atlan.com\",\"atlansupport@atlan.com\",\"hello@atlan.com\"]}}],\"filter\":[{\"term\":{\"entityGuidsAll\":{\"value\":\"test-guid-123\",\"case_insensitive\":false}}},{\"term\":{\"utmTags\":{\"value\":\"action_asset_viewed\"}}},{\"bool\":{\"should\":[{\"term\":{\"utmTags\":{\"value\":\"ui_profile\"}}},{\"term\":{\"utmTags\":{\"value\":\"ui_sidebar\"}}}],\"minimum_should_match\":1}}]}},\"sort\":[{\"timestamp\":{\"order\":\"asc\"}}]}"
+  },
+  "logs": [
+    {
+      "userAgent": "test-user-agent",
+      "host": "test-host",
+      "ipAddress": "test-ip-address",
+      "userName": "aryaman.bhushan",
+      "entityGuidsAll": [
+        "test-guid-123"
+      ],
+      "entityQFNamesAll": [
+        "CRWfUcf9l0uBJ7dZdA5fP@kZYqGBytPBeXuoLC6jNOb"
+      ],
+      "entityGuidsAllowed": [
+        "test-guid-123"
+      ],
+      "entityQFNamesAllowed": [
+        "CRWfUcf9l0uBJ7dZdA5fP@kZYqGBytPBeXuoLC6jNOb"
+      ],
+      "entityTypeNamesAll": [
+        "AtlasGlossaryTerm"
+      ],
+      "entityTypeNamesAllowed": [
+        "AtlasGlossaryTerm"
+      ],
+      "utmTags": [
+        "page_assets",
+        "project_webapp",
+        "action_asset_viewed",
+        "asset_type_atlasglossaryterm",
+        "ui_sidebar"
+      ],
+      "hasResult": true,
+      "resultsCount": 1,
+      "responseTime": 47,
+      "createdAt": 1702387435596,
+      "timestamp": 1702387435547,
+      "failed": false,
+      "request.dsl": {
+        "from": 0,
+        "size": 1,
+        "query": {
+          "function_score": {
+            "query": {
+              "bool": {
+                "filter": {
+                  "bool": {
+                    "must": [
+                      {
+                        "term": {
+                          "__guid": "test-guid-123"
+                        }
+                      },
+                      {
+                        "term": {
+                          "__state": "ACTIVE"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "functions": [
+              {
+                "filter": {
+                  "match": {
+                    "starredBy": "aryaman.bhushan"
+                  }
+                },
+                "weight": 5
+              },
+              {
+                "filter": {
+                  "match": {
+                    "certificateStatus": "VERIFIED"
+                  }
+                },
+                "weight": 5
+              },
+              {
+                "filter": {
+                  "match": {
+                    "certificateStatus": "DRAFT"
+                  }
+                },
+                "weight": 4
+              },
+              {
+                "filter": {
+                  "match": {
+                    "__typeName": "Table"
+                  }
+                },
+                "weight": 5
+              },
+              {
+                "filter": {
+                  "match": {
+                    "__typeName": "View"
+                  }
+                },
+                "weight": 5
+              },
+              {
+                "filter": {
+                  "match": {
+                    "__typeName": "Column"
+                  }
+                },
+                "weight": 3
+              },
+              {
+                "filter": {
+                  "match": {
+                    "__typeName": "AtlasGlossaryTerm"
+                  }
+                },
+                "weight": 4
+              },
+              {
+                "filter": {
+                  "match": {
+                    "__typeName": "Process"
+                  }
+                },
+                "weight": 0.1
+              }
+            ],
+            "boost_mode": "sum",
+            "score_mode": "sum"
+          }
+        }
+      },
+      "request.dslText": "{\"from\":0,\"size\":1,\"query\":{\"function_score\":{\"query\":{\"bool\":{\"filter\":{\"bool\":{\"must\":[{\"term\":{\"__guid\":\"test-guid-123\"}},{\"term\":{\"__state\":\"ACTIVE\"}}]}}}},\"functions\":[{\"filter\":{\"match\":{\"starredBy\":\"aryaman.bhushan\"}},\"weight\":5},{\"filter\":{\"match\":{\"certificateStatus\":\"VERIFIED\"}},\"weight\":5},{\"filter\":{\"match\":{\"certificateStatus\":\"DRAFT\"}},\"weight\":4},{\"filter\":{\"match\":{\"__typeName\":\"Table\"}},\"weight\":5},{\"filter\":{\"match\":{\"__typeName\":\"View\"}},\"weight\":5},{\"filter\":{\"match\":{\"__typeName\":\"Column\"}},\"weight\":3},{\"filter\":{\"match\":{\"__typeName\":\"AtlasGlossaryTerm\"}},\"weight\":4},{\"filter\":{\"match\":{\"__typeName\":\"Process\"}},\"weight\":0.1}],\"boost_mode\":\"sum\",\"score_mode\":\"sum\"}}}",
+      "request.relationAttributes": [
+        "name",
+        "description",
+        "subType",
+        "shortDescription"
+      ]
+    }
+  ],
+  "approximateCount": 1
+}

--- a/tests/unit/data/search_log_responses/sl_most_recent_viewers.json
+++ b/tests/unit/data/search_log_responses/sl_most_recent_viewers.json
@@ -1,0 +1,131 @@
+{
+  "searchParameters": {
+    "dsl": {
+      "from": 0,
+      "size": 0,
+      "aggregations": {
+        "uniqueUsers": {
+          "terms": {
+            "field": "userName",
+            "size": 20,
+            "order": [
+              {
+                "latest_timestamp": "desc"
+              }
+            ]
+          },
+          "aggregations": {
+            "latest_timestamp": {
+              "max": {
+                "field": "timestamp"
+              }
+            }
+          }
+        },
+        "totalDistinctUsers": {
+          "cardinality": {
+            "field": "userName",
+            "precision_threshold": 1000
+          }
+        }
+      },
+      "track_total_hits": true,
+      "query": {
+        "bool": {
+          "must_not": [
+            {
+              "terms": {
+                "userName": [
+                  "atlansupport",
+                  "support",
+                  "support@atlan.com",
+                  "atlansupport@atlan.com",
+                  "hello@atlan.com"
+                ]
+              }
+            }
+          ],
+          "filter": [
+            {
+              "term": {
+                "entityGuidsAll": {
+                  "value": "test-guid-123",
+                  "case_insensitive": false
+                }
+              }
+            },
+            {
+              "term": {
+                "utmTags": {
+                  "value": "action_asset_viewed"
+                }
+              }
+            },
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "utmTags": {
+                        "value": "ui_profile"
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "utmTags": {
+                        "value": "ui_sidebar"
+                      }
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ]
+        }
+      },
+      "sort": [
+        {
+          "timestamp": {
+            "order": "asc"
+          }
+        }
+      ]
+    },
+    "queryString": "{\"from\":0,\"size\":0,\"aggregations\":{\"uniqueUsers\":{\"terms\":{\"field\":\"userName\",\"size\":20,\"order\":[{\"latest_timestamp\":\"desc\"}]},\"aggregations\":{\"latest_timestamp\":{\"max\":{\"field\":\"timestamp\"}}}},\"totalDistinctUsers\":{\"cardinality\":{\"field\":\"userName\",\"precision_threshold\":1000}}},\"track_total_hits\":true,\"query\":{\"bool\":{\"must_not\":[{\"terms\":{\"userName\":[\"atlansupport\",\"support\",\"support@atlan.com\",\"atlansupport@atlan.com\",\"hello@atlan.com\"]}}],\"filter\":[{\"term\":{\"entityGuidsAll\":{\"value\":\"test-guid-123\",\"case_insensitive\":false}}},{\"term\":{\"utmTags\":{\"value\":\"action_asset_viewed\"}}},{\"bool\":{\"should\":[{\"term\":{\"utmTags\":{\"value\":\"ui_profile\"}}},{\"term\":{\"utmTags\":{\"value\":\"ui_sidebar\"}}}],\"minimum_should_match\":1}}]}},\"sort\":[{\"timestamp\":{\"order\":\"asc\"}}]}"
+  },
+  "aggregations": {
+    "totalDistinctUsers": {
+      "value": 3
+    },
+    "uniqueUsers": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "aryaman.bhushan",
+          "doc_count": 15,
+          "latest_timestamp": {
+            "value": 1702467380854
+          }
+        },
+        {
+          "key": "chris",
+          "doc_count": 2,
+          "latest_timestamp": {
+            "value": 1702456573382
+          }
+        },
+        {
+          "key": "ernest",
+          "doc_count": 1,
+          "latest_timestamp": {
+            "value": 1702430875247
+          }
+        }
+      ]
+    }
+  },
+  "approximateCount": 18
+}

--- a/tests/unit/data/search_log_responses/sl_most_viewed_assets.json
+++ b/tests/unit/data/search_log_responses/sl_most_viewed_assets.json
@@ -1,0 +1,154 @@
+{
+  "searchParameters": {
+    "dsl": {
+      "from": 0,
+      "size": 0,
+      "aggregations": {
+        "uniqueAssets": {
+          "aggregations": {
+            "uniqueUsers": {
+              "cardinality": {
+                "field": "userName",
+                "precision_threshold": 1000
+              }
+            }
+          },
+          "terms": {
+            "field": "entityGuidsAll",
+            "size": 10
+          }
+        },
+        "totalDistinctUsers": {
+          "cardinality": {
+            "field": "userName",
+            "precision_threshold": 1000
+          }
+        }
+      },
+      "track_total_hits": true,
+      "query": {
+        "bool": {
+          "must_not": [
+            {
+              "terms": {
+                "userName": [
+                  "atlansupport",
+                  "support",
+                  "support@atlan.com",
+                  "atlansupport@atlan.com",
+                  "hello@atlan.com"
+                ]
+              }
+            }
+          ],
+          "filter": [
+            {
+              "term": {
+                "utmTags": {
+                  "value": "action_asset_viewed"
+                }
+              }
+            },
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "utmTags": {
+                        "value": "ui_profile"
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "utmTags": {
+                        "value": "ui_sidebar"
+                      }
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ]
+        }
+      },
+      "sort": [
+        {
+          "timestamp": {
+            "order": "asc"
+          }
+        }
+      ]
+    },
+    "queryString": "{\"from\":0,\"size\":0,\"aggregations\":{\"uniqueAssets\":{\"aggregations\":{\"uniqueUsers\":{\"cardinality\":{\"field\":\"userName\",\"precision_threshold\":1000}}},\"terms\":{\"field\":\"entityGuidsAll\",\"size\":10}},\"totalDistinctUsers\":{\"cardinality\":{\"field\":\"userName\",\"precision_threshold\":1000}}},\"track_total_hits\":true,\"query\":{\"bool\":{\"must_not\":[{\"terms\":{\"userName\":[\"atlansupport\",\"support\",\"support@atlan.com\",\"atlansupport@atlan.com\",\"hello@atlan.com\"]}}],\"filter\":[{\"term\":{\"utmTags\":{\"value\":\"action_asset_viewed\"}}},{\"bool\":{\"should\":[{\"term\":{\"utmTags\":{\"value\":\"ui_profile\"}}},{\"term\":{\"utmTags\":{\"value\":\"ui_sidebar\"}}}],\"minimum_should_match\":1}}]}},\"sort\":[{\"timestamp\":{\"order\":\"asc\"}}]}"
+  },
+  "aggregations": {
+    "totalDistinctUsers": {
+      "value": 3
+    },
+    "uniqueAssets": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "c19550f5-91ea-45a5-8b83-de07fcd5bbd1",
+          "doc_count": 18,
+          "uniqueUsers": {
+            "value": 3
+          }
+        },
+        {
+          "key": "a31756e0-a2f0-4fb6-ba8f-934bd607117b",
+          "doc_count": 7,
+          "uniqueUsers": {
+            "value": 1
+          }
+        },
+        {
+          "key": "cc162918-0602-4806-a2ea-4a835d4dea8f",
+          "doc_count": 4,
+          "uniqueUsers": {
+            "value": 2
+          }
+        },
+        {
+          "key": "d4c540a8-cd87-4273-bb89-b40a7681b3f2",
+          "doc_count": 4,
+          "uniqueUsers": {
+            "value": 1
+          }
+        },
+        {
+          "key": "08308c94-d0e6-411b-bc03-d1a8f50e71de",
+          "doc_count": 1,
+          "uniqueUsers": {
+            "value": 1
+          }
+        },
+        {
+          "key": "3a1d3738-1efc-4533-bd4a-9f876a519090",
+          "doc_count": 1,
+          "uniqueUsers": {
+            "value": 1
+          }
+        },
+        {
+          "key": "3aa33907-9f69-46aa-9c31-e38b0804c078",
+          "doc_count": 1,
+          "uniqueUsers": {
+            "value": 1
+          }
+        },
+        {
+          "key": "b84bfe43-806f-4a5b-8256-1b0f3acc1b4b",
+          "doc_count": 1,
+          "uniqueUsers": {
+            "value": 1
+          }
+        }
+      ]
+    }
+  },
+  "approximateCount": 40
+}

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -36,6 +36,7 @@ UNIQUE_ASSETS = "uniqueAssets"
 LOG_IP_ADDRESS = "ipAddress"
 LOG_USERNAME = "userName"
 SEARCH_PARAMS = "searchParameters"
+SEARCH_COUNT = "approximateCount"
 DATA_RESPONSES_DIR = Path(__file__).parent / "data" / "search_log_responses"
 SL_MOST_RECENT_VIEWERS_JSON = "sl_most_recent_viewers.json"
 SL_MOST_VIEWED_ASSETS_JSON = "sl_most_viewed_assets.json"
@@ -944,7 +945,7 @@ def test_search_log_most_recent_viewers(mock_sl_api_call, sl_most_recent_viewers
     assert len(viewers) == 3
     assert response.asset_views is None
     assert request_dsl_json == sl_most_recent_viewers_json[SEARCH_PARAMS]["dsl"]
-    assert response.count == sl_most_recent_viewers_json["approximateCount"]
+    assert response.count == sl_most_recent_viewers_json[SEARCH_COUNT]
     assert viewers[0].username == recent_viewers_aggs_buckets[0]["key"]
     assert viewers[0].view_count == recent_viewers_aggs_buckets[0]["doc_count"]
     assert viewers[0].most_recent_view
@@ -966,7 +967,7 @@ def test_search_log_most_viewed_assets(mock_sl_api_call, sl_most_viewed_assets_j
     assert len(detail) == 8
     assert response.user_views is None
     assert request_dsl_json == sl_most_viewed_assets_json[SEARCH_PARAMS]["dsl"]
-    assert response.count == sl_most_viewed_assets_json["approximateCount"]
+    assert response.count == sl_most_viewed_assets_json[SEARCH_COUNT]
     assert detail[0].guid == viewed_assets_aggs_buckets["key"]
     assert detail[0].total_views == viewed_assets_aggs_buckets["doc_count"]
     assert detail[0].distinct_users == viewed_assets_aggs_buckets[UNIQUE_USERS]["value"]
@@ -982,11 +983,28 @@ def test_search_log_views_by_guid(mock_sl_api_call, sl_detailed_log_entries_json
     response = client.search_log.search(request)
     log_entries = response.current_page()
     assert request_dsl_json == sl_detailed_log_entries_json[SEARCH_PARAMS]["dsl"]
-    assert (
-        len(response.current_page()) == sl_detailed_log_entries_json["approximateCount"]
-    )
+    assert len(response.current_page()) == sl_detailed_log_entries_json[SEARCH_COUNT]
     assert log_entries[0].user_name == sl_detailed_log_entries[0][LOG_USERNAME]
     assert log_entries[0].ip_address == sl_detailed_log_entries[0][LOG_IP_ADDRESS]
+    assert log_entries[0].host
+    assert log_entries[0].user_agent
+    assert log_entries[0].utm_tags
+    assert log_entries[0].entity_guids_all
+    assert log_entries[0].entity_guids_allowed
+    assert log_entries[0].entity_qf_names_all
+    assert log_entries[0].entity_qf_names_allowed
+    assert log_entries[0].entity_type_names_all
+    assert log_entries[0].entity_type_names_allowed
+    assert log_entries[0].has_result
+    assert log_entries[0].results_count
+    assert log_entries[0].response_time
+    assert log_entries[0].created_at
+    assert log_entries[0].timestamp
+    assert log_entries[0].failed is False
+    assert log_entries[0].request_dsl
+    assert log_entries[0].request_dsl_text
+    assert log_entries[0].request_attributes is None
+    assert log_entries[0].request_relation_attributes
 
 
 class TestBatch:

--- a/tests/unit/test_search_model.py
+++ b/tests/unit/test_search_model.py
@@ -283,7 +283,8 @@ def test_index_search_request():
         ' "dsl": {"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true, '
         '"post_filter": {"term": {"databaseName.keyword": '
         '{"value": "ATLAN_SAMPLE_DATA"}}}, "query": {"term": {"__typeName.keyword": {"value": "Schema"}}}, '
-        '"sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": []}'
+        '"sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": [], '
+        '"requestMetadata": {"saveSearchLog": true, "utmTags": ["project_sdk_python"]}}'
     )
 
 
@@ -299,7 +300,8 @@ def test_index_search_request_get_dsl_str():
         ' "dsl": {"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true,'
         ' "post_filter": {"term": {"databaseName.keyword": {"value": "ATLAN_SAMPLE_DATA"}}},'
         ' "query": {"term": {"__typeName.keyword": {"value": "Schema"}}},'
-        ' "sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": []}}'
+        ' "sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": [],'
+        ' "requestMetadata": {"saveSearchLog": true, "utmTags": ["project_sdk_python"]}}}'
     )
 
 

--- a/tests/unit/test_search_model.py
+++ b/tests/unit/test_search_model.py
@@ -267,7 +267,7 @@ def test_dsl():
         == '{"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true, '
         '"post_filter": {"term": {"databaseName.keyword": '
         '{"value": "ATLAN_SAMPLE_DATA"}}}, "query": {"term": '
-        '{"__typeName.keyword": {"value": "Schema"}}}, "sort": [{"__guid": {"order": "asc"}}]}'
+        '{"__typeName.keyword": {"value": "Schema"}}}, "sort": [{"__guid": {"order": "asc"}}], "_source": []}'
     )
 
 
@@ -283,7 +283,7 @@ def test_index_search_request():
         ' "dsl": {"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true, '
         '"post_filter": {"term": {"databaseName.keyword": '
         '{"value": "ATLAN_SAMPLE_DATA"}}}, "query": {"term": {"__typeName.keyword": {"value": "Schema"}}}, '
-        '"sort": [{"__guid": {"order": "asc"}}]}, "relationAttributes": []}'
+        '"sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": []}'
     )
 
 
@@ -299,7 +299,7 @@ def test_index_search_request_get_dsl_str():
         ' "dsl": {"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true,'
         ' "post_filter": {"term": {"databaseName.keyword": {"value": "ATLAN_SAMPLE_DATA"}}},'
         ' "query": {"term": {"__typeName.keyword": {"value": "Schema"}}},'
-        ' "sort": [{"__guid": {"order": "asc"}}]}, "relationAttributes": []}}'
+        ' "sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": []}}'
     )
 
 

--- a/tests/unit/test_search_model.py
+++ b/tests/unit/test_search_model.py
@@ -267,7 +267,7 @@ def test_dsl():
         == '{"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true, '
         '"post_filter": {"term": {"databaseName.keyword": '
         '{"value": "ATLAN_SAMPLE_DATA"}}}, "query": {"term": '
-        '{"__typeName.keyword": {"value": "Schema"}}}, "sort": [{"__guid": {"order": "asc"}}], "_source": []}'
+        '{"__typeName.keyword": {"value": "Schema"}}}, "sort": [{"__guid": {"order": "asc"}}]}'
     )
 
 
@@ -283,7 +283,7 @@ def test_index_search_request():
         ' "dsl": {"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true, '
         '"post_filter": {"term": {"databaseName.keyword": '
         '{"value": "ATLAN_SAMPLE_DATA"}}}, "query": {"term": {"__typeName.keyword": {"value": "Schema"}}}, '
-        '"sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": [], '
+        '"sort": [{"__guid": {"order": "asc"}}]}, "relationAttributes": [], '
         '"requestMetadata": {"saveSearchLog": true, "utmTags": ["project_sdk_python"]}}'
     )
 
@@ -300,7 +300,7 @@ def test_index_search_request_get_dsl_str():
         ' "dsl": {"from": 0, "size": 100, "aggregations": {}, "track_total_hits": true,'
         ' "post_filter": {"term": {"databaseName.keyword": {"value": "ATLAN_SAMPLE_DATA"}}},'
         ' "query": {"term": {"__typeName.keyword": {"value": "Schema"}}},'
-        ' "sort": [{"__guid": {"order": "asc"}}], "_source": []}, "relationAttributes": [],'
+        ' "sort": [{"__guid": {"order": "asc"}}]}, "relationAttributes": [],'
         ' "requestMetadata": {"saveSearchLog": true, "utmTags": ["project_sdk_python"]}}}'
     )
 


### PR DESCRIPTION
### Todos

- [x] monitor views of assets over some time span (this is part of the new search log)
- [x] monitor search queries for patterns (common / emerging) — also part of the new search log (via `cmd + k`)
- [x] add unit and integration tests.
- [x] add snippets to the developer portal docs.

### Sample Snippets

#### 1.  Without time range

```py
from pyatlan.model.search_log import SearchLogRequest
from pyatlan.client.atlan import AtlanClient

client = AtlanClient()

request = SearchLogRequest.by_guid(
    guid="<asset-guid>", user_size=2
)
response = client.search_log.search(request)

print(f"Total Assets Views : {response.total_views}")

for user in response.unique_users:
    print(
        f"Username : {user.name}, View count: {user.view_count}, Last view timestamp : {user.view_timestamp}"
    )
```

#### Output:
```bash
Total Assets Views : 39
Username : aryaman.bhushan, View count: 37, Last view timestamp : 2023-12-05 11:27:56.977000+00:00
Username : chris, View count: 2, Last view timestamp : 2023-12-05 09:52:46.723000+00:00
```

#### 2. With time range

```py
client = AtlanClient()

# 4 hrs ago
request = SearchLogRequest.by_guid(
    guid="<asset-guid>",
    user_size=2,
    start_time=1701766262000,
    end_time=1701780919766,
)

response = client.search_log.search(request)
print(f"Total Assest Views : {response.total_views}")

for user in response.unique_users:
    print(
        f"Username : {user.name}, View count: {user.view_count}, Last view timestamp : {user.view_timestamp}"
    )
```

```bash
Total Assest Views : 13
Username : aryaman.bhushan, View count: 12, Last view timestamp : 2023-12-05 11:27:56.977000+00:00
Username : chris, View count: 1, Last view timestamp : 2023-12-05 09:52:46.723000+00:00
```

#### 3. Retrieve recent search log

```py
client = AtlanClient()
request = SearchLogRequest.get_recent_search(usernames=["aryaman.bhushan"], size=5)
response = client.search_log.search(request)

print(f"Total search count: {response.total_count}")
for asset_log in response:
    print(asset_log.dict())
```

```bash
Total search count: 81
{'log_host': 'devx.atlan.com', 'log_ipaddress': '<ip_address>', 'log_user_agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15...', 'log_username': 'aryaman.bhushan', 'log_guid': '<asset_guid>', 'log_qualified_name': '<asset_qualified_name>', 'log_type_name': 'Table', 'log_timestamp': datetime.datetime(2023, 12, 6, 8, 26, 59, 986000, tzinfo=datetime.timezone.utc)}
...
...
```