### PR TITLE
 DVX-387: Corrects `qualified_name` population for related entities in glossary objects

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -1451,8 +1451,7 @@ class AssetClient:
     ) -> List[A]:
         dsl = DSL(query=query)
         search_request = IndexSearchRequest(
-            dsl=dsl,
-            attributes=attributes,
+            dsl=dsl, attributes=attributes, relation_attributes=["name"]
         )
         results = self.search(search_request)
         if (

--- a/pyatlan/generator/templates/methods/asset/atlas_glossary.jinja2
+++ b/pyatlan/generator/templates/methods/asset/atlas_glossary.jinja2
@@ -1,18 +1,17 @@
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
+        guid = values.get("guid")
         attributes = values.get("attributes")
         unique_attributes = values.get("unique_attributes")
-        qualified_name = attributes.qualified_name if attributes else None
-
-        if not qualified_name:
-            # If the qualified name is present inside unique attributes (in case of a related entity)
-            if unique_attributes and unique_attributes.get("qualifiedName"):
-                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+        if attributes and not attributes.qualified_name:
+            # If the qualified name is present inside
+            # unique attributes (in case of a related entity)
             # Otherwise, set the qualified name to the GUID
-            # to avoid collisions when creating glossary objects
-            else:
-                values["attributes"].qualified_name = values["guid"]
+            # to avoid collisions when creating glossary object
+            attributes.qualified_name = (
+                unique_attributes and unique_attributes.get("qualifiedName")
+            ) or guid
         return values
 
     @classmethod

--- a/pyatlan/generator/templates/methods/asset/atlas_glossary.jinja2
+++ b/pyatlan/generator/templates/methods/asset/atlas_glossary.jinja2
@@ -1,8 +1,18 @@
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
-        if "attributes" in values  and values["attributes"] and not values["attributes"].qualified_name:
-            values["attributes"].qualified_name = values["guid"]
+        attributes = values.get("attributes")
+        unique_attributes = values.get("unique_attributes")
+        qualified_name = attributes.qualified_name if attributes else None
+
+        if not qualified_name:
+            # If the qualified name is present inside unique attributes (in case of a related entity)
+            if unique_attributes and unique_attributes.get("qualifiedName"):
+                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+            # Otherwise, set the qualified name to the GUID
+            # to avoid collisions when creating glossary objects
+            else:
+                values["attributes"].qualified_name = values["guid"]
         return values
 
     @classmethod

--- a/pyatlan/generator/templates/methods/asset/atlas_glossary_category.jinja2
+++ b/pyatlan/generator/templates/methods/asset/atlas_glossary_category.jinja2
@@ -9,8 +9,18 @@
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
-        if "attributes" in values  and values["attributes"] and not values["attributes"].qualified_name:
-            values["attributes"].qualified_name = values["guid"]
+        attributes = values.get("attributes")
+        unique_attributes = values.get("unique_attributes")
+        qualified_name = attributes.qualified_name if attributes else None
+
+        if not qualified_name:
+            # If the qualified name is present inside unique attributes (in case of a related entity)
+            if unique_attributes and unique_attributes.get("qualifiedName"):
+                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+            # Otherwise, set the qualified name to the GUID
+            # to avoid collisions when creating glossary objects
+            else:
+                values["attributes"].qualified_name = values["guid"]
         return values
 
     @classmethod

--- a/pyatlan/generator/templates/methods/asset/atlas_glossary_category.jinja2
+++ b/pyatlan/generator/templates/methods/asset/atlas_glossary_category.jinja2
@@ -9,18 +9,17 @@
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
+        guid = values.get("guid")
         attributes = values.get("attributes")
         unique_attributes = values.get("unique_attributes")
-        qualified_name = attributes.qualified_name if attributes else None
-
-        if not qualified_name:
-            # If the qualified name is present inside unique attributes (in case of a related entity)
-            if unique_attributes and unique_attributes.get("qualifiedName"):
-                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+        if attributes and not attributes.qualified_name:
+            # If the qualified name is present inside
+            # unique attributes (in case of a related entity)
             # Otherwise, set the qualified name to the GUID
-            # to avoid collisions when creating glossary objects
-            else:
-                values["attributes"].qualified_name = values["guid"]
+            # to avoid collisions when creating glossary object
+            attributes.qualified_name = (
+                unique_attributes and unique_attributes.get("qualifiedName")
+            ) or guid
         return values
 
     @classmethod

--- a/pyatlan/generator/templates/methods/asset/atlas_glossary_term.jinja2
+++ b/pyatlan/generator/templates/methods/asset/atlas_glossary_term.jinja2
@@ -1,18 +1,17 @@
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
+        guid = values.get("guid")
         attributes = values.get("attributes")
         unique_attributes = values.get("unique_attributes")
-        qualified_name = attributes.qualified_name if attributes else None
-
-        if not qualified_name:
-            # If the qualified name is present inside unique attributes (in case of a related entity)
-            if unique_attributes and unique_attributes.get("qualifiedName"):
-                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+        if attributes and not attributes.qualified_name:
+            # If the qualified name is present inside
+            # unique attributes (in case of a related entity)
             # Otherwise, set the qualified name to the GUID
-            # to avoid collisions when creating glossary objects
-            else:
-                values["attributes"].qualified_name = values["guid"]
+            # to avoid collisions when creating glossary object
+            attributes.qualified_name = (
+                unique_attributes and unique_attributes.get("qualifiedName")
+            ) or guid
         return values
 
     @classmethod

--- a/pyatlan/generator/templates/methods/asset/atlas_glossary_term.jinja2
+++ b/pyatlan/generator/templates/methods/asset/atlas_glossary_term.jinja2
@@ -1,8 +1,18 @@
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
-        if "attributes" in values  and values["attributes"] and not values["attributes"].qualified_name:
-            values["attributes"].qualified_name = values["guid"]
+        attributes = values.get("attributes")
+        unique_attributes = values.get("unique_attributes")
+        qualified_name = attributes.qualified_name if attributes else None
+
+        if not qualified_name:
+            # If the qualified name is present inside unique attributes (in case of a related entity)
+            if unique_attributes and unique_attributes.get("qualifiedName"):
+                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+            # Otherwise, set the qualified name to the GUID
+            # to avoid collisions when creating glossary objects
+            else:
+                values["attributes"].qualified_name = values["guid"]
         return values
 
     @classmethod

--- a/pyatlan/model/assets/atlas_glossary.py
+++ b/pyatlan/model/assets/atlas_glossary.py
@@ -21,12 +21,18 @@ class AtlasGlossary(Asset, type_name="AtlasGlossary"):
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
-        if (
-            "attributes" in values
-            and values["attributes"]
-            and not values["attributes"].qualified_name
-        ):
-            values["attributes"].qualified_name = values["guid"]
+        attributes = values.get("attributes")
+        unique_attributes = values.get("unique_attributes")
+        qualified_name = attributes.qualified_name if attributes else None
+
+        if not qualified_name:
+            # If the qualified name is present inside unique attributes (in case of a related entity)
+            if unique_attributes and unique_attributes.get("qualifiedName"):
+                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+            # Otherwise, set the qualified name to the GUID
+            # to avoid collisions when creating glossary objects
+            else:
+                values["attributes"].qualified_name = values["guid"]
         return values
 
     @classmethod

--- a/pyatlan/model/assets/atlas_glossary.py
+++ b/pyatlan/model/assets/atlas_glossary.py
@@ -21,18 +21,17 @@ class AtlasGlossary(Asset, type_name="AtlasGlossary"):
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
+        guid = values.get("guid")
         attributes = values.get("attributes")
         unique_attributes = values.get("unique_attributes")
-        qualified_name = attributes.qualified_name if attributes else None
-
-        if not qualified_name:
-            # If the qualified name is present inside unique attributes (in case of a related entity)
-            if unique_attributes and unique_attributes.get("qualifiedName"):
-                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+        if attributes and not attributes.qualified_name:
+            # If the qualified name is present inside
+            # unique attributes (in case of a related entity)
             # Otherwise, set the qualified name to the GUID
-            # to avoid collisions when creating glossary objects
-            else:
-                values["attributes"].qualified_name = values["guid"]
+            # to avoid collisions when creating glossary object
+            attributes.qualified_name = (
+                unique_attributes and unique_attributes.get("qualifiedName")
+            ) or guid
         return values
 
     @classmethod

--- a/pyatlan/model/assets/atlas_glossary_category.py
+++ b/pyatlan/model/assets/atlas_glossary_category.py
@@ -29,12 +29,18 @@ class AtlasGlossaryCategory(Asset, type_name="AtlasGlossaryCategory"):
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
-        if (
-            "attributes" in values
-            and values["attributes"]
-            and not values["attributes"].qualified_name
-        ):
-            values["attributes"].qualified_name = values["guid"]
+        attributes = values.get("attributes")
+        unique_attributes = values.get("unique_attributes")
+        qualified_name = attributes.qualified_name if attributes else None
+
+        if not qualified_name:
+            # If the qualified name is present inside unique attributes (in case of a related entity)
+            if unique_attributes and unique_attributes.get("qualifiedName"):
+                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+            # Otherwise, set the qualified name to the GUID
+            # to avoid collisions when creating glossary objects
+            else:
+                values["attributes"].qualified_name = values["guid"]
         return values
 
     @classmethod

--- a/pyatlan/model/assets/atlas_glossary_category.py
+++ b/pyatlan/model/assets/atlas_glossary_category.py
@@ -29,18 +29,17 @@ class AtlasGlossaryCategory(Asset, type_name="AtlasGlossaryCategory"):
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
+        guid = values.get("guid")
         attributes = values.get("attributes")
         unique_attributes = values.get("unique_attributes")
-        qualified_name = attributes.qualified_name if attributes else None
-
-        if not qualified_name:
-            # If the qualified name is present inside unique attributes (in case of a related entity)
-            if unique_attributes and unique_attributes.get("qualifiedName"):
-                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+        if attributes and not attributes.qualified_name:
+            # If the qualified name is present inside
+            # unique attributes (in case of a related entity)
             # Otherwise, set the qualified name to the GUID
-            # to avoid collisions when creating glossary objects
-            else:
-                values["attributes"].qualified_name = values["guid"]
+            # to avoid collisions when creating glossary object
+            attributes.qualified_name = (
+                unique_attributes and unique_attributes.get("qualifiedName")
+            ) or guid
         return values
 
     @classmethod

--- a/pyatlan/model/assets/atlas_glossary_term.py
+++ b/pyatlan/model/assets/atlas_glossary_term.py
@@ -26,12 +26,18 @@ class AtlasGlossaryTerm(Asset, type_name="AtlasGlossaryTerm"):
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
-        if (
-            "attributes" in values
-            and values["attributes"]
-            and not values["attributes"].qualified_name
-        ):
-            values["attributes"].qualified_name = values["guid"]
+        attributes = values.get("attributes")
+        unique_attributes = values.get("unique_attributes")
+        qualified_name = attributes.qualified_name if attributes else None
+
+        if not qualified_name:
+            # If the qualified name is present inside unique attributes (in case of a related entity)
+            if unique_attributes and unique_attributes.get("qualifiedName"):
+                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+            # Otherwise, set the qualified name to the GUID
+            # to avoid collisions when creating glossary objects
+            else:
+                values["attributes"].qualified_name = values["guid"]
         return values
 
     @classmethod

--- a/pyatlan/model/assets/atlas_glossary_term.py
+++ b/pyatlan/model/assets/atlas_glossary_term.py
@@ -26,18 +26,17 @@ class AtlasGlossaryTerm(Asset, type_name="AtlasGlossaryTerm"):
 
     @root_validator()
     def _set_qualified_name_fallback(cls, values):
+        guid = values.get("guid")
         attributes = values.get("attributes")
         unique_attributes = values.get("unique_attributes")
-        qualified_name = attributes.qualified_name if attributes else None
-
-        if not qualified_name:
-            # If the qualified name is present inside unique attributes (in case of a related entity)
-            if unique_attributes and unique_attributes.get("qualifiedName"):
-                values["attributes"].qualified_name = unique_attributes["qualifiedName"]
+        if attributes and not attributes.qualified_name:
+            # If the qualified name is present inside
+            # unique attributes (in case of a related entity)
             # Otherwise, set the qualified name to the GUID
-            # to avoid collisions when creating glossary objects
-            else:
-                values["attributes"].qualified_name = values["guid"]
+            # to avoid collisions when creating glossary object
+            attributes.qualified_name = (
+                unique_attributes and unique_attributes.get("qualifiedName")
+            ) or guid
         return values
 
     @classmethod

--- a/tests/integration/glossary_test.py
+++ b/tests/integration/glossary_test.py
@@ -3,7 +3,7 @@
 import itertools
 import logging
 from time import sleep
-from typing import Generator, Optional
+from typing import Generator, List, Optional
 
 import pytest
 from pydantic.v1 import StrictStr
@@ -46,10 +46,15 @@ def create_category(
 
 
 def create_term(
-    client: AtlanClient, name: str, glossary_guid: str
+    client: AtlanClient,
+    name: str,
+    glossary_guid: str,
+    categories: Optional[List[AtlasGlossaryCategory]] = None,
 ) -> AtlasGlossaryTerm:
     t = AtlasGlossaryTerm.create(
-        name=StrictStr(name), glossary_guid=StrictStr(glossary_guid)
+        name=StrictStr(name),
+        glossary_guid=StrictStr(glossary_guid),
+        categories=categories,
     )
     r = client.asset.save(t)
     return r.assets_created(AtlasGlossaryTerm)[0]
@@ -111,6 +116,25 @@ def mid1a_category(
     )
     yield c
     delete_asset(client, guid=c.guid, asset_type=AtlasGlossaryCategory)
+
+
+@pytest.fixture(scope="module")
+def mid1a_term(
+    client: AtlanClient,
+    hierarchy_glossary: AtlasGlossary,
+    mid1a_category: AtlasGlossaryCategory,
+) -> Generator[AtlasGlossaryTerm, None, None]:
+    assert mid1a_category.qualified_name
+    t = create_term(
+        client,
+        name=f"mid1a_{TERM_NAME1}",
+        glossary_guid=hierarchy_glossary.guid,
+        categories=[
+            AtlasGlossaryCategory.ref_by_qualified_name(mid1a_category.qualified_name)
+        ],
+    )
+    yield t
+    delete_asset(client, guid=t.guid, asset_type=AtlasGlossaryTerm)
 
 
 @pytest.fixture(scope="module")
@@ -553,6 +577,41 @@ def test_find_category_by_name(
             name=category.name, glossary_name=glossary.name
         )[0].guid
     )
+
+
+def test_find_category_by_name_qn_guid_correctly_populated(
+    client: AtlanClient,
+    hierarchy_glossary: AtlasGlossary,
+    top1_category: AtlasGlossaryCategory,
+    top2_category: AtlasGlossaryCategory,
+    mid1a_category: AtlasGlossaryCategory,
+    mid1a_term: AtlasGlossaryTerm,
+    mid2a_category: AtlasGlossaryCategory,
+):
+
+    category = client.asset.find_category_by_name(
+        name=mid1a_category.name,
+        glossary_name=hierarchy_glossary.name,
+        attributes=["terms", "anchor", "parentCategory"],
+    )[0]
+
+    # Glossary
+    assert category.anchor
+    assert category.anchor.guid == hierarchy_glossary.guid
+    assert category.anchor.name == hierarchy_glossary.name
+    assert category.anchor.qualified_name == hierarchy_glossary.qualified_name
+
+    # Glossary category
+    assert category.parent_category
+    assert category.parent_category.guid == top1_category.guid
+    assert category.parent_category.name == top1_category.name
+    assert category.parent_category.qualified_name == top1_category.qualified_name
+
+    # Glossary term
+    assert category.terms and category.terms[0]
+    assert category.terms[0].guid == mid1a_term.guid
+    assert category.terms[0].name == mid1a_term.name
+    assert category.terms[0].qualified_name == mid1a_term.qualified_name
 
 
 def test_category_delete_by_guid_raises_error_invalid_request_error(

--- a/tests/unit/data/search_responses/glossary_category_by_name.json
+++ b/tests/unit/data/search_responses/glossary_category_by_name.json
@@ -1,0 +1,137 @@
+{
+    "queryType": "INDEX",
+    "searchParameters": {
+      "attributes": [
+        "terms",
+        "anchor",
+        "parentCategory"
+      ],
+      "relationAttributes": [
+        "name"
+      ],
+      "showSearchScore": false,
+      "suppressLogs": false,
+      "excludeMeanings": false,
+      "excludeClassifications": false,
+      "includeClassificationNames": false,
+      "requestMetadata": {
+        "searchInput": null,
+        "utmTags": null,
+        "saveSearchLog": false
+      },
+      "async": {
+        "isCallAsync": false,
+        "searchContextId": null,
+        "searchContextSequenceNo": null,
+        "requestTimeoutInSecs": null
+      },
+      "showHighlights": false,
+      "dsl": {
+        "from": 0,
+        "size": 100,
+        "aggregations": {},
+        "track_total_hits": true,
+        "query": {
+          "bool": {
+            "filter": [
+              {
+                "term": {
+                  "__state": {
+                    "value": "ACTIVE"
+                  }
+                }
+              },
+              {
+                "term": {
+                  "__typeName.keyword": {
+                    "value": "AtlasGlossaryCategory"
+                  }
+                }
+              },
+              {
+                "term": {
+                  "name.keyword": {
+                    "value": "test-cat-1-1"
+                  }
+                }
+              },
+              {
+                "term": {
+                  "__glossary": {
+                    "value": "BHjy6jlRgnusXmpYJDxV1"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "sort": [
+          {
+            "__guid": {
+              "order": "asc"
+            }
+          }
+        ]
+      },
+      "allowDeletedRelations": false,
+      "accessControlExclusive": false,
+      "query": "{\"from\":0,\"size\":100,\"aggregations\":{},\"track_total_hits\":true,\"query\":{\"bool\":{\"filter\":[{\"term\":{\"__state\":{\"value\":\"ACTIVE\"}}},{\"term\":{\"__typeName.keyword\":{\"value\":\"AtlasGlossaryCategory\"}}},{\"term\":{\"name.keyword\":{\"value\":\"test-cat-1-1\"}}},{\"term\":{\"__glossary\":{\"value\":\"BHjy6jlRgnusXmpYJDxV1\"}}}]}},\"sort\":[{\"__guid\":{\"order\":\"asc\"}}]}",
+      "saveSearchLog": false,
+      "callAsync": false
+    },
+    "entities": [
+      {
+        "typeName": "AtlasGlossaryCategory",
+        "attributes": {
+          "terms": [
+            {
+              "guid": "828d8571-a4fc-42ed-8d47-62377384570c",
+              "typeName": "AtlasGlossaryTerm",
+              "attributes": {
+                "name": "test-term"
+              },
+              "uniqueAttributes": {
+                "qualifiedName": "hGvqXNi2L68JiPaAd2NXk@BHjy6jlRgnusXmpYJDxV1"
+              }
+            }
+          ],
+          "qualifiedName": "O22GldBLInkycVX1b525p@BHjy6jlRgnusXmpYJDxV1",
+          "anchor": {
+            "guid": "fb48e605-b848-43a0-963e-d6cd93e9bda1",
+            "typeName": "AtlasGlossary",
+            "attributes": {
+              "name": "test-glossary"
+            },
+            "uniqueAttributes": {
+              "qualifiedName": "BHjy6jlRgnusXmpYJDxV1"
+            }
+          },
+          "name": "test-cat-1-1",
+          "parentCategory": {
+            "guid": "ea324959-050a-4b6f-914b-737bda68e58b",
+            "typeName": "AtlasGlossaryCategory",
+            "attributes": {
+              "name": "test-cat-1"
+            },
+            "uniqueAttributes": {
+              "qualifiedName": "b3fbkneFAeVevNziw1bDh@BHjy6jlRgnusXmpYJDxV1"
+            }
+          }
+        },
+        "guid": "9f7a35f4-8d37-4273-81ec-c497a83a2472",
+        "status": "ACTIVE",
+        "displayText": "test-cat-1-1",
+        "classificationNames": [],
+        "classifications": [],
+        "meaningNames": [],
+        "meanings": [],
+        "isIncomplete": false,
+        "labels": [],
+        "createdBy": "test.test",
+        "updatedBy": "test.test",
+        "createTime": 1712917818815,
+        "updateTime": 1713257349051
+      }
+    ],
+    "approximateCount": 1
+}


### PR DESCRIPTION
- Also added `relation_attributes=['name']` to the `IndexSearchRequest` to include the related asset name.