### PR TITLE
DVX-488: Implement infinite paging approach

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -190,18 +190,10 @@ class AssetClient:
         aggregations = self._get_aggregations(raw_json)
         count = raw_json.get("approximateCount", 0)
 
-        if (
-            count > IndexSearchResults._MASS_EXTRACT_THRESHOLD
-            and not IndexSearchResults.presorted_by_timestamp(criteria.dsl.sort)
-        ):
-            if not bulk:
-                raise ErrorCode.ENABLE_BULK_FOR_MASS_EXTRACTION.exception_with_parameters(
-                    IndexSearchResults._MASS_EXTRACT_THRESHOLD
-                )
-            # Re-fetch the first page results with updated timestamp sorting
-            # for bulk search if count > _MASS_EXTRACT_THRESHOLD (100,000 assets)
-            criteria.dsl.sort = self._prepare_sorts_for_bulk_search(criteria.dsl.sort)
-            return self.search(criteria)
+        if not bulk and count > IndexSearchResults._MASS_EXTRACT_THRESHOLD:
+            raise ErrorCode.ENABLE_BULK_FOR_MASS_EXTRACTION.exception_with_parameters(
+                IndexSearchResults._MASS_EXTRACT_THRESHOLD
+            )
 
         return IndexSearchResults(
             client=self._client,

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -537,6 +537,20 @@ class ErrorCode(Enum):
         "Please double-check your provided data contract JSON.",
         InvalidRequestError,
     )
