### PR TITLE
DVX-131: Add ability to update certificate, announcement for GlossaryTerm and GlossaryCategory

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -7,7 +7,7 @@ import logging
 import time
 from abc import ABC
 from enum import Enum
-from typing import Generator, Iterable, Optional, Type, TypeVar, Union
+from typing import Generator, Iterable, Optional, Type, TypeVar, Union, overload
 from warnings import warn
 
 import requests
@@ -853,6 +853,42 @@ class AssetClient:
             raise ErrorCode.MISSING_GLOSSARY_GUID.exception_with_parameters(asset_type)
         asset.anchor = AtlasGlossary.ref_by_guid(glossary_guid)
 
+    @overload
+    def update_certificate(
+        self,
+        asset_type: Type[A],
+        qualified_name: str,
+        name: str,
+        certificate_status: CertificateStatus,
+        message: Optional[str] = None,
+        glossary_guid: Optional[str] = None,
+    ) -> Optional[A]:
+        ...
+
+    @overload
+    def update_certificate(
+        self,
+        asset_type: Type[AtlasGlossaryTerm],
+        qualified_name: str,
+        name: str,
+        certificate_status: CertificateStatus,
+        message: Optional[str] = None,
+        glossary_guid: str = None,
+    ) -> Optional[AtlasGlossaryTerm]:
+        ...
+
+    @overload
+    def update_certificate(
+        self,
+        asset_type: Type[AtlasGlossaryCategory],
+        qualified_name: str,
+        name: str,
+        certificate_status: CertificateStatus,
+        message: Optional[str] = None,
+        glossary_guid: str = None,
+    ) -> Optional[AtlasGlossaryCategory]:
+        ...
+
     @validate_arguments()
     def update_certificate(
         self,
@@ -871,7 +907,8 @@ class AssetClient:
         :param name: the name of the asset on which to update the certificate
         :param certificate_status: specific certificate to set on the asset
         :param message: (optional) message to set (or None for no message)
-        :param glossary_guid: unique identifier of the glossary
+        :param glossary_guid: unique identifier of the glossary, required
+        only when the asset type is `AtlasGlossaryTerm` or `AtlasGlossaryCategory`
         :returns: the result of the update, or None if the update failed
         :raises AtlanError: on any API communication issue
         """
@@ -883,6 +920,36 @@ class AssetClient:
         if isinstance(asset, (AtlasGlossaryTerm, AtlasGlossaryCategory)):
             self._update_glossary_anchor(asset, glossary_guid, asset_type.__name__)
         return self._update_asset_by_attribute(asset, asset_type, qualified_name)
+
+    @overload
+    def remove_certificate(
+        self,
+        asset_type: Type[A],
+        qualified_name: str,
+        name: str,
+        glossary_guid: Optional[str] = None,
+    ) -> Optional[A]:
+        ...
+
+    @overload
+    def remove_certificate(
+        self,
+        asset_type: Type[AtlasGlossaryTerm],
+        qualified_name: str,
+        name: str,
+        glossary_guid: str,
+    ) -> Optional[AtlasGlossaryTerm]:
+        ...
+
+    @overload
+    def remove_certificate(
+        self,
+        asset_type: Type[AtlasGlossaryCategory],
+        qualified_name: str,
+        name: str,
+        glossary_guid: str,
+    ) -> Optional[AtlasGlossaryCategory]:
+        ...
 
     @validate_arguments()
     def remove_certificate(
@@ -898,7 +965,8 @@ class AssetClient:
         :param asset_type: type of asset from which to remove the certificate
         :param qualified_name: the qualified_name of the asset from which to remove the certificate
         :param name: the name of the asset from which to remove the certificate
-        :param glossary_guid: unique identifier of the glossary
+        :param glossary_guid: unique identifier of the glossary, required
+        only when the asset type is `AtlasGlossaryTerm` or `AtlasGlossaryCategory`
         :returns: the result of the removal, or None if the removal failed
         """
         asset = asset_type()
@@ -908,6 +976,39 @@ class AssetClient:
         if isinstance(asset, (AtlasGlossaryTerm, AtlasGlossaryCategory)):
             self._update_glossary_anchor(asset, glossary_guid, asset_type.__name__)
         return self._update_asset_by_attribute(asset, asset_type, qualified_name)
+
+    @overload
+    def update_announcement(
+        self,
+        asset_type: Type[A],
+        qualified_name: str,
+        name: str,
+        announcement: Announcement,
+        glossary_guid: Optional[str] = None,
+    ) -> Optional[A]:
+        ...
+
+    @overload
+    def update_announcement(
+        self,
+        asset_type: Type[AtlasGlossaryTerm],
+        qualified_name: str,
+        name: str,
+        announcement: Announcement,
+        glossary_guid: str,
+    ) -> Optional[AtlasGlossaryTerm]:
+        ...
+
+    @overload
+    def update_announcement(
+        self,
+        asset_type: Type[AtlasGlossaryCategory],
+        qualified_name: str,
+        name: str,
+        announcement: Announcement,
+        glossary_guid: str,
+    ) -> Optional[AtlasGlossaryCategory]:
+        ...
 
     @validate_arguments()
     def update_announcement(
@@ -925,7 +1026,8 @@ class AssetClient:
         :param qualified_name: the qualified_name of the asset on which to update the announcement
         :param name: the name of the asset on which to update the announcement
         :param announcement: to apply to the asset
-        :param glossary_guid: unique identifier of the glossary
+        :param glossary_guid: unique identifier of the glossary, required
+        only when the asset type is `AtlasGlossaryTerm` or `AtlasGlossaryCategory`
         :returns: the result of the update, or None if the update failed
         """
         asset = asset_type()
@@ -935,6 +1037,36 @@ class AssetClient:
         if isinstance(asset, (AtlasGlossaryTerm, AtlasGlossaryCategory)):
             self._update_glossary_anchor(asset, glossary_guid, asset_type.__name__)
         return self._update_asset_by_attribute(asset, asset_type, qualified_name)
+
+    @overload
+    def remove_announcement(
+        self,
+        asset_type: Type[A],
+        qualified_name: str,
+        name: str,
+        glossary_guid: Optional[str] = None,
+    ) -> Optional[A]:
+        ...
+
+    @overload
+    def remove_announcement(
+        self,
+        asset_type: Type[AtlasGlossaryTerm],
+        qualified_name: str,
+        name: str,
+        glossary_guid: str,
+    ) -> Optional[AtlasGlossaryTerm]:
+        ...
+
+    @overload
+    def remove_announcement(
+        self,
+        asset_type: Type[AtlasGlossaryCategory],
+        qualified_name: str,
+        name: str,
+        glossary_guid: str,
+    ) -> Optional[AtlasGlossaryCategory]:
+        ...
 
     @validate_arguments()
     def remove_announcement(
@@ -949,8 +1081,8 @@ class AssetClient:
 
         :param asset_type: type of asset from which to remove the announcement
         :param qualified_name: the qualified_name of the asset from which to remove the announcement
-        :param name: the name of the asset from which to remove the announcement
-        :param glossary_guid: unique identifier of the glossary
+        :param glossary_guid: unique identifier of the glossary, required
+        only when the asset type is `AtlasGlossaryTerm` or `AtlasGlossaryCategory`
         :returns: the result of the removal, or None if the removal failed
         """
         asset = asset_type()

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -472,9 +472,16 @@ class ErrorCode(Enum):
     )
     INVALID_CREDENTIALS = (
         400,
-        "ATLAN-PYTHON-400-043",
+        "ATLAN-PYTHON-400-054",
         "Credentials provided did not work: {0}.",
         "Please double-check your credentials and test them again.",
+        InvalidRequestError,
+    )
+    MISSING_GLOSSARY_GUID = (
+        400,
+        "ATLAN-PYTHON-400-055",
+        "'glossary_guid' keyword argument is missing for asset type: {0}",
+        "Please double-check your method keyword arguments.",
         InvalidRequestError,
     )
     AUTHENTICATION_PASSTHROUGH = (

--- a/tests/unit/test_credential_client.py
+++ b/tests/unit/test_credential_client.py
@@ -18,7 +18,7 @@ TEST_MISSING_TOKEN_ID = (
     "ATLAN-PYTHON-400-032 No ID was provided when attempting to update the API token."
 )
 TEST_INVALID_CREDENTIALS = (
-    "ATLAN-PYTHON-400-043 Credentials provided did not work: failed"
+    "ATLAN-PYTHON-400-054 Credentials provided did not work: failed"
 )
 TEST_INVALID_GUID_GET_VALIDATION_ERR = (
     "1 validation error for Get\nguid\n  str type expected (type=type_error.str)"

--- a/tests/unit/test_typedef_model.py
+++ b/tests/unit/test_typedef_model.py
@@ -274,7 +274,6 @@ def test_type_def_response(type_defs):
 class TestAttributeDef:
     @pytest.fixture()
     def sut(self) -> AttributeDef:
-
         with patch("pyatlan.model.typedef._get_all_qualified_names") as mock_get_qa:
             mock_get_qa.return_value = set()
             return AttributeDef.create(


### PR DESCRIPTION
**Note:** Initially, I attempted to implement this functionality using third-party packages, such as [multimethod](https://github.com/coady/multimethod), which offer method overloading. [Despite Python not natively supporting](https://stackoverflow.com/a/10202988) method overloading like some other languages, I encountered issues with type hints and significant code duplication. Therefore, I opted for achieving a similar outcome using default values and the `*args` and `**kwargs` syntax.
