### PR TITLE
Allow newer versions of networkx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.24
 pydantic~=2.6.1
 jinja2==3.1.3
-networkx==3.1
+networkx>=3.1
 tenacity==8.2.3


### PR DESCRIPTION
Bumps `networkx`  to >= 3.1 since `pyatlan` seem to work fine with newer versions (`networkx` 3.2 and 3.3).

Having version fixed at 3.1. can cause conflicts with other packages that depend on newer versions of `networkx`. This PR resolves such conflicts.