### PR TITLE
req-changes: Use string presigned URL

### DIFF
--- a/pyatlan/client/file.py
+++ b/pyatlan/client/file.py
@@ -7,7 +7,7 @@ from pyatlan.client.constants import (
     PRESIGNED_URL_UPLOAD,
 )
 from pyatlan.errors import ErrorCode
-from pyatlan.model.file import PresignedURLRequest, PresignedURLResponse
+from pyatlan.model.file import CloudStorageIdentifier, PresignedURLRequest
 
 
 class FileClient:
@@ -22,17 +22,8 @@ class FileClient:
             )
         self._client = client
 
-    @staticmethod
-    def _detect_cloud_storage(url: str) -> str:
-        if PresignedURLResponse.CloudStorageIdentifier.S3 in url:
-            return PresignedURLResponse.CloudStorageIdentifier.S3.name
-        else:
-            return PresignedURLResponse.CloudStorageIdentifier.UNSUPPORTED.name
-
     @validate_arguments
-    def generate_presigned_url(
-        self, request: PresignedURLRequest
-    ) -> PresignedURLResponse:
+    def generate_presigned_url(self, request: PresignedURLRequest) -> str:
         """
         Generates a presigned URL based on Atlan's tenant object store.
 
@@ -42,16 +33,14 @@ class FileClient:
         :returns: a response object containing a presigned URL with its cloud provider.
         """
         raw_json = self._client._call_api(PRESIGNED_URL, request_obj=request)
-        presigned_url = raw_json and raw_json.get("url", "")
-        cloud_storage = self._detect_cloud_storage(presigned_url)
-        return PresignedURLResponse(url=presigned_url, cloud_storage=cloud_storage)
+        return raw_json and raw_json.get("url", "")
 
     @validate_arguments
-    def upload_file(self, url_response: PresignedURLResponse, file_path: str) -> None:
+    def upload_file(self, presigned_url: str, file_path: str) -> None:
         """
         Uploads a file to Atlan's object storage.
 
-        :param url_response: instance of a generated PresignedURLResponse (method : PUT).
+        :param presigned_url: any valid presigned URL.
         :param file_path: path to the file to be uploaded.
         :raises AtlanError: on any error during API invocation.
         :raises InvalidRequestException: if the upload file path is invalid,
@@ -63,14 +52,11 @@ class FileClient:
             raise ErrorCode.INVALID_UPLOAD_FILE_PATH.exception_with_parameters(
                 str(err.strerror), file_path
             )
-        if (
-            url_response.cloud_storage
-            == PresignedURLResponse.CloudStorageIdentifier.S3.name
-        ):
+        if CloudStorageIdentifier.S3 in presigned_url:
             return self._client._s3_presigned_url_file_upload(
                 upload_file=upload_file,
                 api=PRESIGNED_URL_UPLOAD.format_path(
-                    {"presigned_url_put": url_response.url}
+                    {"presigned_url_put": presigned_url}
                 ),
             )
         else:
@@ -79,13 +65,13 @@ class FileClient:
     @validate_arguments
     def download_file(
         self,
-        url_response: PresignedURLResponse,
+        presigned_url: str,
         file_path: str,
     ) -> str:
         """
         Downloads a file from Atlan's tenant object storage.
 
-        :param url_response: instance of a generated PresignedURLResponse (method: GET).
+        :param presigned_url: any valid presigned URL.
         :param file_path: path to the file where you want to download the file.
         :raises InvalidRequestException: if unable to download the file.
         :raises AtlanError: on any error during API invocation.
@@ -94,6 +80,6 @@ class FileClient:
         return self._client._presigned_url_file_download(
             file_path=file_path,
             api=PRESIGNED_URL_DOWNLOAD.format_path(
-                {"presigned_url_get": url_response.url}
+                {"presigned_url_get": presigned_url}
             ),
         )

--- a/pyatlan/model/file.py
+++ b/pyatlan/model/file.py
@@ -17,12 +17,7 @@ class PresignedURLRequest(AtlanObject):
         PUT = "PUT"
 
 
-class PresignedURLResponse(AtlanObject):
-    url: str
-    cloud_storage: str
-
-    class CloudStorageIdentifier(str, Enum):
-        S3 = "amazonaws.com"
-        GCS = "storage.googleapis.com"
-        AZURE_BLOB = "blob.core.windows.net"
-        UNSUPPORTED = "unsupported"
+class CloudStorageIdentifier(str, Enum):
+    S3 = "amazonaws.com"
+    GCS = "storage.googleapis.com"
+    AZURE_BLOB = "blob.core.windows.net"

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -550,10 +550,10 @@ def test_glossary_category_remove_announcement(
 
 def test_workflow_find_by_type(client: AtlanClient):
     results = client.workflow.find_by_type(
-        prefix=WorkflowPackage.FIVETRAN, max_results=10
+        prefix=WorkflowPackage.SNOWFLAKE, max_results=10
     )
     assert results
-    assert len(results) == 1
+    assert len(results) >= 1
 
 
 def test_audit_find_by_user(

--- a/tests/integration/test_index_search.py
+++ b/tests/integration/test_index_search.py
@@ -168,7 +168,7 @@ def test_search_next_when_start_changed_returns_remaining(client: AtlanClient):
     size = 2
     dsl = DSL(
         query=Term.with_state("ACTIVE"),
-        post_filter=Term.with_type_name("Database"),
+        post_filter=Term.with_type_name("Table"),
         size=size,
     )
     request = IndexSearchRequest(

--- a/tests/unit/constants.py
+++ b/tests/unit/constants.py
@@ -1,5 +1,4 @@
 from pyatlan.model.assets import AtlasGlossary
-from pyatlan.model.file import PresignedURLResponse
 
 TEST_ASSET_CLIENT_METHODS = {
     "find_personas_by_name": [
@@ -442,26 +441,26 @@ TEST_FILE_CLIENT_METHODS = {
         ([None], "none is not an allowed value"),
     ],
     "upload_file": [
-        ([[123], "file-path"], "url_response\n  value is not a valid dict"),
+        ([[123], "file-path"], "presigned_url\n  str type expected"),
         ([None, "file-path"], "none is not an allowed value"),
         (
-            [PresignedURLResponse(url="test-url", cloud_storage="S3"), [123]],
+            ["test-url", [123]],
             "file_path\n  str type expected",
         ),
         (
-            [PresignedURLResponse(url="test-url", cloud_storage="S3"), None],
+            ["test-url", None],
             "none is not an allowed value",
         ),
     ],
     "download_file": [
-        ([[123], "file-path"], "url_response\n  value is not a valid dict"),
+        ([[123], "file-path"], "presigned_url\n  str type expected"),
         ([None, "file-path"], "none is not an allowed value"),
         (
-            [PresignedURLResponse(url="test-url", cloud_storage="S3"), [123]],
+            ["test-url", [123]],
             "file_path\n  str type expected",
         ),
         (
-            [PresignedURLResponse(url="test-url", cloud_storage="S3"), None],
+            ["test-url", None],
             "none is not an allowed value",
         ),
     ],


### PR DESCRIPTION
- Moved presigned URL cloud detection logic directly to the `FileClient.upload_file()` method.
https://github.com/atlanhq/atlan-developer-portal/pull/288#discussion_r1583436547