### PR TITLE
DVX-130: Fixes setup of the `ADLSObject` asset

### DIFF
--- a/pyatlan/generator/templates/imports.jinja2
+++ b/pyatlan/generator/templates/imports.jinja2
@@ -100,4 +100,5 @@ from pyatlan.utils import (
     next_id,
     to_camel_case,
     validate_required_fields,
+    get_parent_qualified_name,
 )

--- a/pyatlan/generator/templates/methods/asset/a_d_l_s_object.jinja2
+++ b/pyatlan/generator/templates/methods/asset/a_d_l_s_object.jinja2
@@ -7,15 +7,12 @@
         *,
         name: str,
         adls_container_qualified_name: str,
-        adls_account_qualified_name: str,
     ) -> ADLSObject:
         validate_required_fields(
-            ["name", "adls_container_qualified_name", "adls_account_qualified_name"],
-            [name, adls_container_qualified_name, adls_account_qualified_name],
+            ["name", "adls_container_qualified_name"],
+            [name, adls_container_qualified_name],
         )
         attributes = ADLSObject.Attributes.create(
-            name=name,
-            adls_container_qualified_name=adls_container_qualified_name,
-            adls_account_qualified_name = adls_account_qualified_name
+            name=name, adls_container_qualified_name=adls_container_qualified_name
         )
         return cls(attributes=attributes)

--- a/pyatlan/generator/templates/methods/attribute/a_d_l_s_object.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/a_d_l_s_object.jinja2
@@ -3,19 +3,11 @@
         # @validate_arguments()
         @init_guid
         def create(
-            cls,
-            *,
-            name: str,
-            adls_container_qualified_name: str,
-            adls_account_qualified_name: str,
+            cls, *, name: str, adls_container_qualified_name: str
         ) -> ADLSObject.Attributes:
             validate_required_fields(
-                [
-                    "name",
-                    "adls_container_qualified_name",
-                    "adls_account_qualified_name",
-                ],
-                [name, adls_container_qualified_name, adls_account_qualified_name],
+                ["name", "adls_container_qualified_name"],
+                [name, adls_container_qualified_name],
             )
 
             # Split the qualified_name to extract necessary information
@@ -27,6 +19,9 @@
                 connector_type = AtlanConnectorType(fields[1])  # type:ignore
             except ValueError as e:
                 raise ValueError("Invalid qualified_name") from e
+            adls_account_qualified_name = get_parent_qualified_name(
+                adls_container_qualified_name
+            )
 
             return ADLSObject.Attributes(
                 name=name,

--- a/pyatlan/model/assets/asset61.py
+++ b/pyatlan/model/assets/asset61.py
@@ -31,7 +31,7 @@ from pyatlan.model.fields.atlan_fields import (
     RelationField,
     TextField,
 )
-from pyatlan.utils import init_guid, validate_required_fields
+from pyatlan.utils import get_parent_qualified_name, init_guid, validate_required_fields
 
 from .asset35 import ADLS
 
@@ -631,16 +631,13 @@ class ADLSObject(ADLS):
         *,
         name: str,
         adls_container_qualified_name: str,
-        adls_account_qualified_name: str,
     ) -> ADLSObject:
         validate_required_fields(
-            ["name", "adls_container_qualified_name", "adls_account_qualified_name"],
-            [name, adls_container_qualified_name, adls_account_qualified_name],
+            ["name", "adls_container_qualified_name"],
+            [name, adls_container_qualified_name],
         )
         attributes = ADLSObject.Attributes.create(
-            name=name,
-            adls_container_qualified_name=adls_container_qualified_name,
-            adls_account_qualified_name=adls_account_qualified_name,
+            name=name, adls_container_qualified_name=adls_container_qualified_name
         )
         return cls(attributes=attributes)
 
@@ -1101,19 +1098,11 @@ class ADLSObject(ADLS):
         # @validate_arguments()
         @init_guid
         def create(
-            cls,
-            *,
-            name: str,
-            adls_container_qualified_name: str,
-            adls_account_qualified_name: str,
+            cls, *, name: str, adls_container_qualified_name: str
         ) -> ADLSObject.Attributes:
             validate_required_fields(
-                [
-                    "name",
-                    "adls_container_qualified_name",
-                    "adls_account_qualified_name",
-                ],
-                [name, adls_container_qualified_name, adls_account_qualified_name],
+                ["name", "adls_container_qualified_name"],
+                [name, adls_container_qualified_name],
             )
 
             # Split the qualified_name to extract necessary information
@@ -1125,6 +1114,9 @@ class ADLSObject(ADLS):
                 connector_type = AtlanConnectorType(fields[1])  # type:ignore
             except ValueError as e:
                 raise ValueError("Invalid qualified_name") from e
