### PR TITLE
DVX-377: Adds support for SSO grouping

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -38,6 +38,7 @@ from pyatlan.client.impersonate import ImpersonationClient
 from pyatlan.client.query import QueryClient
 from pyatlan.client.role import RoleClient
 from pyatlan.client.search_log import SearchLogClient
+from pyatlan.client.sso import SSOClient
 from pyatlan.client.task import TaskClient
 from pyatlan.client.token import TokenClient
 from pyatlan.client.typedef import TypeDefClient
@@ -143,6 +144,7 @@ class AtlanClient(BaseSettings):
     _impersonate_client: Optional[ImpersonationClient] = PrivateAttr(default=None)
     _query_client: Optional[QueryClient] = PrivateAttr(default=None)
     _task_client: Optional[TaskClient] = PrivateAttr(default=None)
+    _sso_client: Optional[SSOClient] = PrivateAttr(default=None)
 
     class Config:
         env_prefix = "atlan_"
@@ -263,6 +265,12 @@ class AtlanClient(BaseSettings):
         if self._task_client is None:
             self._task_client = TaskClient(client=self)
         return self._task_client
+
+    @property
+    def sso(self) -> SSOClient:
+        if self._sso_client is None:
+            self._sso_client = SSOClient(client=self)
+        return self._sso_client
 
     def update_headers(self, header: Dict[str, str]):
         self._session.headers.update(header)

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -475,3 +475,31 @@ DELETE_TYPE_DEFS = API(
 DELETE_TYPE_DEF_BY_NAME = API(
     TYPEDEF_BY_NAME, HTTPMethod.DELETE, HTTPStatus.NO_CONTENT, endpoint=EndPoint.ATLAS
 )
+
+SSO_API = "idp/"
+SSO_GROUP_MAPPER = SSO_API + "{sso_alias}/mappers"
+
+GET_SSO_GROUP_MAPPING = API(
+    SSO_GROUP_MAPPER + "/{group_map_id}",
+    HTTPMethod.GET,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+GET_ALL_SSO_GROUP_MAPPING = API(
+    SSO_GROUP_MAPPER, HTTPMethod.GET, HTTPStatus.OK, endpoint=EndPoint.HERACLES
+)
+CREATE_SSO_GROUP_MAPPING = API(
+    SSO_GROUP_MAPPER, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HERACLES
+)
+UPDATE_SSO_GROUP_MAPPING = API(
+    SSO_GROUP_MAPPER + "/{group_map_id}",
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+DELETE_SSO_GROUP_MAPPING = API(
+    SSO_GROUP_MAPPER + "/{group_map_id}/delete",
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)

--- a/pyatlan/client/sso.py
+++ b/pyatlan/client/sso.py
@@ -1,0 +1,134 @@
+from typing import List
+
+from pydantic.v1 import ValidationError, parse_obj_as, validate_arguments
+
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.constants import (
+    CREATE_SSO_GROUP_MAPPING,
+    DELETE_SSO_GROUP_MAPPING,
+    GET_ALL_SSO_GROUP_MAPPING,
+    GET_SSO_GROUP_MAPPING,
+    UPDATE_SSO_GROUP_MAPPING,
+)
+from pyatlan.errors import ErrorCode
+from pyatlan.model.group import AtlanGroup
+from pyatlan.model.sso import SSOMapper, SSOMapperConfig
+from pyatlan.utils import get_epoch_timestamp
+
+
+class SSOClient:
+    """
+    A client for operating on Atlan's single sign-on (SSO).
+    """
+
+    def __init__(self, client: ApiCaller):
+        if not isinstance(client, ApiCaller):
+            raise ErrorCode.INVALID_PARAMETER_TYPE.exception_with_parameters(
+                "client", "ApiCaller"
+            )
+        self._client = client
+
+    @staticmethod
+    def _generate_group_mapper_name(atlan_group_id):
+        return f"{atlan_group_id}--{int(get_epoch_timestamp() * 1000)}"
+
+    @staticmethod
+    def _parse_sso_mapper(raw_json):
+        try:
+            if isinstance(raw_json, List):
+                return parse_obj_as(List[SSOMapper], raw_json)
+            return parse_obj_as(SSOMapper, raw_json)
+        except ValidationError as err:
+            raise ErrorCode.JSON_ERROR.exception_with_parameters(
+                raw_json, 200, str(err)
+            ) from err
+
+    def _check_existing_group_mappings(
+        self, sso_alias: str, atlan_group: AtlanGroup
+    ) -> None:
+        existing_group_maps = self.get_all_group_mappings(sso_alias=sso_alias)
+        for group_map in existing_group_maps:
+            if group_map.name and str(atlan_group.id) in group_map.name:
+                raise ErrorCode.SSO_GROUP_MAPPING_ALREADY_EXISTS.exception_with_parameters(
+                    atlan_group.alias, group_map.config.attribute_value
+                )
+
+    @validate_arguments
+    def create_group_mapping(
+        self, sso_alias: str, atlan_group: AtlanGroup, sso_group_name: str
+    ) -> SSOMapper:
+        self._check_existing_group_mappings(sso_alias, atlan_group)
+        group_mapper_config = SSOMapperConfig(
+            attributes="[]",
+            sync_mode="FORCE",
+            attribute_values_regex="",
+            attribute_name="memberOf",
+            attribute_value=sso_group_name,
+            group_name=atlan_group.name,
+        )  # type: ignore[call-arg]
+        group_mapper_name = self._generate_group_mapper_name(atlan_group.id)
+        group_mapper = SSOMapper(
+            name=group_mapper_name,
+            config=group_mapper_config,
+            identity_provider_alias=sso_alias,
+            identity_provider_mapper="saml-group-idp-mapper",
+        )  # type: ignore[call-arg]
+        raw_json = self._client._call_api(
+            CREATE_SSO_GROUP_MAPPING.format_path({"sso_alias": sso_alias}),
+            request_obj=group_mapper,
+        )
+        return self._parse_sso_mapper(raw_json)
+
+    @validate_arguments
+    def update_group_mapping(
+        self,
+        sso_alias: str,
+        atlan_group: AtlanGroup,
+        group_map_id: str,
+        sso_group_name: str,
+    ) -> SSOMapper:
+        group_mapper_config = SSOMapperConfig(
+            attributes="[]",
+            sync_mode="FORCE",
+            group_name=atlan_group.name,
+            attribute_name="memberOf",
+            attribute_value=sso_group_name,
+        )  # type: ignore[call-arg]
+        group_mapper = SSOMapper(
+            id=group_map_id,
+            config=group_mapper_config,
+            identity_provider_alias=sso_alias,
+            identity_provider_mapper="saml-group-idp-mapper",
+        )  # type: ignore[call-arg]
+        raw_json = self._client._call_api(
+            UPDATE_SSO_GROUP_MAPPING.format_path(
+                {"sso_alias": sso_alias, "group_map_id": group_map_id}
+            ),
+            request_obj=group_mapper,
+        )
+        return self._parse_sso_mapper(raw_json)
+
+    @validate_arguments
+    def get_all_group_mappings(self, sso_alias: str) -> List[SSOMapper]:
+        raw_json = self._client._call_api(
+            GET_ALL_SSO_GROUP_MAPPING.format_path({"sso_alias": sso_alias})
+        )
+        return self._parse_sso_mapper(raw_json)
+
+    @validate_arguments
+    def get_group_mapping(self, sso_alias: str, group_map_id: str) -> SSOMapper:
+        raw_json = self._client._call_api(
+            GET_SSO_GROUP_MAPPING.format_path(
+                {"sso_alias": sso_alias, "group_map_id": group_map_id}
+            )
+        )
+        return self._parse_sso_mapper(raw_json)
+
+    @validate_arguments
+    def delete_group_mapping(self, sso_alias: str, group_map_id: str) -> SSOMapper:
+        raw_json = self._client._call_api(
+            DELETE_SSO_GROUP_MAPPING.format_path(
+                {"sso_alias": sso_alias, "group_map_id": group_map_id}
+            )
+        )
+        return raw_json

--- a/pyatlan/client/sso.py
+++ b/pyatlan/client/sso.py
@@ -152,7 +152,13 @@ class SSOClient:
         raw_json = self._client._call_api(
             GET_ALL_SSO_GROUP_MAPPING.format_path({"sso_alias": sso_alias})
         )
-        return self._parse_sso_mapper(raw_json)
+        # Since `raw_json` includes both user and group mappings
+        group_mappings = [
+            mapping
+            for mapping in raw_json
+            if mapping["identityProviderMapper"] == SSOClient.IDP_GROUP_MAPPER
+        ]
+        return self._parse_sso_mapper(group_mappings)
 
     @validate_arguments
     def get_group_mapping(self, sso_alias: str, group_map_id: str) -> SSOMapper:

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -500,6 +500,13 @@ class ErrorCode(Enum):
         + "repository providing context in which this error occurred.",
         InvalidRequestError,
     )
+    SSO_GROUP_MAPPING_ALREADY_EXISTS = (
+        400,
+        "ATLAN-PYTHON-400-058",
+        "SSO group mapping already exists between {0} (Atlan group) <-> {1} (SSO group).",
+        "You can use SSOClient.update_group_mapping() to update the existing group mapping.",
+        InvalidRequestError,
+    )
     AUTHENTICATION_PASSTHROUGH = (
         401,
         "ATLAN-PYTHON-401-000",

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -94,6 +94,14 @@ class AssetFilterGroup(str, Enum):
     CERTIFICATE = "certificateStatus"
 
 
+class AtlanSSO(str, Enum):
+    GOOGLE = "google"
+    AZURE_AD = "azure"
+    OKTA = "okta"
+    JUMPCLOUD = "jumpcloud"
+    ONELOGIN = "onelogin"
+
+
 class AtlanComparisonOperator(str, Enum):
     LT = "<"
     GT = ">"

--- a/pyatlan/model/sso.py
+++ b/pyatlan/model/sso.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from pydantic.v1 import Field
+
+from pyatlan.model.core import AtlanObject
+
+
+class SSOMapperConfig(AtlanObject):
+    sync_mode: Optional[str] = Field(default=None)
+    attributes: Optional[str] = Field(default=None)
+    group_name: Optional[str] = Field(default=None, alias="group")
+    attribute_name: Optional[str] = Field(default=None, alias="attribute.name")
+    attribute_value: Optional[str] = Field(default=None, alias="attribute.value")
+    attribute_friendly_name: Optional[str] = Field(
+        default=None, alias="attribute.friendly.name"
+    )
+    attribute_values_regex: Optional[str] = Field(
+        default=None, alias="are.attribute.values.regex"
+    )
+
+
+class SSOMapper(AtlanObject):
+    id: Optional[str] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    identity_provider_mapper: str
+    identity_provider_alias: str
+    config: SSOMapperConfig

--- a/tests/integration/test_sso_client.py
+++ b/tests/integration/test_sso_client.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Atlan Pte. Ltd.
+import time
+from typing import Generator
+
+import pytest
+
+from pyatlan.client.atlan import AtlanClient
+from pyatlan.client.sso import SSOClient
+from pyatlan.errors import InvalidRequestError
+from pyatlan.model.enums import AtlanSSO
+from pyatlan.model.group import AtlanGroup
+from pyatlan.model.sso import SSOMapper
+from tests.integration.client import TestId
+
+FIXED_USER = "aryaman.bhushan"
+MODULE_NAME = TestId.make_unique("SSOClient")
+
+GROUP_NAME = MODULE_NAME
+SSO_GROUP_NAME = "test-sso-group"
+SSO_GROUP_NAME_UPDATED = "test-sso-group-updated"
+
+
+def delete_group(client: AtlanClient, guid: str) -> None:
+    client.group.purge(guid)
+
+
+def delete_sso_mapping(client: AtlanClient, group_map_id: str) -> None:
+    response = client.sso.delete_group_mapping(
+        sso_alias=AtlanSSO.AZURE_AD, group_map_id=group_map_id
+    )
+    assert response is None
+
+
+@pytest.fixture(scope="module")
+def group(client: AtlanClient) -> Generator[AtlanGroup, None, None]:
+    to_create = AtlanGroup.create(GROUP_NAME)
+    fixed_user = client.user.get_by_username(FIXED_USER)
+    assert fixed_user
+    g = client.group.create(group=to_create, user_ids=[str(fixed_user.id)])
+    groups = client.group.get_by_name(alias=GROUP_NAME)
+    assert groups
+    assert len(groups) == 1
+    yield groups[0]
+    assert g.group
+    delete_group(client, g.group)
+
+
+@pytest.fixture(scope="module")
+def sso_mapping(
+    client: AtlanClient, group: AtlanGroup
+) -> Generator[SSOMapper, None, None]:
+    assert group
+    assert group.id
+    response = client.sso.create_group_mapping(
+        sso_alias=AtlanSSO.AZURE_AD, atlan_group=group, sso_group_name=SSO_GROUP_NAME
+    )
+    assert response
+
+    azure_group_mapping = None
+    sso_mappings = client.sso.get_all_group_mappings(sso_alias=AtlanSSO.AZURE_AD)
+    for mapping in sso_mappings:
+        if (
+            group.id
+            and group.id in str(mapping.name)
+            and mapping.identity_provider_mapper == SSOClient.IDP_GROUP_MAPPER
+        ):
+            azure_group_mapping = mapping
+            break
+    assert azure_group_mapping and azure_group_mapping.id
+    yield azure_group_mapping
+    delete_sso_mapping(client, azure_group_mapping.id)
+
+
+def _assert_sso_group_mapping(
+    group: AtlanGroup, sso_mapping: SSOMapper, is_updated: bool = False
+):
+    assert sso_mapping
+    assert sso_mapping.id
+    assert sso_mapping.identity_provider_alias == AtlanSSO.AZURE_AD
+    assert sso_mapping.identity_provider_mapper == SSOClient.IDP_GROUP_MAPPER
+    assert sso_mapping.config.attributes == "[]"
+    assert sso_mapping.config.group_name == group.name
+    assert sso_mapping.config.attribute_values_regex is None
+    assert sso_mapping.config.attribute_friendly_name is None
+
+    assert sso_mapping.config.sync_mode == SSOClient.GROUP_MAPPER_SYNC_MODE
+    assert sso_mapping.config.attribute_name == SSOClient.GROUP_MAPPER_ATTRIBUTE
+    if is_updated:
+        assert sso_mapping.name is None
+        assert sso_mapping.config.attribute_value == SSO_GROUP_NAME_UPDATED
+    else:
+        assert group.id and (group.id in str(sso_mapping.name))
+        assert sso_mapping.config.attribute_value == SSO_GROUP_NAME
+
+
+def test_sso_create_group_mapping(
+    client: AtlanClient,
+    group: AtlanGroup,
+    sso_mapping: SSOMapper,
+):
+    assert group
+    assert sso_mapping
+    _assert_sso_group_mapping(group, sso_mapping)
+
+
+@pytest.mark.order(after="test_sso_create_group_mapping")
+def test_sso_create_group_mapping_again_raises_invalid_request_error(
+    client: AtlanClient,
+    group: AtlanGroup,
+    sso_mapping: SSOMapper,
+):
+    assert group
+    assert sso_mapping
+
+    with pytest.raises(InvalidRequestError) as err:
+        client.sso.create_group_mapping(
+            sso_alias=AtlanSSO.AZURE_AD,
+            atlan_group=group,
+            sso_group_name=SSO_GROUP_NAME,
+        )
+    assert (
+        f"ATLAN-PYTHON-400-058 SSO group mapping already exists between "
+        f"{group.alias} (Atlan group) <-> {SSO_GROUP_NAME} (SSO group)"
+    ) in str(err.value)
+
+
+@pytest.mark.order(
+    after="test_sso_create_group_mapping_again_raises_invalid_request_error"
+)
+def test_sso_retrieve_group_mapping(
+    client: AtlanClient,
+    group: AtlanGroup,
+    sso_mapping: SSOMapper,
+):
+    assert group
+    assert sso_mapping
+    assert sso_mapping.id
+    time.sleep(5)
+
+    retrieved_sso_mapping = client.sso.get_group_mapping(
+        sso_alias=AtlanSSO.AZURE_AD, group_map_id=sso_mapping.id
+    )
+    _assert_sso_group_mapping(group, retrieved_sso_mapping)
+
+
+@pytest.mark.order(after="test_sso_retrieve_group_mapping")
+def test_sso_retrieve_all_group_mappings(
+    client: AtlanClient,
+    group: AtlanGroup,
+    sso_mapping: SSOMapper,
+):
+    assert group
+    assert group.id
+    assert sso_mapping
+    time.sleep(5)
+
+    retrieved_mappings = client.sso.get_all_group_mappings(sso_alias=AtlanSSO.AZURE_AD)
+    assert len(retrieved_mappings) >= 1
+    mapping_found = False
+    for mapping in retrieved_mappings:
+        if (
+            group.id in str(mapping.name)
+            and mapping.identity_provider_mapper == SSOClient.IDP_GROUP_MAPPER
+        ):
+            mapping_found = True
+            _assert_sso_group_mapping(group, mapping)
+            break
+    if not mapping_found:
+        pytest.fail(
+            f"{group.alias} (Atlan Group) <-> ({sso_mapping.config.attribute_value}) "
+            f"{AtlanSSO.AZURE_AD} SSO group mapping not found."
+        )
+
+
+@pytest.mark.order(after="test_sso_retrieve_all_group_mappings")
+def test_update_group_mapping(
+    client: AtlanClient,
+    group: AtlanGroup,
+    sso_mapping: SSOMapper,
+):
+    assert group
+    assert sso_mapping
+    assert sso_mapping.id
+
+    updated_mapping = client.sso.update_group_mapping(
+        sso_alias=AtlanSSO.AZURE_AD,
+        atlan_group=group,
+        group_map_id=sso_mapping.id,
+        sso_group_name=SSO_GROUP_NAME_UPDATED,
+    )
+    _assert_sso_group_mapping(group, updated_mapping, True)

--- a/tests/unit/data/sso_responses/create_group_mapping.json
+++ b/tests/unit/data/sso_responses/create_group_mapping.json
@@ -1,0 +1,13 @@
+{
+    "name": "27b60291-67e1-44f5-a1fc-8a77fa96d78e--1713518829204",
+    "identityProviderMapper": "saml-group-idp-mapper",
+    "identityProviderAlias": "auth0",
+    "config": {
+        "are.attribute.values.regex": "",
+        "attribute.name": "memberOf",
+        "attribute.value": "test-sso-group",
+        "attributes": "[]",
+        "group": "test-atlan-group",
+        "syncMode": "FORCE"
+    }
+}

--- a/tests/unit/data/sso_responses/get_all_group_mapping.json
+++ b/tests/unit/data/sso_responses/get_all_group_mapping.json
@@ -1,0 +1,62 @@
+[
+    {
+      "id": "12eb9f4c-2f63-47c5-8dfc-5d9440f50e56",
+      "name": "email",
+      "identityProviderMapper": "saml-user-attribute-idp-mapper",
+      "identityProviderAlias": "auth0",
+      "config": {
+        "attribute.friendly.name": "email",
+        "attribute.name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+        "syncMode": "IMPORT",
+        "user.attribute": "email"
+      }
+    },
+    {
+      "id": "a73e8264-4b64-4e93-8635-2abbc40c81c9",
+      "name": "firstName",
+      "identityProviderMapper": "saml-user-attribute-idp-mapper",
+      "identityProviderAlias": "auth0",
+      "config": {
+        "attribute.friendly.name": "firstName",
+        "attribute.name": "http://schemas.auth0.com/nickname",
+        "syncMode": "IMPORT",
+        "user.attribute": "firstName"
+      }
+    },
+    {
+      "id": "83036af2-230c-4c6e-ad3c-55314c01af06",
+      "name": "atlan-group-guid-1234--1713528648788",
+      "identityProviderMapper": "saml-group-idp-mapper",
+      "identityProviderAlias": "auth0",
+      "config": {
+        "attribute.name": "memberOf",
+        "attribute.value": "test-sso-group",
+        "attributes": "[]",
+        "group": "test-atlan-group",
+        "syncMode": "FORCE"
+      }
+    },
+    {
+      "id": "3db148da-fef0-495e-a7f7-109998797a95",
+      "name": "lastName",
+      "identityProviderMapper": "saml-user-attribute-idp-mapper",
+      "identityProviderAlias": "auth0",
+      "config": {
+        "attribute.friendly.name": "lastName",
+        "attribute.name": "http://schemas.auth0.com/nickname",
+        "syncMode": "IMPORT",
+        "user.attribute": "lastName"
+      }
+    },
+    {
+      "id": "811e0480-6ed2-43a8-b04b-a1fd2c672ed2",
+      "name": "hardcodedRole",
+      "identityProviderMapper": "oidc-hardcoded-role-idp-mapper",
+      "identityProviderAlias": "auth0",
+      "config": {
+        "attributes": "[]",
+        "role": "$guest",
+        "syncMode": "IMPORT"
+      }
+    }
+]

--- a/tests/unit/data/sso_responses/get_group_mapping.json
+++ b/tests/unit/data/sso_responses/get_group_mapping.json
@@ -1,0 +1,13 @@
+{
+    "id": "83036af2-230c-4c6e-ad3c-55314c01af06",
+    "name": "atlan-group-guid-1234--1713518829204",
+    "identityProviderMapper": "saml-group-idp-mapper",
+    "identityProviderAlias": "auth0",
+    "config": {
+        "attribute.name": "memberOf",
+        "attribute.value": "sso_create_1234",
+        "attributes": "[]",
+        "group": "testgroup2",
+        "syncMode": "FORCE"
+    }
+}

--- a/tests/unit/data/sso_responses/update_group_mapping.json
+++ b/tests/unit/data/sso_responses/update_group_mapping.json
@@ -1,0 +1,13 @@
+{
+    "id": "83036af2-230c-4c6e-ad3c-55314c01af06",
+    "name": "atlan-group-guid-1234--1713518829204",
+    "identityProviderMapper": "saml-group-idp-mapper",
+    "identityProviderAlias": "auth0",
+    "config": {
+        "attribute.name": "memberOf",
+        "attribute.value": "test-sso-group-update",
+        "attributes": "[]",
+        "group": "test-atlan-group",
+        "syncMode": "FORCE"
+    }
+}

--- a/tests/unit/test_sso_client.py
+++ b/tests/unit/test_sso_client.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Atlan Pte. Ltd.
+from json import load
+from pathlib import Path
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+from pydantic.v1 import ValidationError, parse_obj_as
+
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.sso import SSOClient
+from pyatlan.errors import InvalidRequestError
+from pyatlan.model.group import AtlanGroup
+from pyatlan.model.sso import SSOMapper
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
+SSO_GET_GROUP_MAPPING_JSON = "get_group_mapping.json"
+SSO_GET_ALL_GROUP_MAPPING_JSON = "get_all_group_mapping.json"
+SSO_CREATE_GROUP_MAPPING_JSON = "create_group_mapping.json"
+SSO_UPDATE_GROUP_MAPPING_JSON = "update_group_mapping.json"
+SSO_RESPONSES_DIR = TEST_DATA_DIR / "sso_responses"
+
+
+def load_json(respones_dir, filename):
+    with (respones_dir / filename).open() as input_file:
+        return load(input_file)
+
+
+def to_json(model):
+    return model.json(by_alias=True, exclude_none=True)
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+
+@pytest.fixture(scope="module")
+def mock_api_caller():
+    return Mock(spec=ApiCaller)
+
+
+@pytest.fixture()
+def get_group_mapping_json():
+    return load_json(SSO_RESPONSES_DIR, SSO_GET_GROUP_MAPPING_JSON)
+
+
+@pytest.fixture()
+def get_all_group_mapping_json():
+    return load_json(SSO_RESPONSES_DIR, SSO_GET_ALL_GROUP_MAPPING_JSON)
+
+
+@pytest.fixture()
+def create_group_mapping_json():
+    return load_json(SSO_RESPONSES_DIR, SSO_CREATE_GROUP_MAPPING_JSON)
+
+
+@pytest.fixture()
+def update_group_mapping_json():
+    return load_json(SSO_RESPONSES_DIR, SSO_UPDATE_GROUP_MAPPING_JSON)
+
+
+@pytest.mark.parametrize("test_api_caller", ["abc", None])
+def test_init_when_wrong_class_raises_exception(test_api_caller):
+    with pytest.raises(
+        InvalidRequestError,
+        match="ATLAN-PYTHON-400-048 Invalid parameter type for client should be ApiCaller",
+    ):
+        SSOClient(test_api_caller)
+
+
+@pytest.mark.parametrize(
+    "sso_alias, group_map_id, error_msg",
+    [
+        [None, "map-id", "none is not an allowed value"],
+        ["auth0", None, "none is not an allowed value"],
+        [[123], "map-id", "so_alias\n  str type expected"],
+        ["azure", [123], "group_map_id\n  str type expected"],
+    ],
+)
+def test_sso_get_group_mapping_wrong_params_raises_validation_error(
+    sso_alias, group_map_id, error_msg
+):
+    with pytest.raises(ValidationError) as err:
+        SSOClient.get_group_mapping(sso_alias=sso_alias, group_map_id=group_map_id)
+    assert error_msg in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "sso_alias, error_msg",
+    [
+        [None, "none is not an allowed value"],
+        [[123], "so_alias\n  str type expected"],
+    ],
+)
+def test_sso_get_all_group_mapping_wrong_params_raises_validation_error(
+    sso_alias, error_msg
+):
+    with pytest.raises(ValidationError) as err:
+        SSOClient.get_all_group_mappings(sso_alias=sso_alias)
+    assert error_msg in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "sso_alias, atlan_group, sso_group_name, error_msg",
+    [
+        [None, "atlan-group", "sso-group", "none is not an allowed value"],
+        ["auth0", None, "sso-group", "none is not an allowed value"],
+        ["auth0", "atlan-group", None, "none is not an allowed value"],
+        [[123], "atlan-group", "sso-group", "so_alias\n  str type expected"],
+        ["auth0", [123], "sso-group", "atlan_group\n  value is not a valid dict"],
+        ["auth0", AtlanGroup(), [123], "sso_group_name\n  str type expected"],
+    ],
+)
+def test_sso_create_group_mapping_wrong_params_raises_validation_error(
+    sso_alias, atlan_group, sso_group_name, error_msg
+):
+    with pytest.raises(ValidationError) as err:
+        SSOClient.create_group_mapping(
+            sso_alias=sso_alias, atlan_group=atlan_group, sso_group_name=sso_group_name
+        )
+    assert error_msg in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "sso_alias, atlan_group, group_map_id, sso_group_name, error_msg",
+    [
+        [None, "atlan-group", "map-id", "sso-group", "none is not an allowed value"],
+        ["auth0", None, "map-id", "sso-group", "none is not an allowed value"],
+        ["auth0", "atlan-group", None, "sso-group", "none is not an allowed value"],
+        ["auth0", "atlan-group", "map-id", None, "none is not an allowed value"],
+        ["auth0", "atlan-group", "map-id", None, "none is not an allowed value"],
+        [[123], "atlan-group", "map-id", "sso-group", "sso_alias\n  str type expected"],
+        [
+            "auth0",
+            [123],
+            "map-id",
+            "sso-group",
+            "atlan_group\n  value is not a valid dict",
+        ],
+        [
+            "auth0",
+            "atlan-group",
+            [123],
+            "sso-group",
+            "group_map_id\n  str type expected",
+        ],
+        [
+            "auth0",
+            "atlan-group",
+            "map-id",
+            [123],
+            "sso_group_name\n  str type expected",
+        ],
+    ],
+)
+def test_sso_update_group_mapping_wrong_params_raises_validation_error(
+    sso_alias, atlan_group, group_map_id, sso_group_name, error_msg
+):
+    with pytest.raises(ValidationError) as err:
+        SSOClient.update_group_mapping(
+            sso_alias=sso_alias,
+            atlan_group=atlan_group,
+            group_map_id=group_map_id,
+            sso_group_name=sso_group_name,
+        )
+    assert error_msg in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "sso_alias, group_map_id, error_msg",
+    [
+        [None, "map-id", "none is not an allowed value"],
+        ["auth0", None, "none is not an allowed value"],
+        [[123], "map-id", "so_alias\n  str type expected"],
+        ["azure", [123], "group_map_id\n  str type expected"],
+    ],
+)
+def test_sso_delete_group_mapping_wrong_params_raises_validation_error(
+    sso_alias, group_map_id, error_msg
+):
+    with pytest.raises(ValidationError) as err:
+        SSOClient.delete_group_mapping(sso_alias=sso_alias, group_map_id=group_map_id)
+    assert error_msg in str(err.value)
+
+
+def test_sso_get_group_mapping(
+    mock_api_caller,
+    get_group_mapping_json,
+):
+    mock_api_caller._call_api.side_effect = [get_group_mapping_json]
+    client = SSOClient(client=mock_api_caller)
+    response = client.get_group_mapping(sso_alias="auth0", group_map_id="1234")
+    assert response == SSOMapper(**get_group_mapping_json)
+    assert mock_api_caller._call_api.call_count == 1
+    mock_api_caller.reset_mock()
+
+
+def test_sso_get_all_group_mapping(
+    mock_api_caller,
+    get_all_group_mapping_json,
+):
+    mock_api_caller._call_api.side_effect = [get_all_group_mapping_json]
+    client = SSOClient(client=mock_api_caller)
+    response = client.get_all_group_mappings(sso_alias="auth0")
+    assert response == parse_obj_as(List[SSOMapper], get_all_group_mapping_json)
+    assert mock_api_caller._call_api.call_count == 1
+    mock_api_caller.reset_mock()
+
+
+def test_sso_create_group_mapping_invalid_request_error(
+    mock_api_caller, get_all_group_mapping_json, create_group_mapping_json
+):
+    mock_api_caller._call_api.side_effect = [
+        get_all_group_mapping_json,
+        create_group_mapping_json,
+    ]
+    existing_atlan_group = AtlanGroup()
+    existing_atlan_group.alias = "existing_atlan_group"
+    existing_atlan_group.id = "atlan-group-guid-1234"
+    client = SSOClient(client=mock_api_caller)
+
+    with pytest.raises(InvalidRequestError) as err:
+        client.create_group_mapping(
+            sso_alias="auth0",
+            atlan_group=existing_atlan_group,
+            sso_group_name="sso-group",
+        )
+    assert (
+        f"ATLAN-PYTHON-400-058 SSO group mapping already exists between "
+        f"{existing_atlan_group.alias} (Atlan group) <-> test-sso-group (SSO group)"
+    ) in str(err.value)
+    assert mock_api_caller._call_api.call_count == 1
+    mock_api_caller.reset_mock()
+
+
+def test_sso_create_group_mapping(
+    mock_api_caller, get_all_group_mapping_json, create_group_mapping_json
+):
+    mock_api_caller._call_api.side_effect = [
+        get_all_group_mapping_json,
+        create_group_mapping_json,
+    ]
+    # Group that doesn't exist in sso group mappings
+    atlan_group = AtlanGroup()
+    atlan_group.id = "atlan-group-new-mapping-guid-1234"
+    client = SSOClient(client=mock_api_caller)
+    response = client.create_group_mapping(
+        sso_alias="auth0",
+        atlan_group=atlan_group,
+        sso_group_name="sso-group",
+    )
+    assert response == SSOMapper(**create_group_mapping_json)
+    assert mock_api_caller._call_api.call_count == 2
+    mock_api_caller.reset_mock()
+
+
+def test_sso_update_group_mapping(mock_api_caller, update_group_mapping_json):
+    mock_api_caller._call_api.side_effect = [
+        update_group_mapping_json,
+    ]
+    client = SSOClient(client=mock_api_caller)
+    response = client.update_group_mapping(
+        sso_alias="auth0",
+        atlan_group=AtlanGroup(),
+        group_map_id="group-map-id",
+        sso_group_name="sso-group",
+    )
+    assert response == SSOMapper(**update_group_mapping_json)
+    assert mock_api_caller._call_api.call_count == 1
+    mock_api_caller.reset_mock()
+
+
+def test_sso_delete_group_mapping(mock_api_caller):
+    mock_api_caller._call_api.side_effect = [None]
+    client = SSOClient(client=mock_api_caller)
+    response = client.delete_group_mapping(
+        sso_alias="auth0",
+        group_map_id="group-map-id",
+    )
+    assert response is None
+    assert mock_api_caller._call_api.call_count == 1
+    mock_api_caller.reset_mock()

