### PR TITLE
ci: Removed `pytest-sugar` plugin from test cron

### DIFF
--- a/.github/workflows/pyatlan-test-cron.yaml
+++ b/.github/workflows/pyatlan-test-cron.yaml
@@ -39,5 +39,5 @@ jobs:
         # Run the integration test suite using the `pytest-timer` plugin
         # to display only the durations of the 25 slowest tests with `pytest-sugar`
         run: |
-          pytest tests/unit --force-sugar
-          pytest tests/integration  -p name_of_plugin --timer-top-n 25 --force-sugar
+          pytest tests/unit
+          pytest tests/integration  -p name_of_plugin --timer-top-n 25


### PR DESCRIPTION
- this change will improve test results readability in the [GH actions.](https://github.com/atlanhq/atlan-python/actions/runs/10051075019/job/27780049060)