### PR TITLE
DVX-181: Adds QA checks (black, flake8, mypy) to the CI

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,17 +20,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      - name: Lint with flake8
+
+      - name: QA checks (black, flake8, mypy)
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          ./qa-checks
+
       - name: Test with pytest
         env: # Or as an environment variable
           ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}

--- a/qa-checks
+++ b/qa-checks
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+perform_check() {
+    local tool_name="$1"
+    local cmd="$2"
+    local suggestion="$3"
+
+    OUTPUT=$($cmd 2>&1)
+    if [ $? -eq 0 ]; then
+        echo "$tool_name ✅"
+    else
+        echo -e "$tool_name ❌ \nsuggestion: run - $suggestion\n"
+        FAILURE=1
+    fi
+    echo "$OUTPUT"
+}
+
+# Formatter
+black-check() {
+    perform_check "black" "black --check --quiet ." "black ."
+}
+
+# Linter
+flake8-check() {
+    perform_check "flake8" "flake8" "flake8 ."
+}
+
+# Static type checker
+mypy-check() {
+    perform_check "mypy" "mypy pyatlan tests" "mypy pyatlan tests"
+}
+
+black-check
+flake8-check
+mypy-check
+exit $FAILURE

--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,8 @@ per-file-ignores =
     tests/*:S101
     pyatlan/model/assets.py:S307
 exclude =
+    env
+    venv
+    __pycache__
     pyatlan/model/assets/__init__.py
     pyatlan/model/structs/__init__.py


### PR DESCRIPTION
**Sample QA checks outputs:**

- Failure: https://github.com/atlanhq/atlan-python/actions/runs/7583173483/job/20654254675?pr=224#step:5:1
- Success: https://github.com/atlanhq/atlan-python/actions/runs/7583235841/job/20654435937?pr=224#step:5:1