### PR TITLE
DVX-272: Enhance pyatlan tests report experience

### DIFF
--- a/.github/workflows/pyatlan-pr.yaml
+++ b/.github/workflows/pyatlan-pr.yaml
@@ -38,7 +38,8 @@ jobs:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           MARK_API_KEY: ${{ secrets.MARK_ATLAN_API_KEY }}
           MARK_BASE_URL: https://mark.atlan.com
-        run: pytest tests/unit
+        # Run with `pytest-sugar` for enhancing the overall test report output
+        run: pytest tests/unit --force-sugar
 
       - name: Prepare integration tests distribution
         id: distribute-integration-test-files
@@ -80,5 +81,5 @@ jobs:
           MARK_API_KEY: ${{ secrets.MARK_ATLAN_API_KEY }}
           MARK_BASE_URL: https://mark.atlan.com
         # Run the integration test file using `pytest-timer` plugin
-        # to display only the durations of the 10 slowest tests
-        run: pytest ${{ matrix.test_file }} -p name_of_plugin --timer-top-n 10
+        # to display only the durations of the 10 slowest tests with `pytest-sugar`
+        run: pytest ${{ matrix.test_file }} -p name_of_plugin --timer-top-n 10 --force-sugar

--- a/.github/workflows/pyatlan-pr.yaml
+++ b/.github/workflows/pyatlan-pr.yaml
@@ -79,4 +79,6 @@ jobs:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           MARK_API_KEY: ${{ secrets.MARK_ATLAN_API_KEY }}
           MARK_BASE_URL: https://mark.atlan.com
-        run: pytest ${{ matrix.test_file }}
+        # Run the integration test file using `pytest-timer` plugin
+        # to display only the durations of the 10 slowest tests
+        run: pytest ${{ matrix.test_file }} -p name_of_plugin --timer-top-n 10

--- a/.github/workflows/pyatlan-test-cron.yaml
+++ b/.github/workflows/pyatlan-test-cron.yaml
@@ -37,7 +37,7 @@ jobs:
           MARK_API_KEY: ${{ secrets.MARK_ATLAN_API_KEY }}
           MARK_BASE_URL: https://mark.atlan.com
         # Run the integration test suite using the `pytest-timer` plugin
-        # to display only the durations of the 25 slowest tests
+        # to display only the durations of the 25 slowest tests with `pytest-sugar`
         run: |
-          pytest tests/unit
-          pytest tests/integration --ignore tests/integration/data_mesh_test.py -p name_of_plugin --timer-top-n 25
+          pytest tests/unit --force-sugar
+          pytest tests/integration --ignore tests/integration/data_mesh_test.py -p name_of_plugin --timer-top-n 25 --force-sugar

--- a/.github/workflows/pyatlan-test-cron.yaml
+++ b/.github/workflows/pyatlan-test-cron.yaml
@@ -36,6 +36,8 @@ jobs:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           MARK_API_KEY: ${{ secrets.MARK_ATLAN_API_KEY }}
           MARK_BASE_URL: https://mark.atlan.com
+        # Run the integration test suite using the `pytest-timer` plugin
+        # to display only the durations of the 25 slowest tests
         run: |
           pytest tests/unit
-          pytest tests/integration --ignore tests/integration/data_mesh_test.py
+          pytest tests/integration --ignore tests/integration/data_mesh_test.py -p name_of_plugin --timer-top-n 25

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@ black==23.7.0
 types-requests==2.31.0.2
 pytest==7.4.0
 pytest-order==1.1.0
+pytest-timer[termcolor]==1.0.0
+pytest-sugar==1.0.0
 retry==0.9.2
 pre-commit==2.20.0
 deepdiff==6.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,11 @@ exclude =
     __pycache__
     pyatlan/model/assets/__init__.py
     pyatlan/model/structs/__init__.py
+
+[pytest]
+; Here `name_of_plugin` is refers to the pytest-timer
+; https://github.com/skudriashev/pytest-timer/blob/a1995d6bb7a6d3f02edbec90622d928a50db95e1/setup.py#L26C50-L26C62
+addopts=-p no:name_of_plugin
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore:urllib3 v2 only supports OpenSSL 1.1.1+


### PR DESCRIPTION
- Integrate the [pytest-sugar ](https://github.com/Teemu/pytest-sugar)plugin, which enhances pytest functionality by instantly showing failures and errors, adding a progress bar, improving test results, and enhancing the overall output appearance.

- Utilize the [pytest-timer](https://github.com/skudriashev/pytest-timer) plugin to display the durations of the 'n' slowest tests. This feature can be **DISABLED** by default and can be used in our CI.

Adjust pytest configuration settings to ignore `DeprecationWarning` messages, improving test report clarity.


<img width="900" alt="Screenshot 2024-02-23 at 6 19 21 PM" src="https://github.com/atlanhq/atlan-python/assets/56113566/3c13610b-28ca-4608-9595-36b8f3924cd7">

### Examples:

**Before:**
- Failure: https://github.com/atlanhq/atlan-python/actions/runs/8001762037/job/21853667577#step:5:108
- Pass: https://github.com/atlanhq/atlan-python/actions/runs/8009305871/job/21877738515?pr=251#step:5:36

**After:**
- Failure: https://github.com/atlanhq/atlan-python/actions/runs/8019685766/job/21908051027?pr=252#step:5:118
- Pass: https://github.com/atlanhq/atlan-python/actions/runs/8019685766/job/21908270583?pr=252#step:5:36
