### PR TITLE
  DVX-392: Fixes explicit assignment of `None` to asset attributes in `BulkRequest`

### DIFF
--- a/pyatlan/model/core.py
+++ b/pyatlan/model/core.py
@@ -277,10 +277,10 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
 
         # Initialize set for attributes to exclude from serialization
         exclude_attributes = set()
-        # Manually need to set these to "None" so that we can exclude
+        # Manually need to set these to "{}" so that we can exclude
         # them from the request playload when they're not set by the user
-        asset.remove_relationship_attributes = None
-        asset.append_relationship_attributes = None
+        asset.remove_relationship_attributes = {}
+        asset.append_relationship_attributes = {}
         # Process relationship attributes and update exclusion set
         for attribute in asset.attributes:
             exclude_attributes.update(
@@ -336,13 +336,13 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
 
             # Update asset based on processed relationship attributes
             if remove_attributes:
-                asset.remove_relationship_attributes = {
-                    to_camel_case(attribute_name): remove_attributes
-                }
+                asset.remove_relationship_attributes.update(
+                    {to_camel_case(attribute_name): remove_attributes}
+                )
             if append_attributes:
-                asset.append_relationship_attributes = {
-                    to_camel_case(attribute_name): append_attributes
-                }
+                asset.append_relationship_attributes.update(
+                    {to_camel_case(attribute_name): append_attributes}
+                )
             if replace_attributes:
                 setattr(asset, attribute_name, replace_attributes)
 

--- a/pyatlan/model/core.py
+++ b/pyatlan/model/core.py
@@ -281,8 +281,8 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
         # them from the request playload when they're not set by the user
         asset.remove_relationship_attributes = {}
         asset.append_relationship_attributes = {}
-        # Process relationship attributes and update exclusion set
-        for attribute in asset.attributes:
+        # Process relationship attributes set by the user and update exclusion set
+        for attribute in asset.attributes.__fields_set__:
             exclude_attributes.update(
                 cls.process_relationship_attributes(asset, attribute)
             )
@@ -319,9 +319,7 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
         replace_attributes = []
         exclude_attributes = set()
 
-        attribute_name, attribute_value = attribute[0], getattr(
-            asset, attribute[0], None
-        )
+        attribute_name, attribute_value = attribute, getattr(asset, attribute, None)
 
         # Process list of relationship attributes
         if attribute_value and isinstance(attribute_value, list):

--- a/pyatlan/model/core.py
+++ b/pyatlan/model/core.py
@@ -275,17 +275,39 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
         if not isinstance(asset, Asset):
             return asset
 
+        # Initialize set for attributes to exclude from serialization
+        exclude_attributes = set()
         # Manually need to set these to "None" so that we can exclude
         # them from the request playload when they're not set by the user
         asset.remove_relationship_attributes = None
         asset.append_relationship_attributes = None
+        # Process relationship attributes and update exclusion set
         for attribute in asset.attributes:
-            asset = cls.process_relationship_attributes(asset, attribute)
-
-        # Flush custom metadata
+            exclude_attributes.update(
+                cls.process_relationship_attributes(asset, attribute)
+            )
+        # Determine relationship attributes to exclude
+        # https://docs.pydantic.dev/1.10/usage/exporting_models/#advanced-include-and-exclude
+        exclude_relationship_attributes = {
+            key: True
+            for key in [
+                "remove_relationship_attributes",
+                "append_relationship_attributes",
+            ]
+            if not getattr(asset, key)
+        }
+        if exclude_attributes:
+            exclude_relationship_attributes = {
+                **{"attributes": exclude_attributes},
+                **exclude_relationship_attributes,
+            }
         asset.flush_custom_metadata()
         return asset.__class__(
-            **asset.dict(by_alias=True, exclude_unset=True, exclude_none=True)
+            **asset.dict(
+                by_alias=True,
+                exclude_unset=True,
+                exclude=exclude_relationship_attributes,
+            )
         )
 
     @classmethod
@@ -295,6 +317,7 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
         append_attributes = []
         remove_attributes = []
         replace_attributes = []
+        exclude_attributes = set()
 
         attribute_name, attribute_value = attribute[0], getattr(
             asset, attribute[0], None
@@ -323,30 +346,30 @@ class BulkRequest(AtlanObject, GenericModel, Generic[T]):
             if replace_attributes:
                 setattr(asset, attribute_name, replace_attributes)
 
-            # If only remove or append attributes are present without any replace attributes,
-            # set the attribute to `None` to exclude it from the bulk request payload
-            # This avoids including unwanted replace attributes that could alter the request behavior
+            # If 'remove', 'append', or both attributes are present and there are no 'replace' attributes,
+            # add the attribute to the set to exclude it from the bulk request payload.
+            # This prevents including unwanted 'replace' attributes that could alter the request behavior.
             if (remove_attributes or append_attributes) and not replace_attributes:
-                setattr(asset, attribute_name, None)
+                exclude_attributes.add(attribute_name)
 
         # Process single relationship attribute
         elif attribute_value and isinstance(attribute_value, Asset):
             if attribute_value.semantic == SaveSemantic.REMOVE:
-                # Set the replace attribute to "None" so that we exclude it
-                # from the request payload's "attributes" property
-                # We only want to pass this attribute under
-                # "remove_relationship_attributes," not both
-                setattr(asset, attribute_name, None)
+                # Add the replace attribute to the set to exclude it
+                # from the "attributes" property in the request payload.
+                # We only want to include this attribute under
+                # "remove_relationship_attributes", not both.
+                exclude_attributes.add(attribute_name)
                 asset.remove_relationship_attributes = {
                     to_camel_case(attribute_name): attribute_value
                 }
             elif attribute_value.semantic == SaveSemantic.APPEND:
-                # Set the replace attribute to "None" so that we exclude it
-                # from the request payload's "attributes" property
-                # We only want to pass this attribute under
-                # "append_relationship_attributes," not both
-                setattr(asset, attribute_name, None)
+                # Add the replace attribute to the set to exclude it
+                # from the "attributes" property in the request payload.
+                # We only want to include this attribute under
+                # "append_relationship_attributes", not both.
+                exclude_attributes.add(attribute_name)
                 asset.append_relationship_attributes = {
                     to_camel_case(attribute_name): attribute_value
                 }
-        return asset
+        return exclude_attributes

--- a/tests/integration/lineage_test.py
+++ b/tests/integration/lineage_test.py
@@ -18,7 +18,12 @@ from pyatlan.model.assets import (
     Table,
     View,
 )
-from pyatlan.model.enums import AtlanConnectorType, EntityStatus, LineageDirection
+from pyatlan.model.enums import (
+    AtlanConnectorType,
+    CertificateStatus,
+    EntityStatus,
+    LineageDirection,
+)
 from pyatlan.model.lineage import FluentLineage, LineageRequest
 from pyatlan.model.search import DSL, Bool, IndexSearchRequest, Prefix, Term
 from tests.integration.client import TestId, delete_asset
@@ -39,6 +44,8 @@ COLUMN_NAME5 = f"{MODULE_NAME}5"
 COLUMN_NAME6 = f"{MODULE_NAME}6"
 
 CONNECTOR_TYPE = AtlanConnectorType.VERTICA
+CERTIFICATE_STATUS = CertificateStatus.VERIFIED
+CERTIFICATE_MESSAGE = "Automated testing of the Python SDK."
 
 
 @pytest.fixture(scope="module")
@@ -66,6 +73,8 @@ def create_database(client: AtlanClient, connection, database_name: str):
     to_create = Database.create(
         name=database_name, connection_qualified_name=connection.qualified_name
     )
+    to_create.certificate_status = CERTIFICATE_STATUS
+    to_create.certificate_status_message = CERTIFICATE_MESSAGE
     result = client.asset.save(to_create)
     return result.assets_created(asset_type=Database)[0]
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -486,6 +486,27 @@ def test_glossary_update_announcement(
     _test_update_announcement(client, glossary, AtlasGlossary, announcement)
 
 
+def test_asset_remove_certificate_by_setting_none(
+    client: AtlanClient,
+    database: Database,
+):
+    assert database
+    assert database.guid
+    assert database.certificate_status
+    assert database.certificate_status_message
+    database.certificate_status = None
+    database.certificate_status_message = None
+    response = client.asset.save(entity=[database])
+    db_updated = response.assets_updated(asset_type=Database)
+
+    assert db_updated
+    assert len(db_updated) == 1
+    assert db_updated[0].name == database.name
+    assert db_updated[0].guid == database.guid
+    assert db_updated[0].certificate_status is None
+    assert db_updated[0].certificate_status_message is None
+
+
 def test_glossary_term_update_announcement(
     client: AtlanClient,
     term1: AtlasGlossaryTerm,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1741,6 +1741,7 @@ class TestBulkRequest:
     SEE_ALSO = "seeAlso"
     REMOVE = "removeRelationshipAttributes"
     APPEND = "appendRelationshipAttributes"
+    PREFERRED_TO_TERMS = "preferredToTerms"
 
     @pytest.fixture(scope="class")
     def glossary(self):
@@ -1797,6 +1798,35 @@ class TestBulkRequest:
         assert self.APPEND in request_json
         assert self.SEE_ALSO in request_json[self.APPEND]
         append_attributes = request_json[self.APPEND][self.SEE_ALSO]
+        assert len(append_attributes) == 1
+        assert append_attributes[0]["guid"] == term3.guid
+        assert self.REMOVE not in request_json
+
+        # Test replace and append (list) with multiple relationships
+        term1.attributes.see_also = [
+            AtlasGlossaryTerm.ref_by_guid(guid=term2.guid),
+            AtlasGlossaryTerm.ref_by_guid(
+                guid=term3.guid, semantic=SaveSemantic.APPEND
+            ),
+        ]
+        term1.attributes.preferred_to_terms = [
+            AtlasGlossaryTerm.ref_by_guid(
+                guid=term3.guid, semantic=SaveSemantic.APPEND
+            ),
+        ]
+        request = BulkRequest(entities=[term1])
+        request_json = self.to_json(request)
+        assert request_json
+        assert self.SEE_ALSO in request_json["attributes"]
+        replace_attributes = request_json["attributes"][self.SEE_ALSO]
+        assert len(replace_attributes) == 1
+        assert replace_attributes[0]["guid"] == term2.guid
+        assert self.APPEND in request_json
+        assert self.SEE_ALSO in request_json[self.APPEND]
+        append_attributes = request_json[self.APPEND][self.SEE_ALSO]
+        assert len(append_attributes) == 1
+        assert append_attributes[0]["guid"] == term3.guid
+        append_attributes = request_json[self.APPEND][self.PREFERRED_TO_TERMS]
         assert len(append_attributes) == 1
         assert append_attributes[0]["guid"] == term3.guid
         assert self.REMOVE not in request_json
@@ -1869,6 +1899,7 @@ class TestBulkRequest:
 
         # Test empty (list)
         term1.attributes.see_also = []
+        term1.attributes.preferred_to_terms = []
         request = BulkRequest(entities=[term1])
         request_json = self.to_json(request)
         assert request_json

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1917,3 +1917,13 @@ class TestBulkRequest:
         assert remove_attributes["guid"] == glossary.guid
         assert self.APPEND not in request_json
         assert "anchor" not in request_json["attributes"]
+
+    def test_asset_attribute_none_assignment(self):
+        table1 = Table.updater(name="test-table-1", qualified_name="test-qn-1")
+        table1.certificate_status = None
+        table1.certificate_status_message = None
+        request = BulkRequest(entities=[table1])
+        request_json = self.to_json(request)
+        assert request_json
+        assert request_json["attributes"]["certificateStatus"] is None
+        assert request_json["attributes"]["certificateStatusMessage"] is None


### PR DESCRIPTION
- Also fixes issues with multiple remove/append relationships
Previously, values were being overwritten inside append/remove dictionaries.
```py
# Test replace and append (list) with multiple relationships
 term1.attributes.see_also = [
            AtlasGlossaryTerm.ref_by_guid(guid=term2.guid),
            AtlasGlossaryTerm.ref_by_guid(
                guid=term3.guid, semantic=SaveSemantic.APPEND
            ),
        ]
 term1.attributes.preferred_to_terms = [
            AtlasGlossaryTerm.ref_by_guid(
                guid=term3.guid, semantic=SaveSemantic.APPEND
            ),
        ]
```