### PR TITLE
DVX-379: Fixes logic for removing parent category relationship in `AtlasGlossaryCategory`

### DIFF
--- a/pyatlan/generator/templates/macros.jinja2
+++ b/pyatlan/generator/templates/macros.jinja2
@@ -17,6 +17,10 @@
     def {{ property_name }}(self, {{ property_name }}:{{ property_type }}):
         if self.attributes is None:
             self.attributes = self.Attributes()
+        {% if property_name == "parent_category" -%}
+        if not parent_category:
+            self.relationship_attributes = {"parentCategory": None}
+        {% endif -%}
         self.attributes.{{ attribute_name }} = {{ property_name }}
 
     {%- endfor %}

--- a/pyatlan/model/assets/atlas_glossary_category.py
+++ b/pyatlan/model/assets/atlas_glossary_category.py
@@ -253,6 +253,8 @@ class AtlasGlossaryCategory(Asset, type_name="AtlasGlossaryCategory"):
     def parent_category(self, parent_category: Optional[AtlasGlossaryCategory]):
         if self.attributes is None:
             self.attributes = self.Attributes()
+        if not parent_category:
+            self.relationship_attributes = {"parentCategory": None}
         self.attributes.parent_category = parent_category
 
     @property

--- a/pyatlan/model/assets/data_product.py
+++ b/pyatlan/model/assets/data_product.py
@@ -126,8 +126,18 @@ class DataProduct(DataMesh):
     """
     Status of this data product.
     """
+    DAAP_STATUS: ClassVar[KeywordField] = KeywordField("daapStatus", "daapStatus")
+    """
+    Status of this data product.
+    """
     DATA_PRODUCT_CRITICALITY: ClassVar[KeywordField] = KeywordField(
         "dataProductCriticality", "dataProductCriticality"
+    )
+    """
+    Criticality of this data product.
+    """
+    DAAP_CRITICALITY: ClassVar[KeywordField] = KeywordField(
+        "daapCriticality", "daapCriticality"
     )
     """
     Criticality of this data product.
@@ -138,8 +148,20 @@ class DataProduct(DataMesh):
     """
     Information sensitivity of this data product.
     """
+    DAAP_SENSITIVITY: ClassVar[KeywordField] = KeywordField(
+        "daapSensitivity", "daapSensitivity"
+    )
+    """
+    Information sensitivity of this data product.
+    """
     DATA_PRODUCT_VISIBILITY: ClassVar[KeywordField] = KeywordField(
         "dataProductVisibility", "dataProductVisibility"
+    )
+    """
+    Visibility of a data product.
+    """
+    DAAP_VISIBILITY: ClassVar[KeywordField] = KeywordField(
+        "daapVisibility", "daapVisibility"
     )
     """
     Visibility of a data product.
