### PR TITLE
Fixes typo in `IAM` role methods of `DynamoDB` and `PostgreSQL` crawlers

### DIFF
--- a/pyatlan/model/packages/dynamo_d_b_crawler.py
+++ b/pyatlan/model/packages/dynamo_d_b_crawler.py
@@ -87,7 +87,7 @@ class DynamoDBCrawler(AbstractCrawler):
         self._credentials_body.update(local_creds)
         return self
 
-    def iam_user_role_auth(self, arn: str, external_id: str) -> DynamoDBCrawler:
+    def iam_role_auth(self, arn: str, external_id: str) -> DynamoDBCrawler:
         """
         Set up the crawler to use IAM role-based authentication.
 

--- a/pyatlan/model/packages/postgres_crawler.py
+++ b/pyatlan/model/packages/postgres_crawler.py
@@ -121,7 +121,7 @@ class PostgresCrawler(AbstractCrawler):
         """
         Set up the crawler to use IAM user-based authentication.
 
-        :param username: username for the IAM user
+        :param username: database username to extract from
         :param access_key: through which to access PostgreSQL
         :param secret_key: through which to access PostgreSQL
         :returns: crawler, set up to use IAM user-based authentication
@@ -136,13 +136,13 @@ class PostgresCrawler(AbstractCrawler):
         self._credentials_body.update(local_creds)
         return self
 
-    def iam_user_role_auth(
+    def iam_role_auth(
         self, username: str, arn: str, external_id: str
     ) -> PostgresCrawler:
         """
-        Set up the crawler to use IAM user role-based authentication.
+        Set up the crawler to use IAM role-based authentication.
 
-        :param username: username for the IAM user
+        :param username: database username to extract from
         :param arn: ARN of the AWS role
         :param external_id: AWS external ID
         :returns: crawler, set up to use IAM user role-based authentication

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -470,7 +470,7 @@ def test_dynamo_db_package(mock_package_env):
             connection_name="test-dynamodb-conn", admin_roles=["admin-guid-1234"]
         )
         .direct(region="test-region")
-        .iam_user_role_auth(
+        .iam_role_auth(
             arn="arn:aws:iam::123456789012:user/test", external_id="test-ext-id"
         )
         .include_regex(regex=".*_TEST_INCLUDE")
@@ -535,7 +535,7 @@ def test_postgres_package(mock_package_env):
             admin_roles=["admin-guid-1234"],
         )
         .direct(hostname="test.com", database="test-db")
-        .iam_user_role_auth(
+        .iam_role_auth(
             username="test-user",
             arn="arn:aws:iam::123456789012:user/test",
             external_id="test-ext-id",


### PR DESCRIPTION
I found this while working on: https://github.com/atlanhq/atlan-developer-portal/pull/301. This will result in a [breaking change](https://github.com/atlanhq/atlan-python/pull/327). Moving forward, I'll aim to merge docs PRs first and then cut the release here to prevent such issues in the future.