--- a/tests/unit/test_sso_client.py
+++ b/tests/unit/test_sso_client.py
@@ -205,7 +205,8 @@ def test_sso_get_all_group_mapping(
     mock_api_caller._call_api.side_effect = [get_all_group_mapping_json]
     client = SSOClient(client=mock_api_caller)
     response = client.get_all_group_mappings(sso_alias="auth0")
-    assert response == parse_obj_as(List[SSOMapper], get_all_group_mapping_json)
+    # Only returns group mapping
+    assert response == parse_obj_as(List[SSOMapper], [get_all_group_mapping_json[2]])
     assert mock_api_caller._call_api.call_count == 1
     mock_api_caller.reset_mock()
 


### PR DESCRIPTION
### Sample usage

```py
from pyatlan.client.atlan import AtlanClient

client = AtlanClient()

group = client.group.get_by_name("test-group-2")[0]


# Retrieve all
response = client.sso.get_all_group_mappings(sso_alias="auth0")

# Create
response = client.sso.create_group_mapping(
    sso_alias="auth0",
    atlan_group=group,
    sso_group_name="sso_create_1234",
)

# Retrieve
group_map_id = "0637576a-5419-40d7-b6cb-fe5841b1da4b"
response = client.sso.get_group_mapping(
    sso_alias="auth0",
    group_map_id=group_map_id,
)

# Update
response = client.sso.update_group_mapping(
    sso_alias="auth0",
    atlan_group=group,
    group_map_id=group_map_id,
    sso_group_name="sso_update_1234",
)

# Delete
response = client.sso.delete_group_mapping(sso_alias="auth0", group_map_id=group_map_id)
```

### Todos
- [x] Add tests.
- [x] Add dev docs.