### PR TITLE
DVX-579: Ensure the asset to which the `README` is attached has a `GUID`

### DIFF
--- a/pyatlan/generator/templates/methods/attribute/readme.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/readme.jinja2
@@ -16,6 +16,11 @@
                 )
             else:
                 asset_name = asset.name
+            if not asset.guid:
+                raise ValueError(
+                    "asset guid must be present, use the client.asset.ref_by_guid() "
+                    "method to retrieve an asset by its GUID"
+                )
             return Readme.Attributes(
                 qualified_name=f"{asset.guid}/readme",
                 name=f"{asset_name} Readme",

--- a/pyatlan/model/assets/core/readme.py
+++ b/pyatlan/model/assets/core/readme.py
@@ -128,6 +128,11 @@ class Readme(Resource):
                 )
             else:
                 asset_name = asset.name
+            if not asset.guid:
+                raise ValueError(
+                    "asset guid must be present, use the client.asset.ref_by_guid() "
+                    "method to retrieve an asset by its GUID"
+                )
             return Readme.Attributes(
                 qualified_name=f"{asset.guid}/readme",
                 name=f"{asset_name} Readme",

--- a/tests/unit/model/readme_test.py
+++ b/tests/unit/model/readme_test.py
@@ -58,6 +58,7 @@ def test_create_readme_without_required_parameters_raises_exception(
     ],
 )
 def test_create_readme(asset, content, asset_name, expected_name):
+    asset.guid = "test-guid-123"
     readme = Readme.create(asset=asset, content=content, asset_name=asset_name)
     assert readme.qualified_name == f"{asset.guid}/readme"
     assert readme.name == f"{expected_name} Readme"

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from inspect import signature
 from pathlib import Path
+from re import escape
 from unittest.mock import create_autospec
 
 import pytest
@@ -911,3 +912,18 @@ def test_create_for_modification_on_asset_raises_exception():
         "class. Please invoke on a specific asset type",
     ):
         Asset.create_for_modification(qualified_name="", name="")
+
+
+def test_readme_creator_asset_guid_validation():
+    with pytest.raises(
+        ValueError,
+        match=escape(
+            "asset guid must be present, use the client.asset.ref_by_guid() "
+            "method to retrieve an asset by its GUID"
+        ),
+    ):
+        Readme.creator(
+            asset=Asset.ref_by_qualified_name("test-qn"),
+            content="<h1>Test Content</h1>",
+            asset_name="test-readme",
+        )


### PR DESCRIPTION
This prevents users from updating a `README` `relationshipGuid` where the `relationshipStatus` is `DELETED` (when the asset `GUID` is absent). This restriction ensures users must use `ref_by_guid` rather than `ref_by_qualified_name`, ensuring that a new `README` is created instead of updating an existing one.