+            adls_account_qualified_name = get_parent_qualified_name(
+                adls_container_qualified_name
+            )
 
             return ADLSObject.Attributes(
                 name=name,

--- a/pyatlan/utils.py
+++ b/pyatlan/utils.py
@@ -48,6 +48,15 @@ def next_id() -> str:
     return f"-{s_nextId}"
 
 
+def get_parent_qualified_name(qualified_name: str) -> str:
+    """
+    Returns qualified name of the parent asset
+    :param qualified_name: qualified of the asset
+    """
+    qn = qualified_name.split("/")
+    return "/".join(qn[:-1])
+
+
 def list_attributes_to_params(
     attributes_list: list, query_params: Optional[dict] = None
 ) -> dict:

--- a/tests/integration/adls_asset_test.py
+++ b/tests/integration/adls_asset_test.py
@@ -12,6 +12,7 @@ from pyatlan.model.enums import (
     EntityStatus,
 )
 from pyatlan.model.response import AssetMutationResponse
+from pyatlan.utils import get_parent_qualified_name
 from tests.integration.client import TestId, delete_asset
 from tests.integration.connection_test import create_connection
 from tests.integration.utils import block
@@ -98,13 +99,12 @@ def test_adls_container(
 
 @pytest.fixture(scope="module")
 def adls_object(
-    client: AtlanClient, adls_container: ADLSContainer, adls_account: ADLSAccount
+    client: AtlanClient, adls_container: ADLSContainer
 ) -> Generator[ADLSObject, None, None]:
     assert adls_container.qualified_name
     to_create = ADLSObject.create(
         name=OBJECT_NAME,
         adls_container_qualified_name=adls_container.qualified_name,
-        adls_account_qualified_name=adls_account.qualified_name,
     )
     response = client.asset.save(to_create)
     result = response.assets_created(asset_type=ADLSObject)[0]
@@ -123,6 +123,10 @@ def test_adls_object(
     assert adls_object.adls_container_qualified_name == adls_container.qualified_name
     assert adls_object.name == OBJECT_NAME
     assert adls_object.connector_name == AtlanConnectorType.ADLS.value
+    assert adls_container.qualified_name
+    assert adls_object.adls_account_qualified_name == get_parent_qualified_name(
+        adls_container.qualified_name
+    )
 
 
 def test_update_adls_object(

--- a/tests/unit/model/a_d_l_s_object_test.py
+++ b/tests/unit/model/a_d_l_s_object_test.py
@@ -1,8 +1,8 @@
 import pytest
 
 from pyatlan.model.assets import ADLSObject
+from pyatlan.utils import get_parent_qualified_name
 from tests.unit.model.constants import (
-    ADLS_ACCOUNT_QUALIFIED_NAME,
     ADLS_CONNECTION_QUALIFIED_NAME,
     ADLS_CONNECTOR_TYPE,
     ADLS_CONTAINER_QUALIFIED_NAME,
@@ -13,34 +13,21 @@ from tests.unit.model.constants import (
 
 # Test cases for missing parameters
 @pytest.mark.parametrize(
-    "name, adls_container_qualified_name, adls_account_qualified_name, message",
+    "name, adls_container_qualified_name, message",
     [
-        (None, "adls/container", "adls_account_qualified_name", "name is required"),
-        (
-            ADLS_OBJECT_NAME,
-            None,
-            ADLS_ACCOUNT_QUALIFIED_NAME,
-            "adls_container_qualified_name is required",
-        ),
-        (
-            ADLS_OBJECT_NAME,
-            ADLS_CONTAINER_QUALIFIED_NAME,
-            None,
-            "adls_account_qualified_name is required",
-        ),
+        (None, "adls/container", "name is required"),
+        (ADLS_OBJECT_NAME, None, "adls_container_qualified_name is required"),
     ],
 )
 def test_create_with_missing_parameters_raise_value_error(
     name: str,
     adls_container_qualified_name: str,
-    adls_account_qualified_name: str,
     message: str,
 ):
     with pytest.raises(ValueError, match=message):
         ADLSObject.create(
             name=name,
             adls_container_qualified_name=adls_container_qualified_name,
-            adls_account_qualified_name=adls_account_qualified_name,
         )
 
 
@@ -49,7 +36,6 @@ def test_create():
     sut = ADLSObject.create(
         name=ADLS_OBJECT_NAME,
         adls_container_qualified_name=ADLS_CONTAINER_QUALIFIED_NAME,
-        adls_account_qualified_name=ADLS_ACCOUNT_QUALIFIED_NAME,
     )
 
     assert sut.name == ADLS_OBJECT_NAME
@@ -57,7 +43,9 @@ def test_create():
     assert sut.qualified_name == f"{ADLS_CONTAINER_QUALIFIED_NAME}/{ADLS_OBJECT_NAME}"
     assert sut.connection_qualified_name == ADLS_CONNECTION_QUALIFIED_NAME
     assert sut.connector_name == ADLS_CONNECTOR_TYPE
-    assert sut.adls_account_qualified_name == ADLS_ACCOUNT_QUALIFIED_NAME
+    assert sut.adls_account_qualified_name == get_parent_qualified_name(
+        ADLS_CONTAINER_QUALIFIED_NAME
+    )
 
 
 # Test cases for creating ADLSObject for modification


### PR DESCRIPTION
I believe we can extract the `ADLS account` qualified name directly from `adls_container_qualified_name` within the `create()` method, following a similar approach to what we're doing in the [Java SDK](https://github.com/atlanhq/atlan-java/blob/0be79dd4061a9573845ce5b637e8e93939a13088/sdk/src/main/java/com/atlan/model/assets/ADLSObject.java#L500).