+    UNABLE_TO_RUN_BULK_WITH_SORTS = (
+        400,
+        "ATLAN-PYTHON-400-063",
+        "Unable to execute bulk search with user-defined sorting options.",
+        "Please ensure that no sorting options are included in your search request when performing a bulk search.",
+        InvalidRequestError,
+    )
+    ENABLE_BULK_FOR_MASS_EXTRACTION = (
+        400,
+        "ATLAN-PYTHON-400-063",
+        "Number of results exceeds the predefined threshold {}. Please execute the search again with `bulk=True`.",
+        "Please note that this will reorder the results based on creation timestamp to efficiently handle a large number of results.",  # noqa
+        InvalidRequestError,
+    )
     AUTHENTICATION_PASSTHROUGH = (
         401,
         "ATLAN-PYTHON-401-000",

--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -399,19 +399,13 @@ class FluentSearch(CompoundQuery):
         request = IndexSearchRequest(dsl=dsl)
         return client.asset.search(request).count
 
-    def execute(
-        self, client: AtlanClient, infinite_paging: bool = False
-    ) -> IndexSearchResults:
+    def execute(self, client: AtlanClient) -> IndexSearchResults:
         """
         Run the fluent search to retrieve assets that match the supplied criteria.
 
         :param client: client through which to retrieve the assets
-        :param infinite_paging: whether to use infinite paging approach or not, defaults to `False`
         :returns: an iterable list of assets that match the supplied criteria, lazily-fetched
         """
-        if not infinite_paging:
-            return client.asset.search(self.to_request())
-
         if not IndexSearchResults.presorted_by_timestamp(self.sorts):
             # Pre-sort by creation time (ascending) for mass-sequential iteration,
             # if not already sorted by creation time first

--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -402,13 +402,11 @@ class FluentSearch(CompoundQuery):
     def execute(self, client: AtlanClient, bulk: bool = False) -> IndexSearchResults:
         """
         Run the fluent search to retrieve assets that match the supplied criteria.
-        `Note:` if the number of results exceeds the predefined threshold
-        (100,000 assets) this will be automatically converted into a `bulk` search.
 
         :param client: client through which to retrieve the assets.
         :param bulk: whether to run the search to retrieve assets that match the supplied criteria,
-        for large numbers of results (> `100,000`). Note: this will reorder the results in order to iterate
-        through a large number (more than `100,000`) results, so any sort ordering you have specified may be ignored.
+        for large numbers of results (> `100,000`), defaults to `False`. Note: this will reorder the results
+        (based on creation timestamp) in order to iterate through a large number (more than `100,000`) results.
         :returns: an iterable list of assets that match the supplied criteria, lazily-fetched
         """
         return client.asset.search(criteria=self.to_request(), bulk=bulk)

--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -399,18 +399,19 @@ class FluentSearch(CompoundQuery):
         request = IndexSearchRequest(dsl=dsl)
         return client.asset.search(request).count
 
-    def execute(self, client: AtlanClient) -> IndexSearchResults:
+    def execute(self, client: AtlanClient, bulk: bool = False) -> IndexSearchResults:
         """
         Run the fluent search to retrieve assets that match the supplied criteria.
+        `Note:` if the number of results exceeds the predefined threshold
+        (100,000 assets) this will be automatically converted into a `bulk` search.
 
-        :param client: client through which to retrieve the assets
+        :param client: client through which to retrieve the assets.
+        :param bulk: whether to run the search to retrieve assets that match the supplied criteria,
+        for large numbers of results (> `100,000`). Note: this will reorder the results in order to iterate
+        through a large number (more than `100,000`) results, so any sort ordering you have specified may be ignored.
         :returns: an iterable list of assets that match the supplied criteria, lazily-fetched
         """
-        if not IndexSearchResults.presorted_by_timestamp(self.sorts):
-            # Pre-sort by creation time (ascending) for mass-sequential iteration,
-            # if not already sorted by creation time first
-            self.sorts = IndexSearchResults.sort_by_timestamp_first(self.sorts)
-        return client.asset.search(self.to_request())
+        return client.asset.search(criteria=self.to_request(), bulk=bulk)
 
 
 from pyatlan.client.atlan import AtlanClient  # noqa: E402

--- a/tests/integration/test_index_search.py
+++ b/tests/integration/test_index_search.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pyatlan.client.asset import LOGGER, IndexSearchResults
+from pyatlan.client.asset import LOGGER
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.assets import Asset, Table
 from pyatlan.model.assets.atlas_glossary_term import AtlasGlossaryTerm
@@ -248,28 +248,6 @@ def test_search_pagination(mock_logger, client: AtlanClient):
     assert mock_logger.call_count < TOTAL_ASSETS
     assert "Bulk search option is enabled." in mock_logger.call_args_list[0][0][0]
     mock_logger.reset_mock()
-
-    # Test search(): when the number of results exceeds the predefined threshold,
-    # the SDK automatically switches to a `bulk` search option using timestamp-based pagination.
-    with patch.object(IndexSearchResults, "_MASS_EXTRACT_THRESHOLD", 1):
-        request = (
-            FluentSearch()
-            .where(CompoundQuery.active_assets())
-            .where(CompoundQuery.asset_type(AtlasGlossaryTerm))
-            .page_size(2)
-        ).to_request()
-        results = client.asset.search(criteria=request)
-        expected_sorts = [
-            Asset.CREATE_TIME.order(SortOrder.ASCENDING),
-            Asset.GUID.order(SortOrder.ASCENDING),
-        ]
-        _assert_search_results(results, expected_sorts, size, TOTAL_ASSETS)
-        assert mock_logger.call_count < TOTAL_ASSETS
-        assert (
-            "Result size (%s) exceeds threshold (%s)."
-            in mock_logger.call_args_list[0][0][0]
-        )
-        mock_logger.reset_mock()
 
 
 def test_search_iter(client: AtlanClient):

--- a/tests/unit/data/search_responses/index_search_paging.json
+++ b/tests/unit/data/search_responses/index_search_paging.json
@@ -1,0 +1,115 @@
+{
+    "queryType": "INDEX",
+    "searchParameters": {
+      "showSearchScore": false,
+      "suppressLogs": false,
+      "excludeMeanings": false,
+      "excludeClassifications": false,
+      "includeClassificationNames": false,
+      "requestMetadata": {
+        "searchInput": null,
+        "utmTags": [
+          "project_sdk_python"
+        ],
+        "saveSearchLog": true
+      },
+      "async": {
+        "isCallAsync": false,
+        "searchContextId": null,
+        "searchContextSequenceNo": null,
+        "requestTimeoutInSecs": null
+      },
+      "showHighlights": false,
+      "dsl": {
+        "from": 0,
+        "size": 10,
+        "aggregations": {},
+        "track_total_hits": true,
+        "query": {
+          "bool": {
+            "filter": [
+              {
+                "term": {
+                  "__state": {
+                    "value": "ACTIVE",
+                    "case_insensitive": false
+                  }
+                }
+              },
+              {
+                "term": {
+                  "__typeName.keyword": {
+                    "value": "AtlasGlossaryTerm",
+                    "case_insensitive": false
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "sort": [
+          {
+            "__timestamp": {
+              "order": "asc"
+            }
+          },
+          {
+            "__guid": {
+              "order": "asc"
+            }
+          }
+        ]
+      },
+      "allowDeletedRelations": false,
+      "accessControlExclusive": false,
+      "query": "{\"from\":0,\"size\":10,\"aggregations\":{},\"track_total_hits\":true,\"query\":{\"bool\":{\"filter\":[{\"term\":{\"__state\":{\"value\":\"ACTIVE\",\"case_insensitive\":false}}},{\"term\":{\"__typeName.keyword\":{\"value\":\"AtlasGlossaryTerm\",\"case_insensitive\":false}}}]}},\"sort\":[{\"__timestamp\":{\"order\":\"asc\"}},{\"__guid\":{\"order\":\"asc\"}}]}",
+      "saveSearchLog": true,
+      "callAsync": false,
+      "utmTags": [
+        "project_sdk_python"
+      ]
+    },
+    "entities": [
+      {
+        "typeName": "AtlasGlossaryTerm",
+        "attributes": {
+          "qualifiedName": "FngX3ZMT2zkbZ9hmR0r4J@06VYiNgoIymrGSbO5pgBA",
+          "name": "Net Revenue Retention"
+        },
+        "guid": "045acd66-e6fc-470b-8383-4011fc66c385",
+        "status": "ACTIVE",
+        "displayText": "Net Revenue Retention",
+        "classificationNames": [],
+        "classifications": [],
+        "meaningNames": [],
+        "meanings": [],
+        "isIncomplete": false,
+        "labels": [],
+        "createdBy": "service-account-apikey-6c22ccb5-bf09-48cf-b300-05c121fd2ed8",
+        "updatedBy": "service-account-apikey-6c22ccb5-bf09-48cf-b300-05c121fd2ed8",
+        "createTime": 1717514296594,
+        "updateTime": 1717514301062
+      },
+      {
+        "typeName": "AtlasGlossaryTerm",
+        "attributes": {
+          "qualifiedName": "Axz1oe9r0mCPceOhu72Sr@YRlSMKbmqb61J1brCAYwD",
+          "name": "Customer"
+        },
+        "guid": "6fab3fea-b85d-488a-b474-7c9651ac6b7a",
+        "status": "ACTIVE",
+        "displayText": "Customer",
+        "classificationNames": [],
+        "classifications": [],
+        "meaningNames": [],
+        "meanings": [],
+        "isIncomplete": false,
+        "labels": [],
+        "createdBy": "service-account-apikey-6c22ccb5-bf09-48cf-b300-05c121fd2ed8",
+        "updatedBy": "service-account-apikey-6c22ccb5-bf09-48cf-b300-05c121fd2ed8",
+        "createTime": 1717514296594,
+        "updateTime": 1717514301062
+      }
+    ],
+    "approximateCount": 2
+}


### PR DESCRIPTION
The feature implements a new pagination approach for search, known as `bulk` search, based on asset creation timestamps. This approach is used when the number of results exceeds the predefined threshold (i.e: `100,000` assets). Users can explicitly run this search by setting the optional keyword argument `bulk=True` in the `FluentSearch.execute()` or `asset.search()` methods.

```py
results = (
    FluentSearch()
    .where(CompoundQuery.active_assets())
    .where(CompoundQuery.asset_type(AtlasGlossaryTerm))
    .page_size(2)
).execute(client, bulk=True)

request = (
    FluentSearch()
    .where(CompoundQuery.active_assets())
    .where(CompoundQuery.asset_type(AtlasGlossaryTerm))
    .page_size(2)
).to_request()

results = client.asset.search(criteria=request, bulk=True)
````