### PR TITLE
 DVX-366: Add support for `restrict_propagation_through_hierarchy` in the `AtlanTag`

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -742,7 +742,7 @@ class AssetClient:
         propagate: bool = True,
         remove_propagation_on_delete: bool = True,
         restrict_lineage_propagation: bool = True,
-        propagation_only_through_lineage: bool = False,
+        restrict_propagation_through_hierarchy: bool = False,
     ) -> None:
         atlan_tags = AtlanTags(
             __root__=[
@@ -751,7 +751,7 @@ class AssetClient:
                     propagate=propagate,
                     remove_propagations_on_entity_delete=remove_propagation_on_delete,
                     restrict_propagation_through_lineage=restrict_lineage_propagation,
-                    propagation_only_through_lineage=propagation_only_through_lineage,
+                    restrict_propagation_through_hierarchy=restrict_propagation_through_hierarchy,
                 )
                 for name in atlan_tag_names
             ]
@@ -772,7 +772,7 @@ class AssetClient:
         propagate: bool = True,
         remove_propagation_on_delete: bool = True,
         restrict_lineage_propagation: bool = True,
-        propagation_only_through_lineage: bool = False,
+        restrict_propagation_through_hierarchy: bool = False,
     ) -> None:
         """
         Add one or more Atlan tags to the provided asset.
@@ -787,8 +787,8 @@ class AssetClient:
         when the Atlan tag is removed from this asset (True) or not (False)
         :param restrict_lineage_propagation: whether to avoid propagating
         through lineage (True) or do propagate through lineage (False)
-        :param propagation_only_through_lineage: if specified as `True`,
-        propagation will only occur downstream lineage and not within hierarchy, defaults to `False`.
+        :param restrict_propagation_through_hierarchy: whether to prevent this Atlan tag from
+        propagating through hierarchy (True) or allow it to propagate through hierarchy (False)
         :raises AtlanError: on any API communication issue
         """
         self._modify_tags(
@@ -799,7 +799,7 @@ class AssetClient:
             propagate,
             remove_propagation_on_delete,
             restrict_lineage_propagation,
-            propagation_only_through_lineage,
+            restrict_propagation_through_hierarchy,
         )
 
     @validate_arguments
@@ -811,7 +811,7 @@ class AssetClient:
         propagate: bool = True,
         remove_propagation_on_delete: bool = True,
         restrict_lineage_propagation: bool = True,
-        propagation_only_through_lineage: bool = False,
+        restrict_propagation_through_hierarchy: bool = False,
     ) -> None:
         """
         Update one or more Atlan tags to the provided asset.
@@ -826,8 +826,8 @@ class AssetClient:
         when the Atlan tag is removed from this asset (True) or not (False)
         :param restrict_lineage_propagation: whether to avoid propagating
         through lineage (True) or do propagate through lineage (False)
-        :param propagation_only_through_lineage: if specified as `True`,
-        propagation will only occur downstream lineage and not within hierarchy, defaults to `False`.
+        :param restrict_propagation_through_hierarchy: whether to prevent this Atlan tag from
+        propagating through hierarchy (True) or allow it to propagate through hierarchy (False)
         :raises AtlanError: on any API communication issue
         """
         self._modify_tags(
@@ -838,7 +838,7 @@ class AssetClient:
             propagate,
             remove_propagation_on_delete,
             restrict_lineage_propagation,
-            propagation_only_through_lineage,
+            restrict_propagation_through_hierarchy,
         )
 
     @validate_arguments

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -971,7 +971,7 @@ class AtlanClient(BaseSettings):
         propagate: bool = True,
         remove_propagation_on_delete: bool = True,
         restrict_lineage_propagation: bool = True,
-        propagation_only_through_lineage: bool = False,
+        restrict_propagation_through_hierarchy: bool = False,
     ) -> None:
         """Deprecated - use asset.add_atlan_tags() instead."""
         warn(
@@ -987,7 +987,7 @@ class AtlanClient(BaseSettings):
             propagate=propagate,
             remove_propagation_on_delete=remove_propagation_on_delete,
             restrict_lineage_propagation=restrict_lineage_propagation,
-            propagation_only_through_lineage=propagation_only_through_lineage,
+            restrict_propagation_through_hierarchy=restrict_propagation_through_hierarchy,
         )
 
     @validate_arguments

--- a/pyatlan/model/core.py
+++ b/pyatlan/model/core.py
@@ -174,19 +174,11 @@ class AtlanTag(AtlanObject):
     restrict_propagation_through_lineage: Optional[bool] = Field(
         default=None, description="", alias="restrictPropagationThroughLineage"
     )
-    propagation_only_through_lineage: Optional[bool] = Field(
-        default=None,
-        description=(
-            "If specified as `True`, propagation will only "
-            "occur downstream lineage and not within hierarchy."
-        ),
-        alias="propagationOnlyThroughLineage",
-    )
-    restrict_propagation_through_hierachy: Optional[bool] = Field(
+    restrict_propagation_through_hierarchy: Optional[bool] = Field(
         default=None,
         description=(
             "Whether to prevent this Atlan tag from propagating through "
-            "hierachy (True) or allow it to propagate through hierachy (False)"
+            "hierarchy (True) or allow it to propagate through hierarchy (False)"
         ),
         alias="restrictPropagationThroughHierachy",
     )

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -473,7 +473,7 @@ def test_get_user_by_username(mock_type_def_client, client: AtlanClient):
                 "propagate": False,
                 "remove_propagation_on_delete": False,
                 "restrict_lineage_propagation": False,
-                "propagation_only_through_lineage": False,
+                "restrict_propagation_through_hierarchy": False,
             },
         ),
         (


### PR DESCRIPTION
- We previously assumed lineage-only propagation was added using `propagation_only_through_lineage`, but it's actually released with `restrict_propagation_through_hierarchy`.

- More info: https://atlanhq.atlassian.net/browse/PLT-1092