### PR TITLE
Fix DVX-352 Attempting to retrieve an MC Monitor asset by GUID is failing in field-sandbox

### DIFF
--- a/pyatlan/utils.py
+++ b/pyatlan/utils.py
@@ -352,11 +352,15 @@ def move_struct(data):
     }
     for struct_name in struct_names:
         if (a := data.get("attributes", None)) and (s := a.get(struct_name, None)):
-            records = [
-                record if "attributes" not in record else record["attributes"]
-                for record in s
-            ]
-            a[struct_name] = records
+            if isinstance(s, list):
+                records = [
+                    record if "attributes" not in record else record["attributes"]
+                    for record in s
+                ]
+                a[struct_name] = records
+            elif isinstance(s, dict):
+                if "attributes" in s:
+                    a[struct_name] = s["attributes"]
 
 
 class AuthorizationFilter(logging.Filter):


### PR DESCRIPTION
The problem was the code used to flatten structs was assuming the value in attributes for the struct_name always contained a list and `mcMonitorRuleScheduleConfig` contain a dict with the typeName and attributes.