### PR TITLE
DVX-97: Adds credential management and refactor packages

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -32,6 +32,7 @@ from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageList
 from pyatlan.client.audit import AuditClient
 from pyatlan.client.common import CONNECTION_RETRY, HTTP_PREFIX, HTTPS_PREFIX
 from pyatlan.client.constants import PARSE_QUERY, UPLOAD_IMAGE
+from pyatlan.client.credential import CredentialClient
 from pyatlan.client.group import GroupClient
 from pyatlan.client.role import RoleClient
 from pyatlan.client.search_log import SearchLogClient
@@ -122,6 +123,7 @@ class AtlanClient(BaseSettings):
     _session: requests.Session = PrivateAttr(default_factory=get_session)
     _request_params: dict = PrivateAttr()
     _workflow_client: Optional[WorkflowClient] = PrivateAttr(default=None)
+    _credential_client: Optional[CredentialClient] = PrivateAttr(default=None)
     _admin_client: Optional[AdminClient] = PrivateAttr(default=None)
     _audit_client: Optional[AuditClient] = PrivateAttr(default=None)
     _search_log_client: Optional[SearchLogClient] = PrivateAttr(default=None)
@@ -191,6 +193,12 @@ class AtlanClient(BaseSettings):
         if self._workflow_client is None:
             self._workflow_client = WorkflowClient(client=self)
         return self._workflow_client
+
+    @property
+    def credential(self) -> CredentialClient:
+        if self._credential_client is None:
+            self._credential_client = CredentialClient(client=self)
+        return self._credential_client
 
     @property
     def group(self) -> GroupClient:

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -387,6 +387,26 @@ WORKFLOW_RUN_API = "workflows?submit=true"
 WORKFLOW_RUN = API(
     WORKFLOW_RUN_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HERACLES
 )
