### PR TITLE
Fixes workflow client `monitor` method

### DIFF
--- a/pyatlan/client/workflow.py
+++ b/pyatlan/client/workflow.py
@@ -76,10 +76,10 @@ class WorkflowClient:
             filter=[
                 NestedQuery(
                     query=Term(
-                        field="metadata.name.keyword",
+                        field="spec.workflowTemplateRef.name.keyword",
                         value=workflow_name,
                     ),
-                    path="metadata",
+                    path="spec",
                 )
             ]
         )


### PR DESCRIPTION
The `WorkflowResponse` **metadata.name** provides the name of the workflow. Therefore, when calling 
`/api/service/runs/indexsearch`, we should find the latest workflow run by passing its name it's name to `spec.workflowTemplateRef.name.keyword` to obtain the desired results.