### PR TITLE
Fixes parallel testing concurrency

### DIFF
--- a/.github/workflows/pyatlan-pr.yaml
+++ b/.github/workflows/pyatlan-pr.yaml
@@ -51,6 +51,9 @@ jobs:
       fail-fast: false
       matrix:
         test_file: ${{fromJson(needs.qa-checks-and-unit-tests.outputs.files)}}
+    concurrency:
+      group: ${{ matrix.test_file }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Added [`concurrency`](https://docs.github.com/en/actions/using-jobs/using-concurrency) to the parallel integration tests. It will put workflow jobs in a waiting state if a similar integration test is already running in a workflow.

<img width="1251" alt="Screenshot 2024-01-24 at 8 05 20 PM" src="https://github.com/atlanhq/atlan-python/assets/56113566/05fc4368-bd98-47ff-bc96-3e617d18c15b">