+CREDENTIALS_API = "credentials"
+TEST_CREDENTIAL_API = CREDENTIALS_API + "/test"
+TEST_CREDENTIAL = API(
+    TEST_CREDENTIAL_API,
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+GET_CREDENTIAL_BY_GUID = API(
+    CREDENTIALS_API + "/{credential_guid}",
+    HTTPMethod.GET,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+UPDATE_CREDENTIAL_BY_GUID = API(
+    CREDENTIALS_API + "/{credential_guid}",
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
 AUDIT_API = "entity/auditSearch"
 AUDIT_SEARCH = API(AUDIT_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.ATLAS)
 SEARCH_LOG_API = "search/searchlog"

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -1,0 +1,85 @@
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.constants import (
+    GET_CREDENTIAL_BY_GUID,
+    TEST_CREDENTIAL,
+    UPDATE_CREDENTIAL_BY_GUID,
+)
+from pyatlan.errors import ErrorCode
+from pyatlan.model.credential import (
+    Credential,
+    CredentialResponse,
+    CredentialTestResponse,
+)
+
+
+class CredentialClient:
+    """
+    A client for managing credentials within the Atlan platform.
+
+    This class provides functionality for interacting with Atlan's credential objects.
+    It allows you to perform operations such as retrieving, testing, and updating given credentials.
+    """
+
+    def __init__(self, client: ApiCaller):
+        if not isinstance(client, ApiCaller):
+            raise ErrorCode.INVALID_PARAMETER_TYPE.exception_with_parameters(
+                "client", "ApiCaller"
+            )
+        self._client = client
+
+    def get(self, guid: str) -> Credential:
+        """
+        Retrieves a credential by its unique identifier (GUID).
+        Note that this will never contain sensitive information
+        in the credential, such as usernames, passwords or client secrets or keys.
+
+        :param guid: GUID of the credential.
+        :returns: A Credential instance.
+        :raises: AtlanException on any error during API invocation.
+        """
+        raw_json = self._client._call_api(
+            GET_CREDENTIAL_BY_GUID.format_path({"credential_guid": guid})
+        )
+        return CredentialResponse(**raw_json).to_credential()
+
+    def test(self, credential: Credential) -> CredentialTestResponse:
+        """
+        Tests the given credential by sending it to Atlan for validation.
+
+        :param credential: The credential to be tested.
+        :type credential: A CredentialTestResponse instance.
+        :return: The response indicating the test result.
+        :raises InvalidRequestException: If the provided credential is invalid type.
+        :raises AtlanException: On any error during API invocation.
+        :raises InvalidRequestException: If the provided credential does not have an ID.
+        """
+        if not isinstance(credential, Credential):
+            raise ErrorCode.INVALID_PARAMETER_TYPE.exception_with_parameters(
+                "credential", "Credential"
+            )
+        if not credential.id:
+            raise ErrorCode.MISSING_TOKEN_ID.exception_with_parameters()
+        raw_json = self._client._call_api(TEST_CREDENTIAL, request_obj=credential)
+        return CredentialTestResponse(**raw_json)
+
+    def test_and_update(self, credential: Credential) -> CredentialResponse:
+        """
+        Updates this credential in Atlan after first
+        testing it to confirm its successful validation.
+
+        :returns: An updated Credential instance.
+        :raises InvalidRequestException: if the provided credentials
+        cannot be validated successfully.
+        :raises AtlanException: on any error during API invocation.
+        """
+
+        test_response = self.test(credential=credential)
+        if not test_response.is_successful:
+            raise ErrorCode.INVALID_CREDENTIALS.exception_with_parameters(
+                test_response.message
+            )
+        raw_json = self._client._call_api(
+            UPDATE_CREDENTIAL_BY_GUID.format_path({"credential_guid": credential.id}),
+            request_obj=credential,
+        )
+        return CredentialResponse(**raw_json)

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -1,3 +1,5 @@
+from pydantic import validate_arguments
+
 from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import (
     GET_CREDENTIAL_BY_GUID,
@@ -27,6 +29,7 @@ class CredentialClient:
             )
         self._client = client
 
+    @validate_arguments()
     def get(self, guid: str) -> CredentialResponse:
         """
         Retrieves a credential by its unique identifier (GUID).
@@ -42,6 +45,7 @@ class CredentialClient:
         )
         return CredentialResponse(**raw_json)
 
+    @validate_arguments()
     def test(self, credential: Credential) -> CredentialTestResponse:
         """
         Tests the given credential by sending it to Atlan for validation.
@@ -59,6 +63,7 @@ class CredentialClient:
         raw_json = self._client._call_api(TEST_CREDENTIAL, request_obj=credential)
         return CredentialTestResponse(**raw_json)
 
+    @validate_arguments()
     def test_and_update(self, credential: Credential) -> CredentialResponse:
         """
         Updates this credential in Atlan after first

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -470,6 +470,13 @@ class ErrorCode(Enum):
         "Please invoke this method on a sub-class of Asset",
         InvalidRequestError,
     )
+    INVALID_CREDENTIALS = (
+        400,
+        "ATLAN-PYTHON-400-043",
+        "Credentials provided did not work: {0}.",
+        "Please double-check your credentials and test them again.",
+        InvalidRequestError,
+    )
     AUTHENTICATION_PASSTHROUGH = (
         401,
         "ATLAN-PYTHON-401-000",

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -1,0 +1,92 @@
+from typing import Any, Optional
+
+from pydantic import Field
+
+from pyatlan.model.core import AtlanObject
+
+
+class Credential(AtlanObject):
+    # Unique identifier (GUID) of the credential.
+    id: Optional[str]
+    # Name of the credential.
+    name: Optional[str]
+    # Hostname for which connectivity is defined by the credential.
+    host: Optional[str]
+    # Port number on which connectivity should be done.
+    port: Optional[int]
+    # Authentication mechanism represented by the credential.
+    auth_type: Optional[str]
+    # Type of connector used by the credential.
+    connector_type: Optional[str]
+    # Less sensitive portion of the credential
+    # typically used for a username for basic authentication
+    # or client IDs for other forms of authentication.
+    username: Optional[str]
+    # More sensitive portion of the credential,
+    # typically used for a password for basic authenticatio
+    # or client secrets for other forms of authentication.
+    password: Optional[str]
+    # Additional details about the credential. This can capture,
+    # for example, a secondary secret for particular forms of authentication
+    # and / or additional details about the scope of the connectivity
+    # (a specific database, role, warehouse, etc).
+    extras: Optional[dict[str, Any]] = Field(alias="extra")
+    # Name of the connector configuration
+    # responsible for managing the credential.
+    connector_config_name: Optional[str]
+
+
+class CredentialResponse(AtlanObject):
+    id: str
+    version: str
+    is_active: bool
+    created_at: int
+    updated_at: int
+    created_by: str
+    tenant_id: str
+    name: str
+    description: Optional[str]
+    connector_config_name: str
+    connector: str
+    connector_type: str
+    auth_type: str
+    host: str
+    port: Optional[int]
+    metadata: Optional[dict[str, Any]]
+    level: Optional[dict[str, Any]]
+    connection: Optional[dict[str, Any]]
+
+    def to_credential(self) -> Credential:
+        """
+        Convert this response into a credential instance.
+        Note: the username, password, and extras fields
+        must still all be populated, as they will never be
+        returned by a credential lookup (for security reasons).
+        """
+        return Credential(
+            id=self.id,
+            name=self.name,
+            host=self.host,
+            port=self.port,
+            auth_type=self.auth_type,
+            connector_type=self.connector_type,
+            connector_config_name=self.connector_config_name,
+        )
+
+
+class CredentialTestResponse(AtlanObject):
+    code: Optional[int]
+    error: Optional[str]
+    info: Optional[object]
+    message: str
+    request_id: Optional[str]
+
+    @property
+    def is_successful(self) -> bool:
+        """
+        Whether the test was successful (True) or failed (False).
+
+        Returns:
+            bool: True if the test was successful, False otherwise.
+        """
+        return self.message == "successful"

--- a/pyatlan/model/packages/base/crawler.py
+++ b/pyatlan/model/packages/base/crawler.py
@@ -37,9 +37,7 @@ class AbstractCrawler(AbstractPackage):
         row_limit: int = 0,
         source_logo: str = "",
     ):
-        self._parameters: list = []
-        self._credentials_body: dict = {}
-        self._epoch = int(utils.get_epoch_timestamp())
+        super().__init__()
         self._connection_name = connection_name
         self._connection_type = connection_type
         self._admin_roles = admin_roles
@@ -49,6 +47,7 @@ class AbstractCrawler(AbstractPackage):
         self._allow_query_preview = allow_query_preview
         self._row_limit = row_limit
         self._source_logo = source_logo
+        self._epoch = int(utils.get_epoch_timestamp())
 
     def _get_connection(self) -> Connection:
         """

--- a/pyatlan/model/packages/confluent_kafka_crawler.py
+++ b/pyatlan/model/packages/confluent_kafka_crawler.py
@@ -65,7 +65,7 @@ class ConfluentKafkaCrawler(AbstractCrawler):
             "extra": {
                 "security_protocol": "SASL_SSL" if encrypted else "SASL_PLAINTEXT"
             },
-            "connectorConfigName": "atlan-connectors-kafka-confluent-cloud",
+            "connector_config_name": "atlan-connectors-kafka-confluent-cloud",
         }
         self._credentials_body.update(local_creds)
         self._parameters.append(dict(name="extraction-method", value="direct"))
@@ -84,7 +84,7 @@ class ConfluentKafkaCrawler(AbstractCrawler):
         :returns: crawler, set up to use API token-based authentication
         """
         local_creds = {
-            "authType": "basic",
+            "auth_type": "basic",
             "username": api_key,
             "password": api_secret,
         }
@@ -99,6 +99,8 @@ class ConfluentKafkaCrawler(AbstractCrawler):
         regular expression will be included in crawling
         :returns: crawler, set to include only those topics specified
         """
+        if not regex:
+            return self
         self._parameters.append(dict(name="include-filter", value=regex))
         return self
 
@@ -111,6 +113,8 @@ class ConfluentKafkaCrawler(AbstractCrawler):
         :returns: crawler, set to exclude any topics
         that match the provided regular expression
         """
+        if not regex:
+            return self
         self._parameters.append(dict(name="exclude-filter", value=regex))
         return self
 

--- a/pyatlan/model/packages/dbt_crawler.py
+++ b/pyatlan/model/packages/dbt_crawler.py
@@ -69,10 +69,10 @@ class DbtCrawler(AbstractCrawler):
             "name": f"default-{self._NAME}-{self._epoch}-1",
             "host": hostname,
             "port": 443,
-            "authType": "token",
+            "auth_type": "token",
             "username": "",
             "password": service_token,
-            "connectorConfigName": f"atlan-connectors-{self._NAME}",
+            "connector_config_name": f"atlan-connectors-{self._NAME}",
         }
         self._credentials_body.update(local_creds)
         self._parameters.append(dict(name="extraction-method", value="api"))

--- a/pyatlan/model/packages/glue_crawler.py
+++ b/pyatlan/model/packages/glue_crawler.py
@@ -27,6 +27,7 @@ class GlueCrawler(AbstractCrawler):
     _PACKAGE_NAME = "@atlan/glue"
     _PACKAGE_PREFIX = WorkflowPackage.GLUE.value
     _CONNECTOR_TYPE = AtlanConnectorType.GLUE
+    _AWS_DATA_CATALOG = "AwsDataCatalog"
     _PACKAGE_ICON = (
         "https://atlan-public.s3.eu-west-1.amazonaws.com/atlan/logos/aws-glue.png"
     )
@@ -69,7 +70,7 @@ class GlueCrawler(AbstractCrawler):
         local_creds = {
             "name": f"default-{self._NAME}-{self._epoch}-0",
             "extra": {"region": region},
-            "connectorConfigName": f"atlan-connectors-{self._NAME}",
+            "connector_config_name": f"atlan-connectors-{self._NAME}",
         }
         self._credentials_body.update(local_creds)
         return self
@@ -83,7 +84,7 @@ class GlueCrawler(AbstractCrawler):
         :returns: crawler, set up to use IAM user-based authentication
         """
         local_creds = {
-            "authType": "iam",
+            "auth_type": "iam",
             "username": access_key,
             "password": secret_key,
         }
@@ -92,16 +93,16 @@ class GlueCrawler(AbstractCrawler):
 
     def _build_asset_filter(self, filter_type: str, filter_assets: list[str]) -> None:
         if not filter_assets:
-            self._parameters.append({"name": f"{filter_type}-filter", "value": {}})
+            self._parameters.append({"name": f"{filter_type}-filter", "value": "{}"})
             return
-        filter_dict: dict = {"AwsDataCatalog": {}}
+        filter_dict: dict = {self._AWS_DATA_CATALOG: {}}
         try:
             for asset in filter_assets:
-                filter_dict["AwsDataCatalog"][asset] = {}
+                filter_dict[self._AWS_DATA_CATALOG][asset] = {}
                 filter_values = dumps(filter_dict)
-                self._parameters.append(
-                    {"name": f"{filter_type}-filter", "value": filter_values}
-                )
+            self._parameters.append(
+                {"name": f"{filter_type}-filter", "value": filter_values}
+            )
         except TypeError:
             raise ErrorCode.UNABLE_TO_TRANSLATE_FILTERS.exception_with_parameters()
 

--- a/pyatlan/model/packages/powerbi_crawler.py
+++ b/pyatlan/model/packages/powerbi_crawler.py
@@ -134,8 +134,9 @@ class PowerBICrawler(AbstractCrawler):
         """
         include_workspaces = workspaces or []
         to_include = self.build_flat_filter(include_workspaces)
-        if to_include:
-            self._parameters.append(dict(name="include-filter", value=to_include))
+        self._parameters.append(
+            dict(name="include-filter", value=to_include if to_include else "{}")
+        )
         return self
 
     def exclude(self, workspaces: list[str]) -> "PowerBICrawler":
@@ -149,8 +150,9 @@ class PowerBICrawler(AbstractCrawler):
         """
         exclude_workspaces = workspaces or []
         to_exclude = self.build_flat_filter(exclude_workspaces)
-        if to_exclude:
-            self._parameters.append(dict(name="exclude-filter", value=to_exclude))
+        self._parameters.append(
+            dict(name="exclude-filter", value=to_exclude if to_exclude else "{}")
+        )
         return self
 
     def direct_endorsements(self, enabled: bool = True) -> "PowerBICrawler":

--- a/pyatlan/model/packages/snowflake_crawler.py
+++ b/pyatlan/model/packages/snowflake_crawler.py
@@ -65,10 +65,10 @@ class SnowflakeCrawler(AbstractCrawler):
         local_creds = {
             "name": f"default-snowflake-{self._epoch}-0",
             "port": 443,
-            "authType": "basic",
+            "auth_type": "basic",
             "username": username,
             "password": password,
-            "extra": {"role": role, "warehouse": warehouse},
+            "extras": {"role": role, "warehouse": warehouse},
         }
         self._credentials_body.update(local_creds)
         return self
@@ -94,10 +94,10 @@ class SnowflakeCrawler(AbstractCrawler):
         local_creds = {
             "name": f"default-snowflake-{self._epoch}-0",
             "port": 443,
-            "authType": "keypair",
+            "auth_type": "keypair",
             "username": username,
             "password": private_key,
-            "extra": {
+            "extras": {
                 "role": role,
                 "warehouse": warehouse,
                 "private_key_password": private_key_password,
@@ -116,7 +116,7 @@ class SnowflakeCrawler(AbstractCrawler):
         local_creds = {
             "host": hostname,
             "name": f"default-snowflake-{self._epoch}-0",
-            "connectorConfigName": "atlan-connectors-snowflake",
+            "connector_config_name": "atlan-connectors-snowflake",
         }
         parameters = {"name": "extract-strategy", "value": "information-schema"}
         self._credentials_body.update(local_creds)
@@ -135,9 +135,9 @@ class SnowflakeCrawler(AbstractCrawler):
         :returns: crawler, set to extract using account usage
         """
         local_creds = {
-            "hostname": hostname,
+            "host": hostname,
             "name": f"default-snowflake-{self._epoch}-0",
-            "connectorConfigName": "atlan-connectors-snowflake",
+            "connector_config_name": "atlan-connectors-snowflake",
         }
         self._credentials_body.update(local_creds)
         self._parameters.append(
@@ -185,8 +185,9 @@ class SnowflakeCrawler(AbstractCrawler):
         """
         include_assets = assets or {}
         to_include = self.build_hierarchical_filter(include_assets)
-        if to_include:
-            self._parameters.append(dict(name="include-filter", value=to_include))
+        self._parameters.append(
+            dict(name="include-filter", value=to_include if to_include else "{}")
+        )
         return self
 
     def exclude(self, assets: dict) -> "SnowflakeCrawler":
@@ -202,8 +203,9 @@ class SnowflakeCrawler(AbstractCrawler):
         """
         exclude_assets = assets or {}
         to_exclude = self.build_hierarchical_filter(exclude_assets)
-        if to_exclude:
-            self._parameters.append(dict(name="exclude-filter", value=to_exclude))
+        self._parameters.append(
+            dict(name="exclude-filter", value=to_exclude if to_exclude else "{}")
+        )
         return self
 
     def _set_required_metadata_params(self):

--- a/pyatlan/model/packages/tableau_crawler.py
+++ b/pyatlan/model/packages/tableau_crawler.py
@@ -125,8 +125,9 @@ class TableauCrawler(AbstractCrawler):
         """
         include_projects = projects or []
         to_include = self.build_flat_filter(include_projects)
-        if to_include:
-            self._parameters.append(dict(name="include-filter", value=to_include))
+        self._parameters.append(
+            dict(name="include-filter", value=to_include if to_include else "{}")
+        )
         return self
 
     def exclude(self, projects: list[str]) -> "TableauCrawler":
@@ -140,8 +141,9 @@ class TableauCrawler(AbstractCrawler):
         """
         exclude_projects = projects or []
         to_exclude = self.build_flat_filter(exclude_projects)
-        if to_exclude:
-            self._parameters.append(dict(name="exclude-filter", value=to_exclude))
+        self._parameters.append(
+            dict(name="exclude-filter", value=to_exclude if to_exclude else "{}")
+        )
         return self
 
     def crawl_hidden_fields(self, enabled: bool = True) -> "TableauCrawler":

--- a/tests/unit/data/package_requests/dbt_cloud.json
+++ b/tests/unit/data/package_requests/dbt_cloud.json
@@ -75,6 +75,14 @@
                     "value": "{\"1234\":{\"4321\":{}}}"
                   },
                   {
+                    "name": "exclude-filter",
+                    "value": "{}"
+                  },
+                  {
+                    "name": "exclude-filter-core",
+                    "value": "*"
+                  },
+                  {
                     "name": "enable-dbt-tagsync",
                     "value": "true"
                   },

--- a/tests/unit/data/package_requests/glue_iam_user.json
+++ b/tests/unit/data/package_requests/glue_iam_user.json
@@ -48,11 +48,11 @@
                   "parameters": [
                     {
                       "name": "include-filter",
-                      "value": "{\"AwsDataCatalog\": {\"test-asset-1\": {}}}"
+                      "value": "{\"AwsDataCatalog\": {\"test-asset-1\": {}, \"test-asset-2\": {}}}"
                     },
                     {
-                      "name": "include-filter",
-                      "value": "{\"AwsDataCatalog\": {\"test-asset-1\": {}, \"test-asset-2\": {}}}"
+                      "name": "exclude-filter",
+                      "value": "{}"
                     },
                     {
                       "name": "credentials-fetch-strategy",

--- a/tests/unit/data/package_requests/powerbi_delegated_user.json
+++ b/tests/unit/data/package_requests/powerbi_delegated_user.json
@@ -52,6 +52,10 @@
                       "value": "{\"test-workspace-guid\": {}}"
                     },
                     {
+                      "name": "exclude-filter",
+                      "value": "{}"
+                    },
+                    {
                       "name": "credential-guid",
                       "value": "{{credentialGuid}}"
                     },

--- a/tests/unit/data/package_requests/powerbi_service_principal.json
+++ b/tests/unit/data/package_requests/powerbi_service_principal.json
@@ -52,6 +52,10 @@
                       "value": "{\"test-workspace-guid\": {}}"
                     },
                     {
+                      "name": "exclude-filter",
+                      "value": "{}"
+                    },
+                    {
                       "name": "credential-guid",
                       "value": "{{credentialGuid}}"
                     },

--- a/tests/unit/data/package_requests/snowflake_basic.json
+++ b/tests/unit/data/package_requests/snowflake_basic.json
@@ -55,6 +55,10 @@
                     "value": "{\"^test-include$\": [\"^test-asset-1$\", \"^test-asset-2$\"]}"
                   },
                   {
+                    "name": "exclude-filter",
+                    "value": "{}"
+                  },
+                  {
                     "name": "enable-lineage",
                     "value": "true"
                   },

--- a/tests/unit/data/package_requests/snowflake_keypair.json
+++ b/tests/unit/data/package_requests/snowflake_keypair.json
@@ -59,6 +59,10 @@
                       "value": "{\"^test-include$\": [\"^test-asset-1$\", \"^test-asset-2$\"]}"
                     },
                     {
+                      "name": "exclude-filter",
+                      "value": "{}"
+                    },
+                    {
                       "name": "enable-lineage",
                       "value": "true"
                     },
@@ -101,7 +105,7 @@
         "parameter": "credentialGuid",
         "type": "credential",
         "body": {
-          "hostname": "test-hostname",
+          "host": "test-hostname",
           "name": "default-snowflake-123456-0",
           "connectorConfigName": "atlan-connectors-snowflake",
           "port": 443,

--- a/tests/unit/data/package_requests/tableau_access_token.json
+++ b/tests/unit/data/package_requests/tableau_access_token.json
@@ -53,7 +53,11 @@
                     },
                     {
                       "name": "include-filter",
-                      "value": "{\"test-project-guid\": {}}"
+                      "value": "{\"test-project-guid-1\": {}, \"test-project-guid-2\": {}}"
+                    },
+                    {
+                      "name": "exclude-filter",
+                      "value": "{}"
                     },
                     {
                       "name": "crawl-unpublished-worksheets-dashboard",

--- a/tests/unit/data/package_requests/tableau_basic.json
+++ b/tests/unit/data/package_requests/tableau_basic.json
@@ -53,7 +53,11 @@
                   },
                   {
                     "name": "include-filter",
-                    "value": "{\"test-project-guid\": {}}"
+                    "value": "{\"test-project-guid-1\": {}, \"test-project-guid-2\": {}}"
+                  },
+                  {
+                    "name": "exclude-filter",
+                    "value": "{}"
                   },
                   {
                     "name": "crawl-unpublished-worksheets-dashboard",

--- a/tests/unit/test_credential_client.py
+++ b/tests/unit/test_credential_client.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Atlan Pte. Ltd.
+from unittest.mock import Mock
+
+import pytest
+
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.credential import CredentialClient
+from pyatlan.errors import InvalidRequestError
+from pyatlan.model.credential import (
+    Credential,
+    CredentialResponse,
+    CredentialTestResponse,
+)
+
+TEST_MISSING_TOKEN_ID = (
+    "ATLAN-PYTHON-400-032 No ID was provided when attempting to update the API token."
+)
+TEST_INVALID_CREDENTIALS = (
+    "ATLAN-PYTHON-400-043 Credentials provided did not work: failed"
+)
+TEST_INVALID_CRED_PARAMETER_TYPE = (
+    "ATLAN-PYTHON-400-048 Invalid parameter type for credential should be Credential"
+)
+TEST_INVALID_API_CALLER_PARAMETER_TYPE = (
+    "ATLAN-PYTHON-400-048 Invalid parameter type for client should be ApiCaller"
+)
+
+
+@pytest.fixture()
+def mock_api_caller():
+    return Mock(spec=ApiCaller)
+
+
+@pytest.fixture()
+def client(mock_api_caller) -> CredentialClient:
+    return CredentialClient(mock_api_caller)
+
+
+@pytest.fixture()
+def credential_response() -> CredentialResponse:
+    return CredentialResponse(
+        id="test-id",
+        version="1.2.3",
+        is_active=True,
+        created_at=1704186290006,
+        updated_at=1704218661848,
+        created_by="test-acc",
+        tenant_id="default",
+        name="test-name",
+        description="test-desc",
+        connector_config_name="test-ccn",
+        connector="test-conn",
+        connector_type="test-ct",
+        auth_type="test-at",
+        host="test-host",
+        port=123,
+        metadata=None,
+        level=None,
+        connection=None,
+    )
+
+
+def _assert_cred_response(cred: Credential, cred_response: CredentialResponse):
+    assert cred.id == cred_response.id
+    assert cred.name == cred_response.name
+    assert cred.port == cred_response.port
+    assert cred.auth_type == cred_response.auth_type
+    assert cred.connector_type == cred_response.connector_type
+    assert cred.connector_config_name == cred_response.connector_config_name
+
+
+@pytest.mark.parametrize("test_api_caller", ["abc", None])
+def test_init_when_wrong_class_raises_exception(test_api_caller):
+    with pytest.raises(
+        InvalidRequestError,
+        match=TEST_INVALID_API_CALLER_PARAMETER_TYPE,
+    ):
+        CredentialClient(test_api_caller)
+
+
+@pytest.mark.parametrize("test_credentials", ["invalid_cred", None])
+def test_cred_test_wrong_params_raises_invalid_request_error(
+    test_credentials, client: CredentialClient
+):
+    with pytest.raises(
+        InvalidRequestError,
+        match=TEST_INVALID_CRED_PARAMETER_TYPE,
+    ):
+        client.test(credential=test_credentials)
+
+
+@pytest.mark.parametrize(
+    "test_credentials, test_response",
+    [
+        ["invalid_cred", None],
+        [None, None],
+        [Credential(), "successful"],
+        [Credential(id="test-id"), "failed"],
+    ],
+)
+def test_cred_test_update_wrong_params_raises_invalid_request_error(
+    test_credentials, test_response, mock_api_caller, client: CredentialClient
+):
+    mock_api_caller._call_api.return_value = {"message": test_response}
+    with pytest.raises(InvalidRequestError) as err:
+        client.test_and_update(credential=test_credentials)
+    if isinstance(test_credentials, Credential):
+        if test_response == "successful":
+            assert TEST_MISSING_TOKEN_ID in str(err.value)
+        else:
+            assert TEST_INVALID_CREDENTIALS in str(err.value)
+    else:
+        assert TEST_INVALID_CRED_PARAMETER_TYPE in str(err.value)
+
+
+def test_cred_get_when_given_guid(
+    client: CredentialClient,
+    mock_api_caller,
+    credential_response: CredentialResponse,
+):
+    mock_api_caller._call_api.return_value = credential_response.dict()
+    assert client.get(guid="test-id") == credential_response
+    cred = client.get(guid="test-id").to_credential()
+    assert isinstance(cred, Credential)
+    _assert_cred_response(cred, credential_response)
+
+
+def test_cred_test_when_given_cred(
+    client: CredentialClient,
+    mock_api_caller,
+    credential_response: CredentialResponse,
+):
+    mock_api_caller._call_api.return_value = {"message": "successful"}
+    cred_test_response = client.test(credential=Credential())
+    assert isinstance(cred_test_response, CredentialTestResponse)
+    assert cred_test_response.message == "successful"
+    assert cred_test_response.code is None
+    assert cred_test_response.error is None
+    assert cred_test_response.info is None
+    assert cred_test_response.request_id is None
+
+
+def test_cred_test_update_when_given_cred(
+    client: CredentialClient,
+    mock_api_caller,
+    credential_response: CredentialResponse,
+):
+    mock_api_caller._call_api.side_effect = [
+        {"message": "successful"},
+        credential_response.dict(),
+    ]
+    cred_response = client.test_and_update(
+        credential=Credential(id=credential_response.id)
+    )
+    assert isinstance(cred_response, CredentialResponse)
+    cred = cred_response.to_credential()
+    _assert_cred_response(cred, credential_response)

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -80,6 +80,7 @@ def test_snowflake_package(
             warehouse="test-warehouse",
         )
         .include(assets={"test-include": ["test-asset-1", "test-asset-2"]})
+        .exclude(assets=None)
         .lineage(True)
         .tags(True)
         .to_workflow()
@@ -105,6 +106,7 @@ def test_snowflake_package(
             warehouse="test-warehouse",
         )
         .include(assets={"test-include": ["test-asset-1", "test-asset-2"]})
+        .exclude(assets=None)
         .lineage(True)
         .tags(False)
         .to_workflow()
@@ -137,6 +139,7 @@ def test_glue_package(
         )
         .direct(region="test-region")
         .include(assets=["test-asset-1", "test-asset-2"])
+        .exclude(assets=None)
         .to_workflow()
     )
     request_json = loads(glue_iam_user_auth.json(by_alias=True, exclude_none=True))
@@ -168,7 +171,8 @@ def test_tableau_package(
             username="test-username",
             password="test-password",
         )
-        .include(projects=["test-project-guid"])
+        .include(projects=["test-project-guid-1", "test-project-guid-2"])
+        .exclude(projects=None)
         .crawl_unpublished(True)
         .crawl_hidden_fields(False)
         .to_workflow()
@@ -188,7 +192,8 @@ def test_tableau_package(
             username="test-username",
             access_token="test-access-token",
         )
-        .include(projects=["test-project-guid"])
+        .include(projects=["test-project-guid-1", "test-project-guid-2"])
+        .exclude(projects=None)
         .crawl_unpublished(True)
         .crawl_hidden_fields(False)
         .to_workflow()
@@ -226,6 +231,7 @@ def test_powerbi_package(
             client_secret="test-client-secret",
         )
         .include(workspaces=["test-workspace-guid"])
+        .exclude(workspaces=None)
         .to_workflow()
     )
     request_json = loads(powerbi_delegated_user.json(by_alias=True, exclude_none=True))
@@ -245,6 +251,7 @@ def test_powerbi_package(
             client_secret="test-client-secret",
         )
         .include(workspaces=["test-workspace-guid"])
+        .exclude(workspaces=None)
         .to_workflow()
     )
     request_json = loads(
@@ -275,6 +282,7 @@ def test_confluent_kafka_package(
         .api_token(api_key="test-api-key", api_secret="test-api-secret")
         .skip_internal(False)
         .include(regex=".*_TEST")
+        .exclude(regex=None)
         .to_workflow()
     )
     request_json = loads(conf_kafka_direct.json(by_alias=True, exclude_none=True))
@@ -326,6 +334,7 @@ def test_dbt_package(
         )
         .limit_to_connection(connection_qualified_name="default/dbt/1234567890")
         .include(filter='{"1234":{"4321":{}}}')
+        .exclude(filter=None)
         .tags(True)
         .enrich_materialized_assets(False)
         .to_workflow()


### PR DESCRIPTION
```py
import logging
from pyatlan.model.credential import Credential

client = AtlanClient()
logging.basicConfig(level=logging.DEBUG)
snowflake_cred = client.credential.get(guid="<cred-guid-123>").to_credential()

# Basic auth
snowflake_cred.auth_type = "basic"
snowflake_cred.username = "<user>"
snowflake_cred.password = "<pass>"
snowflake_cred.extras = {
    "role": "<role>",
    "warehouse": "<wh>",
}

# OR
# Key-pair Auth
snowflake_cred.auth_type = "keypair"
snowflake_cred.username = "<user>"
snowflake_cred.password = KEY
snowflake_cred.extras = {
    "role": "<role>",
    "warehouse": "<wh>",
    "private_key_password": "<pass>",
}
response = client.credential.test_and_update(credential=snowflake_cred)
```