### PR TITLE
DVX-398: Removed the required kwarg (`name`) from the `DataContract` `creator()`

### DIFF
--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -530,6 +530,13 @@ class ErrorCode(Enum):
         "Please raise a feature request on the Python SDK GitHub to add support for it.",
         InvalidRequestError,
     )
+    INVALID_CONTRACT_JSON = (
+        400,
+        "ATLAN-PYTHON-400-062",
+        "Provided data contract JSON is invalid.",
+        "Please double-check your provided data contract JSON.",
+        InvalidRequestError,
+    )
     AUTHENTICATION_PASSTHROUGH = (
         401,
         "ATLAN-PYTHON-401-000",

--- a/pyatlan/generator/templates/imports.jinja2
+++ b/pyatlan/generator/templates/imports.jinja2
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import sys
 import uuid
+from json import loads
+from json.decoder import JSONDecodeError
 from datetime import datetime
 from io import StringIO
 from typing import Any, ClassVar, Dict, List, Optional, Set, Type, TypeVar, TYPE_CHECKING, cast, overload

--- a/pyatlan/generator/templates/methods/asset/data_contract.jinja2
+++ b/pyatlan/generator/templates/methods/asset/data_contract.jinja2
@@ -1,15 +1,12 @@
 
     @classmethod
     @init_guid
-    def creator(
-        cls, *, name: str, asset_qualified_name: str, contract_json: str
-    ) -> DataContract:
+    def creator(cls, *, asset_qualified_name: str, contract_json: str) -> DataContract:
         validate_required_fields(
-            ["name", "asset_qualified_name", "contract_json"],
-            [name, asset_qualified_name, contract_json],
+            ["asset_qualified_name", "contract_json"],
+            [asset_qualified_name, contract_json],
         )
         attributes = DataContract.Attributes.creator(
-            name=name,
             asset_qualified_name=asset_qualified_name,
             contract_json=contract_json,
         )

--- a/pyatlan/generator/templates/methods/attribute/data_contract.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/data_contract.jinja2
@@ -2,14 +2,19 @@
         @classmethod
         @init_guid
         def creator(
-            cls, *, name: str, asset_qualified_name: str, contract_json: str
+            cls, *, asset_qualified_name: str, contract_json: str
         ) -> DataContract.Attributes:
             validate_required_fields(
-                ["name", "asset_qualified_name", "contract_json"],
-                [name, asset_qualified_name, contract_json],
+                ["asset_qualified_name", "contract_json"],
+                [asset_qualified_name, contract_json],
             )
+            try:
+                contract_name = f"Data contract for {loads(contract_json)['dataset']}"
+            except (JSONDecodeError, KeyError):
+                raise ErrorCode.INVALID_CONTRACT_JSON.exception_with_parameters()
+
             return DataContract.Attributes(
-                name=name,
+                name=contract_name,
                 qualified_name=f"{asset_qualified_name}/contract",
                 data_contract_json=contract_json,
             )

--- a/tests/unit/model/constants.py
+++ b/tests/unit/model/constants.py
@@ -94,7 +94,6 @@ DATA_PRODUCT_QUALIFIED_NAME = (
 DATA_PRODUCT_UNDER_SUB_DOMAIN_QUALIFIED_NAME = (
     f"{DATA_SUB_DOMAIN_QUALIFIED_NAME}/product/{DATA_PRODUCT_NAME}"
 )
-DATA_CONTRACT_NAME = "data-contract"
 ASSET_QUALIFIED_NAME = "some-asset-qualified-name"
 DATA_CONTRACT_QUALIFIED_NAME = f"{ASSET_QUALIFIED_NAME}/contract"
 DATA_CONTRACT_JSON = {
@@ -104,6 +103,7 @@ DATA_CONTRACT_JSON = {
     "data_source": ASSET_QUALIFIED_NAME,
     "dataset": "some-asset-name",
 }
+DATA_CONTRACT_NAME = f"Data contract for {DATA_CONTRACT_JSON['dataset']}"
 CP_NAME = "column-process"
 CP_PROCESS_ID = "cp-process-id"
 CP_CONNECTION_QUALIFIED_NAME = "default/vertica/123456789"

--- a/tests/unit/model/constants.py
+++ b/tests/unit/model/constants.py
@@ -100,7 +100,7 @@ DATA_CONTRACT_JSON = {
     "type": "Table",
     "status": "DRAFT",
     "kind": "DataContract",
-    "data_source": ASSET_QUALIFIED_NAME,
+    "data_source": "some-asset-connection-name",
     "dataset": "some-asset-name",
 }
 DATA_CONTRACT_NAME = f"Data contract for {DATA_CONTRACT_JSON['dataset']}"


### PR DESCRIPTION
- Updated `creator()` to use the **Atlan CLI** approach to construct the `DataContract` **name**.

### Sample snippet:

```py
from json import dumps
from pyatlan.client.atlan import AtlanClient
from pyatlan.model.assets import DataContract
from pyatlan.model.enums import CertificateStatus

contract_json = {
    "type": table.type_name,
    "status": CertificateStatus.DRAFT,
    "kind": "DataContract",
    "data_source": connection.name,
    "dataset": table.name,
    "description": "Automated testing of the Python SDK.",
}

contract = DataContract.creator(
    asset_qualified_name=table.qualified_name,
    contract_json=dumps(contract_json),
)

response = client.asset.save(contract)
```