### PR TITLE
DVX-362: Adds `AssetFilter` enum

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -85,6 +85,15 @@ class AssetSidebarTab(str, Enum):
     SODA = "Soda"
 
 
+class AssetFilter(str, Enum):
+    TERMS = "terms"
+    OWNERS = "owners"
+    USAGE = "usage"
+    TAGS = "__traitNames"
+    PROPERTIES = "properties"
+    CERTIFICATE = "certificateStatus"
+
+
 class AtlanComparisonOperator(str, Enum):
     LT = "<"
     GT = ">"


### PR DESCRIPTION
```py
from pyatlan.client.atlan import AtlanClient
from pyatlan.model.assets import Persona
from pyatlan.model.enums import AssetSidebarTab, AssetFilter

client = AtlanClient()

to_update = Persona.create_for_modification(
    "default/Ng5X6AXv8Tcz2eyKkS3bIh", "Test-Persona", True
)

to_update.deny_asset_tabs = {
    AssetSidebarTab.LINEAGE.value,
    AssetSidebarTab.RELATIONS.value,
    AssetSidebarTab.QUERIES.value,
}
to_update.deny_asset_types = {"Table", "Column"}

to_update.deny_asset_filters = {
    AssetFilter.OWNERS.value,
    AssetFilter.TAGS.value,
    AssetFilter.CERTIFICATE.value,
}

to_update.deny_custom_metadata_guids = {
    "59220d25-5d39-4f3a-8de5-072098bee793",
    "bb0c9836-94fd-4a54-9007-0f25fb802c2c",
}
response = client.asset.save(to_update)

print(response)
```