@@ -184,9 +206,13 @@ class DataProduct(DataMesh):
 
     _convenience_properties: ClassVar[List[str]] = [
         "data_product_status",
+        "daap_status",
         "data_product_criticality",
+        "daap_criticality",
         "data_product_sensitivity",
+        "daap_sensitivity",
         "data_product_visibility",
+        "daap_visibility",
         "data_product_assets_d_s_l",
         "data_product_assets_playbook_filter",
         "data_product_score_value",
@@ -207,6 +233,16 @@ class DataProduct(DataMesh):
         self.attributes.data_product_status = data_product_status
 
     @property
+    def daap_status(self) -> Optional[DataProductStatus]:
+        return None if self.attributes is None else self.attributes.daap_status
+
+    @daap_status.setter
+    def daap_status(self, daap_status: Optional[DataProductStatus]):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.daap_status = daap_status
+
+    @property
     def data_product_criticality(self) -> Optional[DataProductCriticality]:
         return (
             None
@@ -221,6 +257,16 @@ class DataProduct(DataMesh):
         if self.attributes is None:
             self.attributes = self.Attributes()
         self.attributes.data_product_criticality = data_product_criticality
+
+    @property
+    def daap_criticality(self) -> Optional[DataProductCriticality]:
+        return None if self.attributes is None else self.attributes.daap_criticality
+
+    @daap_criticality.setter
+    def daap_criticality(self, daap_criticality: Optional[DataProductCriticality]):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.daap_criticality = daap_criticality
 
     @property
     def data_product_sensitivity(self) -> Optional[DataProductSensitivity]:
@@ -239,6 +285,16 @@ class DataProduct(DataMesh):
         self.attributes.data_product_sensitivity = data_product_sensitivity
 
     @property
+    def daap_sensitivity(self) -> Optional[DataProductSensitivity]:
+        return None if self.attributes is None else self.attributes.daap_sensitivity
+
+    @daap_sensitivity.setter
+    def daap_sensitivity(self, daap_sensitivity: Optional[DataProductSensitivity]):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.daap_sensitivity = daap_sensitivity
+
+    @property
     def data_product_visibility(self) -> Optional[DataProductVisibility]:
         return (
             None if self.attributes is None else self.attributes.data_product_visibility
@@ -251,6 +307,16 @@ class DataProduct(DataMesh):
         if self.attributes is None:
             self.attributes = self.Attributes()
         self.attributes.data_product_visibility = data_product_visibility
+
+    @property
+    def daap_visibility(self) -> Optional[DataProductVisibility]:
+        return None if self.attributes is None else self.attributes.daap_visibility
+
+    @daap_visibility.setter
+    def daap_visibility(self, daap_visibility: Optional[DataProductVisibility]):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.daap_visibility = daap_visibility
 
     @property
     def data_product_assets_d_s_l(self) -> Optional[str]:
@@ -348,13 +414,23 @@ class DataProduct(DataMesh):
         data_product_status: Optional[DataProductStatus] = Field(
             default=None, description=""
         )
+        daap_status: Optional[DataProductStatus] = Field(default=None, description="")
         data_product_criticality: Optional[DataProductCriticality] = Field(
+            default=None, description=""
+        )
+        daap_criticality: Optional[DataProductCriticality] = Field(
             default=None, description=""
         )
         data_product_sensitivity: Optional[DataProductSensitivity] = Field(
             default=None, description=""
         )
+        daap_sensitivity: Optional[DataProductSensitivity] = Field(
+            default=None, description=""
+        )
         data_product_visibility: Optional[DataProductVisibility] = Field(
+            default=None, description=""
+        )
+        daap_visibility: Optional[DataProductVisibility] = Field(
             default=None, description=""
         )
         data_product_assets_d_s_l: Optional[str] = Field(default=None, description="")

--- a/pyatlan/model/assets/looker_project.py
+++ b/pyatlan/model/assets/looker_project.py
@@ -37,6 +37,18 @@ class LookerProject(Looker):
     """
     TBC
     """
+    LOOKER_PARENT_PROJECTS: ClassVar[RelationField] = RelationField(
+        "lookerParentProjects"
+    )
+    """
+    TBC
+    """
+    LOOKER_CHILD_PROJECTS: ClassVar[RelationField] = RelationField(
+        "lookerChildProjects"
+    )
+    """
+    TBC
+    """
     FIELDS: ClassVar[RelationField] = RelationField("fields")
     """
     TBC
@@ -49,6 +61,8 @@ class LookerProject(Looker):
     _convenience_properties: ClassVar[List[str]] = [
         "models",
         "explores",
+        "looker_parent_projects",
+        "looker_child_projects",
         "fields",
         "views",
     ]
@@ -72,6 +86,34 @@ class LookerProject(Looker):
         if self.attributes is None:
             self.attributes = self.Attributes()
         self.attributes.explores = explores
+
+    @property
+    def looker_parent_projects(self) -> Optional[List[LookerProject]]:
+        return (
+            None if self.attributes is None else self.attributes.looker_parent_projects
+        )
+
+    @looker_parent_projects.setter
+    def looker_parent_projects(
+        self, looker_parent_projects: Optional[List[LookerProject]]
+    ):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.looker_parent_projects = looker_parent_projects
+
+    @property
+    def looker_child_projects(self) -> Optional[List[LookerProject]]:
+        return (
+            None if self.attributes is None else self.attributes.looker_child_projects
+        )
+
+    @looker_child_projects.setter
+    def looker_child_projects(
+        self, looker_child_projects: Optional[List[LookerProject]]
+    ):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.looker_child_projects = looker_child_projects
 
     @property
     def fields(self) -> Optional[List[LookerField]]:
@@ -98,6 +140,12 @@ class LookerProject(Looker):
             default=None, description=""
         )  # relationship
         explores: Optional[List[LookerExplore]] = Field(
+            default=None, description=""
+        )  # relationship
+        looker_parent_projects: Optional[List[LookerProject]] = Field(
+            default=None, description=""
+        )  # relationship
+        looker_child_projects: Optional[List[LookerProject]] = Field(
             default=None, description=""
         )  # relationship
         fields: Optional[List[LookerField]] = Field(

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -85,7 +85,7 @@ class AssetSidebarTab(str, Enum):
     SODA = "Soda"
 
 
-class AssetFilter(str, Enum):
+class AssetFilterGroup(str, Enum):
     TERMS = "terms"
     OWNERS = "owners"
     USAGE = "usage"

--- a/tests/unit/model/glossary_category_test.py
+++ b/tests/unit/model/glossary_category_test.py
@@ -99,6 +99,23 @@ def test_create_for_modification():
     assert sut.anchor.guid == GLOSSARY_GUID
 
 
+def test_update_when_parent_category_is_removed():
+    category = AtlasGlossaryCategory.updater(
+        qualified_name=GLOSSARY_CATEGORY_QUALIFIED_NAME,
+        name=GLOSSARY_CATEGORY_NAME,
+        glossary_guid=GLOSSARY_GUID,
+    )
+    assert category.parent_category is None
+    assert category.relationship_attributes is None
+    assert category.anchor.guid == GLOSSARY_GUID
+    assert category.name == GLOSSARY_CATEGORY_NAME
+    assert category.qualified_name == GLOSSARY_CATEGORY_QUALIFIED_NAME
+
+    category.parent_category = None
+    assert category.parent_category is None
+    assert category.relationship_attributes == {"parentCategory": None}
+
+
 def test_trim_to_required():
     sut = AtlasGlossaryCategory.create_for_modification(
         qualified_name=GLOSSARY_CATEGORY_QUALIFIED_NAME,


### PR DESCRIPTION
 - Retrieved latest `DataProduct` model changes.
 - Renamed enum `AssetFilter` -> `AssetFilterGroup`.