### PR TITLE
Fixes field alias typo for `restrict_propagation_through_hierarchy` in the `AtlanTag` model.

### DIFF
--- a/pyatlan/model/core.py
+++ b/pyatlan/model/core.py
@@ -180,7 +180,7 @@ class AtlanTag(AtlanObject):
             "Whether to prevent this Atlan tag from propagating through "
             "hierarchy (True) or allow it to propagate through hierarchy (False)"
         ),
-        alias="restrictPropagationThroughHierachy",
+        alias="restrictPropagationThroughHierarchy",
     )
     validity_periods: Optional[List[str]] = Field(default=None, alias="validityPeriods")
     _source_tag_attachements: List[SourceTagAttachment] = PrivateAttr(


### PR DESCRIPTION
~Also updated the parameter name in tag methods from `restrict_propagation_through_hierarchy` to `restrict_hierarchy_propagation` for consistency with other parameters.~