### PR TITLE
Change atlan credential client property name to "credentials" similar to the Java SDK

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -195,7 +195,7 @@ class AtlanClient(BaseSettings):
         return self._workflow_client
 
     @property
-    def credential(self) -> CredentialClient:
+    def credentials(self) -> CredentialClient:
         if self._credential_client is None:
             self._credential_client = CredentialClient(client=self)
         return self._credential_client

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -43,6 +43,8 @@ class CredentialClient:
         raw_json = self._client._call_api(
             GET_CREDENTIAL_BY_GUID.format_path({"credential_guid": guid})
         )
+        if not isinstance(raw_json, dict):
+            return raw_json
         return CredentialResponse(**raw_json)
 
     @validate_arguments()

--- a/tests/unit/test_credential_client.py
+++ b/tests/unit/test_credential_client.py
@@ -146,6 +146,15 @@ def test_cred_get_when_given_guid(
     _assert_cred_response(cred, credential_response)
 
 
+def test_cred_get_when_given_wrong_guid(
+    client: CredentialClient,
+    mock_api_caller,
+    credential_response: CredentialResponse,
+):
+    mock_api_caller._call_api.return_value = None
+    assert client.get(guid="test-wrong-id") is None
+
+
 def test_cred_test_when_given_cred(
     client: CredentialClient,
     mock_api_caller,


### PR DESCRIPTION
- Fixes invalid GUID credential retrieval.