### PR TITLE
DVX-432: Utilize generated `atlas core` enums in the template

### DIFF
--- a/pyatlan/generator/class_generator.py
+++ b/pyatlan/generator/class_generator.py
@@ -635,12 +635,13 @@ class Generator:
     def render_modules(self, modules: List[ModuleInfo]):
         self.render_init(modules)  # type: ignore
 
-    def render_module(self, asset_info: AssetInfo):
+    def render_module(self, asset_info: AssetInfo, enum_defs: List["EnumDefInfo"]):
         template = self.environment.get_template("module.jinja2")
         content = template.render(
             {
                 "asset_info": asset_info,
                 "existz": os.path.exists,
+                "enum_defs": enum_defs,
             }
         )
         with (ASSETS_DIR / f"{asset_info.module_name}.py").open("w") as script:
@@ -830,11 +831,11 @@ if __name__ == "__main__":
     for file in (ASSETS_DIR).glob("*.py"):
         file.unlink()
     generator = Generator()
+    EnumDefInfo.create(type_defs.enum_defs)
     for asset_info in ModuleInfo.assets.values():
-        generator.render_module(asset_info)
+        generator.render_module(asset_info, EnumDefInfo.enum_def_info)
     generator.render_init(ModuleInfo.assets.values())  # type: ignore
     generator.render_structs(type_defs.struct_defs)
-    EnumDefInfo.create(type_defs.enum_defs)
     generator.render_enums(EnumDefInfo.enum_def_info)
     generator.render_docs_struct_snippets(type_defs.struct_defs)
     generator.render_docs_entity_properties(type_defs.reserved_entity_defs)

--- a/pyatlan/generator/templates/module.jinja2
+++ b/pyatlan/generator/templates/module.jinja2
@@ -6,6 +6,12 @@
 
 {% include 'imports.jinja2' %}
 
+from pyatlan.model.enums import (
+{% for enum in enum_defs %}
+{{ enum.name }},
+{% endfor %}
+)
+
 {% if asset_info.name != 'Referenceable' and asset_info.name != 'Asset' %}
 from .asset import SelfAsset
 {% endif %}


### PR DESCRIPTION
When a new `atlas_core` enum is introduced and generated models depend on those enums, a `NameError` occurs due to the hardcoding of [enums in the template](https://github.com/atlanhq/atlan-python/blob/main/pyatlan/generator/templates/imports.jinja2#L18). This issue arises because the hardcoded enums are not up-to-date with the latest enums. To address this problem, I inject the atlas enums directly into the template. However, I retain the hardcoded enums import statement in the template, as it contains all enums (both `pyatlan` defined and `generated enums`). After generation, pre-commit formatting checks are used to clean up any duplicate or unused import statements.