### PR TITLE
Adding AWS IoT connectors

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -254,6 +254,8 @@ class AtlanConnectorType(str, Enum):
     GENERIC = ("genericdb", AtlanConnectionCategory.DATABASE)
     FILE = ("file", AtlanConnectionCategory.OBJECT_STORE)
     MICROSTRATEGY = ("microstrategy", AtlanConnectionCategory.BI)
+    AWS_SITEWISE = ("aws-sitewise", AtlanConnectionCategory.DATABASE)
+    AWS_GREENGRASS = ("aws-greengrass", AtlanConnectionCategory.DATABASE)
 
 
 class AtlanCustomAttributePrimitiveType(str, Enum):

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -254,7 +254,7 @@ class AtlanConnectorType(str, Enum):
     GENERIC = ("genericdb", AtlanConnectionCategory.DATABASE)
     FILE = ("file", AtlanConnectionCategory.OBJECT_STORE)
     MICROSTRATEGY = ("microstrategy", AtlanConnectionCategory.BI)
-    AWS_SITEWISE = ("aws-sitewise", AtlanConnectionCategory.DATABASE)
+    AWS_SITE_WISE = ("aws-sitewise", AtlanConnectionCategory.DATABASE)
     AWS_GREENGRASS = ("aws-greengrass", AtlanConnectionCategory.DATABASE)
 
 


### PR DESCRIPTION
Customer IFF is looking to ingest their factory IoT metadata as relational catalogs on Atlan. Changes are for integrating the connectors involved.