### PR TITLE
DVX-522: Added initial support for sending `OpenLineage` events 

### DIFF
--- a/pyatlan/client/common.py
+++ b/pyatlan/client/common.py
@@ -19,7 +19,12 @@ CONNECTION_RETRY = Retry(
 @runtime_checkable
 class ApiCaller(Protocol):
     def _call_api(
-        self, api, query_params=None, request_obj=None, exclude_unset: bool = True
+        self,
+        api,
+        query_params=None,
+        request_obj=None,
+        exclude_unset: bool = True,
+        text_response: bool = False,
     ):
         pass
 

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -602,3 +602,10 @@ CONTRACT_INIT_API = API(
     HTTPStatus.OK,
     endpoint=EndPoint.HERACLES,
 )
+OPEN_LINEAGE_API = "/api/v1/lineage"
+OPEN_LINEAGE_SEND_EVENT_API = API(
+    "{connector_type}" + OPEN_LINEAGE_API,
+    HTTPMethod.POST,
+    HTTPStatus.ACCEPTED,
+    endpoint=EndPoint.CHRONOS,
+)

--- a/pyatlan/client/open_lineage.py
+++ b/pyatlan/client/open_lineage.py
@@ -1,0 +1,47 @@
+from http import HTTPStatus
+
+from pydantic.v1 import validate_arguments
+
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.constants import OPEN_LINEAGE_SEND_EVENT_API
+from pyatlan.errors import AtlanError, ErrorCode
+from pyatlan.model.enums import AtlanConnectorType
+from pyatlan.model.open_lineage.event import OpenLineageEvent
+
+
+class OpenLineageClient:
+    """
+    A client for interacting with OpenLineage.
+    """
+
+    def __init__(self, client: ApiCaller):
+        if not isinstance(client, ApiCaller):
+            raise ErrorCode.INVALID_PARAMETER_TYPE.exception_with_parameters(
+                "client", "ApiCaller"
+            )
+        self._client = client
+
+    @validate_arguments
+    def send(
+        self, request: OpenLineageEvent, connector_type: AtlanConnectorType
+    ) -> str:
+        try:
+            response = self._client._call_api(
+                request_obj=request,
+                api=OPEN_LINEAGE_SEND_EVENT_API.format_path(
+                    {"connector_type": connector_type}
+                ),
+                text_response=True,
+            )
+            return response
+        except AtlanError as e:
+            if (
+                e.error_code.http_error_code == HTTPStatus.UNAUTHORIZED
+                and e.error_code.error_message.startswith(
+                    "Unauthorized: url path not configured to receive data, urlPath:"
+                )
+            ):
+                raise ErrorCode.OPENLINEAGE_NOT_CONFIGURED.exception_with_parameters(
+                    connector_type
+                ) from e
+            raise e

--- a/pyatlan/client/open_lineage.py
+++ b/pyatlan/client/open_lineage.py
@@ -30,7 +30,7 @@ class OpenLineageClient:
 
         :param request: OpenLineage event to send
         :param connector_type: of the connection that should receive the OpenLineage event
-        :raises AtlanError: on any issues with API communication
+        :raises AtlanError: when OpenLineage is not configured OR on any issues with API communication
         """
 
         try:

--- a/pyatlan/client/open_lineage.py
+++ b/pyatlan/client/open_lineage.py
@@ -24,16 +24,23 @@ class OpenLineageClient:
     @validate_arguments
     def send(
         self, request: OpenLineageEvent, connector_type: AtlanConnectorType
-    ) -> str:
+    ) -> None:
+        """
+        Sends the OpenLineage event to Atlan to be consumed.
+
+        :param request: OpenLineage event to send
+        :param connector_type: of the connection that should receive the OpenLineage event
+        :raises AtlanError: on any issues with API communication
+        """
+
         try:
-            response = self._client._call_api(
+            self._client._call_api(
                 request_obj=request,
                 api=OPEN_LINEAGE_SEND_EVENT_API.format_path(
                     {"connector_type": connector_type}
                 ),
                 text_response=True,
             )
-            return response
         except AtlanError as e:
             if (
                 e.error_code.http_error_code == HTTPStatus.UNAUTHORIZED

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -547,6 +547,14 @@ class ErrorCode(Enum):
         "Please ensure that no sorting options are included in your search request when performing a bulk search.",
         InvalidRequestError,
     )
+    OPENLINEAGE_NOT_CONFIGURED = (
+        400,
+        "ATLAN-PYTHON-400-064",
+        "Requested OpenLineage connector type '{0}' is not configured.",
+        "You must first run the appropriate marketplace package to "
+        + "configure OpenLineage for this connector before you can send events for it.",
+        InvalidRequestError,
+    )
     AUTHENTICATION_PASSTHROUGH = (
         401,
         "ATLAN-PYTHON-401-000",

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -2317,6 +2317,8 @@ class AtlanMeshColor(str, Enum):
 class DataContractStatus(Enum):
     DRAFT = "draft"
     VERIFIED = "verified"
+
+
 class OpenLineageEventType(Enum):
     """
     Current transition of the run state.

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -2317,6 +2317,19 @@ class AtlanMeshColor(str, Enum):
 class DataContractStatus(Enum):
     DRAFT = "draft"
     VERIFIED = "verified"
+class OpenLineageEventType(Enum):
+    """
+    Current transition of the run state.
+    It is required to issue 1 START event
+    and 1 of [COMPLETE, ABORT, FAIL ] event per run.
+    """
+
+    START = "START"
+    RUNNING = "RUNNING"
+    COMPLETE = "COMPLETE"
+    ABORT = "ABORT"
+    FAIL = "FAIL"
+    OTHER = "OTHER"
 
 
 # **************************************

--- a/pyatlan/model/open_lineage/__init__.py
+++ b/pyatlan/model/open_lineage/__init__.py
@@ -1,6 +1,5 @@
-# # flake8: noqa
-# from .event import OpenLineageEvent
-# from .job import OpenLineageJob
-# from .run import OpenLineageRun
+from .event import OpenLineageEvent
+from .job import OpenLineageJob
+from .run import OpenLineageRun
 
-# __all__ = ["OpenLineageEvent", "OpenLineageJob", "OpenLineageRun"]
+__all__ = ["OpenLineageEvent", "OpenLineageJob", "OpenLineageRun"]

--- a/pyatlan/model/open_lineage/__init__.py
+++ b/pyatlan/model/open_lineage/__init__.py
@@ -1,0 +1,6 @@
+# # flake8: noqa
+# from .event import OpenLineageEvent
+# from .job import OpenLineageJob
+# from .run import OpenLineageRun
+
+# __all__ = ["OpenLineageEvent", "OpenLineageJob", "OpenLineageRun"]

--- a/pyatlan/model/open_lineage/base.py
+++ b/pyatlan/model/open_lineage/base.py
@@ -1,0 +1,71 @@
+from typing import Optional
+from urllib.parse import urlparse
+
+from dateutil import parser  # type:ignore[import-untyped]
+from pydantic.v1 import Field, validator
+
+from pyatlan.model.core import AtlanObject
+
+
+class OpenLineageBaseEvent(AtlanObject):
+    event_time: Optional[str] = Field(
+        default=None, description="time the event occurred at", alias="eventTime"
+    )
+    producer: Optional[str] = Field(default=None, description="producer of the event")
+    schema_url: Optional[str] = Field(
+        default="https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        description="Schema URL for the event",
+        alias="schemaURL",
+        const=True,
+    )
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.schema_url = self._get_schema()
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/BaseEvent"
+
+    @validator("event_time")
+    def validate_event_time(cls, value: str) -> str:
+        # Parse and validate the ISO format
+        parser.isoparse(value)
+        if "t" not in value.lower():
+            raise ValueError(f"Parsed date-time has to contain time: {value}")
+        return value
+
+    @validator("producer")
+    def validate_producer(cls, value: str) -> str:
+        urlparse(value)
+        return value
+
+    @validator("schema_url")
+    def validate_schema_url(cls, value: str) -> str:
+        urlparse(value)
+        return value
+
+
+class OpenLineageBaseFacet(AtlanObject):
+    """All fields of the base facet are prefixed with _ to avoid name conflicts in facets"""
+
+    producer: Optional[str] = Field(default=None, alias="_producer")
+    schema_url: Optional[str] = Field(default=None, alias="_schemaURL")
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/BaseFacet"
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.schema_url = self._get_schema()
+
+    @validator("producer")
+    def validate_producer(cls, value: str) -> str:
+        urlparse(value)
+        return value
+
+    @validator("schema_url")
+    def validate_schema_url(cls, value: str) -> str:
+        urlparse(value)
+        return value

--- a/pyatlan/model/open_lineage/base.py
+++ b/pyatlan/model/open_lineage/base.py
@@ -8,6 +8,10 @@ from pyatlan.model.core import AtlanObject
 
 
 class OpenLineageBaseEvent(AtlanObject):
+    """
+    Base model for OpenLineage events.
+    """
+
     event_time: Optional[str] = Field(
         default=None, description="time the event occurred at", alias="eventTime"
     )
@@ -47,7 +51,9 @@ class OpenLineageBaseEvent(AtlanObject):
 
 
 class OpenLineageBaseFacet(AtlanObject):
-    """All fields of the base facet are prefixed with _ to avoid name conflicts in facets"""
+    """
+    Base model for OpenLineage facets.
+    """
 
     producer: Optional[str] = Field(default=None, alias="_producer")
     schema_url: Optional[str] = Field(default=None, alias="_schemaURL")

--- a/pyatlan/model/open_lineage/column_lineage_dataset.py
+++ b/pyatlan/model/open_lineage/column_lineage_dataset.py
@@ -1,0 +1,32 @@
+from typing import List, Optional
+
+from pydantic.v1 import Field
+
+from pyatlan.model.core import AtlanObject
+
+
+class OpenLineageTransformation(AtlanObject):
+    type: Optional[str] = Field(
+        default=None,
+        description="Type of the transformation. Allowed values are: DIRECT, INDIRECT",
+    )
+    subtype: Optional[str] = Field(
+        default=None, description="Subtype of the transformation"
+    )
+    description: Optional[str] = Field(
+        default=None, description="String representation of the transformation applied"
+    )
+    masking: Optional[bool] = Field(
+        default=None, description="Is the transformation masking the data or not"
+    )
+
+
+class OpenLineageInputField(AtlanObject):
+    namespace: Optional[str] = Field(
+        default=None, description="Input dataset namespace"
+    )
+    name: Optional[str] = Field(default=None, description="Input dataset name")
+    field: Optional[str] = Field(default=None, description="Input field")
+    transformations: Optional[List[OpenLineageTransformation]] = Field(
+        default_factory=list, description="List of transformations"
+    )

--- a/pyatlan/model/open_lineage/dataset.py
+++ b/pyatlan/model/open_lineage/dataset.py
@@ -9,6 +9,10 @@ from pyatlan.model.open_lineage.facet import OpenLineageDatasetFacet
 
 
 class OpenLineageDataset(AtlanObject):
+    """
+    Model for handling OpenLineage datasets.
+    """
+
     name: Optional[str] = Field(
         default=None, description="Unique name for that dataset within that namespace."
     )

--- a/pyatlan/model/open_lineage/dataset.py
+++ b/pyatlan/model/open_lineage/dataset.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic.v1 import Field
+
+from pyatlan.model.core import AtlanObject
+from pyatlan.model.open_lineage.facet import OpenLineageDatasetFacet
+
+
+class OpenLineageDataset(AtlanObject):
+    name: Optional[str] = Field(
+        default=None, description="Unique name for that dataset within that namespace."
+    )
+    namespace: Optional[str] = Field(
+        default=None,
+        description="Namespace containing that dataset.",
+    )
+    facets: Optional[Dict[str, OpenLineageDatasetFacet]] = Field(
+        default_factory=dict,
+        description="Facets for this dataset",
+    )
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/Job"

--- a/pyatlan/model/open_lineage/event.py
+++ b/pyatlan/model/open_lineage/event.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional
+
+from pydantic.v1 import Field, root_validator
+from pytz import utc  # type:ignore[import-untyped]
+
+from pyatlan.model.enums import AtlanConnectorType, OpenLineageEventType
+from pyatlan.model.open_lineage.base import OpenLineageBaseEvent
+from pyatlan.model.open_lineage.input_dataset import OpenLineageInputDataset
+from pyatlan.model.open_lineage.job import OpenLineageJob
+from pyatlan.model.open_lineage.output_dataset import OpenLineageOutputDataset
+from pyatlan.model.open_lineage.run import OpenLineageRun
+
+if TYPE_CHECKING:
+    from pyatlan.client.atlan import AtlanClient
+
+
+class OpenLineageEvent(OpenLineageBaseEvent):
+    """
+    Base class for handling OpenLineage events,
+    passing through to the OpenLineage Python SDK
+    but wrapping events such that they are handled
+    appropriately in the Atlan Python SDK.
+    """
+
+    run: Optional[OpenLineageRun] = Field(default=None)
+    job: Optional[OpenLineageJob] = Field(default=None)
+    event_type: Optional[OpenLineageEventType] = Field(default=None)
+    inputs: Optional[List[OpenLineageInputDataset]] = Field(default_factory=list)
+    outputs: Optional[List[OpenLineageOutputDataset]] = Field(default_factory=list)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent"
+
+    @root_validator(pre=True)
+    def set_default_schema_url(cls, values):
+        values["schema_url"] = cls._get_schema()
+        return values
+
+    @classmethod
+    def creator(
+        self, run: OpenLineageRun, event_type: OpenLineageEventType
+    ) -> OpenLineageEvent:
+        return OpenLineageEvent(
+            run=run,
+            job=run.job,
+            producer=run.job.producer or "",
+            event_type=event_type,
+            event_time=datetime.now(tz=utc).isoformat(),  # type:ignore[call-arg]
+        )
+
+    def emit(self, client: Optional[AtlanClient] = None) -> str:
+        from pyatlan.client.atlan import AtlanClient
+
+        client = client or AtlanClient.get_default_client()
+        return client.open_lineage.send(
+            request=self, connector_type=AtlanConnectorType.SPARK
+        )

--- a/pyatlan/model/open_lineage/event.py
+++ b/pyatlan/model/open_lineage/event.py
@@ -66,7 +66,7 @@ class OpenLineageEvent(OpenLineageBaseEvent):
         return OpenLineageEvent(
             run=run,
             job=run.job,
-            producer=run.job.producer or "",
+            producer=run.job and run.job.producer or "",
             event_type=event_type,
             event_time=datetime.now(tz=utc).isoformat(),  # type:ignore[call-arg]
         )

--- a/pyatlan/model/open_lineage/facet.py
+++ b/pyatlan/model/open_lineage/facet.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic.v1 import Field
+
+from pyatlan.model.core import AtlanObject
+from pyatlan.model.open_lineage.base import OpenLineageBaseFacet
+
+
+class OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields(AtlanObject):
+    namespace: Optional[str] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    field: Optional[str] = Field(default=None)
+
+
+class OpenLineageColumnLineageDatasetFacetFieldsAdditional(AtlanObject):
+    input_fields: Optional[
+        List[OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields]
+    ] = Field(default_factory=list)
+    transformation_description: Optional[str] = Field(default=None)
+    transformation_type: Optional[str] = Field(default=None)
+
+
+class OpenLineageDatasetFacet(OpenLineageBaseFacet):
+    """A Dataset Facet"""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+
+
+class OpenLineageJobFacet(OpenLineageBaseFacet):
+    """A Job Facet"""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/JobFacet"
+
+
+class OpenLineageColumnLineageDatasetFacet(OpenLineageBaseFacet):
+    """
+    This facet contains column lineage of a dataset.
+    """
+
+    fields: Dict[str, OpenLineageColumnLineageDatasetFacetFieldsAdditional] = Field(
+        default_factory=dict
+    )
+
+    @staticmethod
+    def _get_schema() -> str:
+        return (
+            "https://openlineage.io/spec/facets/1-1-0/"
+            "ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet"
+        )
+
+
+class OpenLineageDatasetFacets(AtlanObject):
+    """A Dataset Facets"""
+
+    column_lineage: Optional[OpenLineageColumnLineageDatasetFacet] = Field(default=None)

--- a/pyatlan/model/open_lineage/input_dataset.py
+++ b/pyatlan/model/open_lineage/input_dataset.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic.v1 import Field
+
+from pyatlan.model.open_lineage.dataset import OpenLineageDataset
+from pyatlan.model.open_lineage.facet import (
+    OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields,
+)
+
+
+class OpenLineageInputDataset(OpenLineageDataset):
+
+    facets: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    input_facets: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/InputDataset"
+
+    @classmethod
+    def creator(cls, namespace: str, asset_name: str) -> OpenLineageInputDataset:
+        return OpenLineageInputDataset(namespace=namespace, name=asset_name, facets={})
+
+    def from_field(
+        self, field_name: str
+    ) -> OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields:
+        return OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields(
+            namespace=self.namespace, name=self.name, field=field_name
+        )

--- a/pyatlan/model/open_lineage/input_dataset.py
+++ b/pyatlan/model/open_lineage/input_dataset.py
@@ -11,6 +11,10 @@ from pyatlan.model.open_lineage.facet import (
 
 
 class OpenLineageInputDataset(OpenLineageDataset):
+    """
+    Model for handling OpenLineage datasets
+    to be used as lineage sources (inputs).
+    """
 
     facets: Optional[Dict[str, Any]] = Field(default_factory=dict)
     input_facets: Optional[Dict[str, Any]] = Field(default_factory=dict)
@@ -21,11 +25,25 @@ class OpenLineageInputDataset(OpenLineageDataset):
 
     @classmethod
     def creator(cls, namespace: str, asset_name: str) -> OpenLineageInputDataset:
+        """
+        Builds the minimal object necessary to create an OpenLineage dataset use-able as a lineage source.
+
+        :param namespace: name of the source of the asset
+        (see: https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md)
+        :param asset_name: name of the asset, by OpenLineage standard (for eg: `DB.SCHEMA.TABLE`)
+        :returns: the minimal request necessary to create the job
+        """
         return OpenLineageInputDataset(namespace=namespace, name=asset_name, facets={})
 
     def from_field(
         self, field_name: str
     ) -> OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields:
+        """
+        Create a new reference to a field within this input dataset.
+
+        :param field_name: name of the field within the input dataset to reference
+        :returns: a reference to the field within this input dataset
+        """
         return OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields(
             namespace=self.namespace, name=self.name, field=field_name
         )

--- a/pyatlan/model/open_lineage/job.py
+++ b/pyatlan/model/open_lineage/job.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic.v1 import Field
+
+from pyatlan.model.core import AtlanObject
+from pyatlan.model.open_lineage.facet import OpenLineageJobFacet
+from pyatlan.model.open_lineage.input_dataset import OpenLineageInputDataset
+from pyatlan.model.open_lineage.output_dataset import OpenLineageOutputDataset
+
+
+class OpenLineageJob(AtlanObject):
+    """
+    Atlan wrapper for abstracting OpenLineage jobs.
+
+    A job is a process that consumes or produces datasets.
+    This is abstract, and can map to different things in different operational contexts.
+    For example, a job could be a task in a workflow orchestration system.
+    It could also be a model, a query, or a checkpoint. Depending on the
+    system under observation, a Job can represent a small or large amount of work.
+
+    For more details
+    https://openlineage.io/docs/spec/object-model#job
+    """
+
+    name: Optional[str] = Field(
+        default=None, description="Unique name for that job within that namespace."
+    )
+    namespace: Optional[str] = Field(
+        default=None,
+        description="Namespace containing that job.",
+    )
+    facets: Optional[Dict[str, OpenLineageJobFacet]] = Field(
+        default_factory=dict,
+        description="Job facets.",
+    )
+    # NOTE: Added to follow a similar pattern used in the Atlan Java SDK
+    # This field is excluded from serialization
+    producer: Optional[str] = Field(default=None, exclude=True)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/Job"
+
+    @classmethod
+    def creator(
+        cls, connection_name: str, job_name: str, producer: str
+    ) -> OpenLineageJob:
+        return OpenLineageJob(
+            namespace=connection_name, name=job_name, producer=producer, facets={}
+        )
+
+    def create_input(self, namespace: str, asset_name: str) -> OpenLineageInputDataset:
+        return OpenLineageInputDataset.creator(
+            namespace=namespace,
+            asset_name=asset_name,
+        )
+
+    def create_output(
+        self: OpenLineageJob,
+        namespace: str,
+        asset_name: str,
+    ) -> OpenLineageOutputDataset:
+        return OpenLineageOutputDataset.creator(
+            namespace=namespace,
+            asset_name=asset_name,
+            producer=self.producer or "",
+        )

--- a/pyatlan/model/open_lineage/job.py
+++ b/pyatlan/model/open_lineage/job.py
@@ -47,11 +47,30 @@ class OpenLineageJob(AtlanObject):
     def creator(
         cls, connection_name: str, job_name: str, producer: str
     ) -> OpenLineageJob:
+        """
+        Builds the minimal object necessary to create an OpenLineage job.
+
+        :param connection_name: name of the Spark connection in which the OpenLineage job should be created
+        :param job_name: unique name of the job - if it already exists the existing job will be updated
+        :param producer: URI indicating the code or software that implements this job
+        :returns: the minimal request necessary to create the job
+        """
         return OpenLineageJob(
             namespace=connection_name, name=job_name, producer=producer, facets={}
         )
 
+    # TODO: provide some intuitive way to manage the facets of the job
+
     def create_input(self, namespace: str, asset_name: str) -> OpenLineageInputDataset:
+        """
+        Builds the minimal object necessary to create an OpenLineage dataset,
+        wired to use as an input (source) for lineage.
+
+        :param namespace: name of the source of the asset
+        (see: https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md)
+        :param asset_name: name of the asset, by OpenLineage standard (for eg: `DB.SCHEMA.TABLE`)
+        :returns: the minimal request necessary to create the input dataset
+        """
         return OpenLineageInputDataset.creator(
             namespace=namespace,
             asset_name=asset_name,
@@ -62,6 +81,15 @@ class OpenLineageJob(AtlanObject):
         namespace: str,
         asset_name: str,
     ) -> OpenLineageOutputDataset:
+        """
+        Builds the minimal object necessary to create an OpenLineage dataset,
+        wired to use as an output (target) for lineage.
+
+        :param namespace: name of the source of the asset
+        (see: https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md)
+        :param asset_name: name of the asset, by OpenLineage standard (for eg: `DB.SCHEMA.TABLE`)
+        :returns: the minimal request necessary to create the output dataset
+        """
         return OpenLineageOutputDataset.creator(
             namespace=namespace,
             asset_name=asset_name,

--- a/pyatlan/model/open_lineage/output_dataset.py
+++ b/pyatlan/model/open_lineage/output_dataset.py
@@ -14,6 +14,11 @@ from pyatlan.model.open_lineage.facet import (
 
 
 class OpenLineageOutputDataset(OpenLineageDataset):
+    """
+    Model for handling OpenLineage datasets
+    to be used as lineage targets (outputs).
+    """
+
     output_facets: Optional[Dict[str, Any]] = Field(default_factory=dict)
     to_fields: Optional[
         List[
@@ -35,6 +40,17 @@ class OpenLineageOutputDataset(OpenLineageDataset):
     def creator(
         cls, namespace: str, asset_name: str, producer: str
     ) -> OpenLineageOutputDataset:
+        """
+        Builds the minimal object necessary to create
+        an OpenLineage dataset use-able as a lineage target.
+
+        :param namespace: name of the source of the asset
+        (see: https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md)
+        :param asset_name: name of the asset, by OpenLineage standard (for eg: `DB.SCHEMA.TABLE`)
+        :param producer: a pre-configured OpenLineage producer
+        :returns: the minimal request necessary to create the output dataset
+        """
+
         return OpenLineageOutputDataset(
             namespace=namespace, name=asset_name, producer=producer
         )

--- a/pyatlan/model/open_lineage/output_dataset.py
+++ b/pyatlan/model/open_lineage/output_dataset.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic.v1 import Field, root_validator
+
+from pyatlan.model.open_lineage.dataset import OpenLineageDataset
+from pyatlan.model.open_lineage.facet import (
+    OpenLineageColumnLineageDatasetFacet,
+    OpenLineageColumnLineageDatasetFacetFieldsAdditional,
+    OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields,
+    OpenLineageDatasetFacets,
+)
+
+
+class OpenLineageOutputDataset(OpenLineageDataset):
+    output_facets: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    to_fields: Optional[
+        List[
+            Dict[
+                str,
+                List[OpenLineageColumnLineageDatasetFacetFieldsAdditionalInputFields],
+            ]
+        ]
+    ] = Field(default_factory=list, exclude=True)
+    # NOTE: Added to follow a similar pattern used in the Atlan Java SDK
+    # This field is excluded from serialization
+    producer: Optional[str] = Field(default=None, exclude=True)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/OutputDataset"
+
+    @classmethod
+    def creator(
+        cls, namespace: str, asset_name: str, producer: str
+    ) -> OpenLineageOutputDataset:
+        return OpenLineageOutputDataset(
+            namespace=namespace, name=asset_name, producer=producer
+        )
+
+    @root_validator(pre=True)
+    def transform_to_fields_into_facets(cls, values: dict) -> dict:
+        """
+        Custom logic to transform to_fields into facets.
+        This validator will modify facets based on to_fields before validation.
+        """
+        column_lineage_data = {}
+        producer = values.get("producer", "")
+        values["facets"] = values.get("facets", {})
+        to_fields = values.get("to_fields", [])
+
+        for entry in to_fields:
+            for key, value in entry.items():
+                # Build the OpenLineageColumnLineageDatasetFacet with input_fields
+                fields_additional = (
+                    OpenLineageColumnLineageDatasetFacetFieldsAdditional(
+                        input_fields=value
+                    )
+                )
+                # Add to the column lineage dict
+                column_lineage_data[key] = fields_additional
+
+        #  TODO: Below code will clobber any pre-existing facets
+        if column_lineage_data:
+            values["facets"] = OpenLineageDatasetFacets(
+                column_lineage=OpenLineageColumnLineageDatasetFacet(
+                    fields=column_lineage_data,
+                    producer=producer,  # type:ignore[call-arg]
+                )
+            ).dict(exclude_unset=True, by_alias=True)
+
+        return values

--- a/pyatlan/model/open_lineage/run.py
+++ b/pyatlan/model/open_lineage/run.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from pydantic.v1 import Field, validator
+
+from pyatlan.model.core import AtlanObject
+from pyatlan.model.open_lineage.job import OpenLineageJob
+from pyatlan.model.open_lineage.utils import generate_new_uuid
+
+
+class OpenLineageRun(AtlanObject):
+    """
+    Atlan wrapper for abstracting OpenLineage jobs.
+
+    A job is a process that consumes or produces datasets.
+    This is abstract, and can map to different things in different operational contexts.
+    For example, a job could be a task in a workflow orchestration system.
+    It could also be a model, a query, or a checkpoint. Depending on the
+    system under observation, a Job can represent a small or large amount of work.
+
+    For more details
+    https://openlineage.io/docs/spec/object-model#job
+    """
+
+    job: OpenLineageJob = Field(default=None, exclude=True)
+    run_id: Optional[str] = Field(
+        default=None,
+        description="Globally unique ID of the run associated with the job.",
+    )
+    facets: Optional[Dict[str, Any]] = Field(
+        default_factory=dict, description="Run facets."
+    )
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/Run"
+
+    @validator("run_id")
+    def validate_run_id(cls, value: str) -> str:
+        UUID(value)
+        return value
+
+    @classmethod
+    def creator(cls, job: OpenLineageJob) -> OpenLineageRun:
+        return OpenLineageRun(job=job, run_id=str(generate_new_uuid()), facets={})

--- a/pyatlan/model/open_lineage/run.py
+++ b/pyatlan/model/open_lineage/run.py
@@ -44,4 +44,10 @@ class OpenLineageRun(AtlanObject):
 
     @classmethod
     def creator(cls, job: OpenLineageJob) -> OpenLineageRun:
+        """
+        Builds the minimal object necessary to create an OpenLineage run.
+
+        :param job: OpenLineage job for which to create a new run
+        :returns: the minimal request necessary to create the run
+        """
         return OpenLineageRun(job=job, run_id=str(generate_new_uuid()), facets={})

--- a/pyatlan/model/open_lineage/utils.py
+++ b/pyatlan/model/open_lineage/utils.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import secrets
+import time
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+def _build_uuidv7(timestamp: int, node: int) -> UUID:
+    # merge timestamp and node into 128-bit UUID
+    # timestamp is first 48 bits, node is last 80 bits
+    uuid_int = (timestamp & 0xFFFFFFFFFFFF) << 80
+    uuid_int |= node & 0xFFFFFFFFFFFFFFFFFFFF
+
+    # Set the version number (4 bit).
+    version = 7
+    uuid_int &= ~(0xF000 << 64)
+    uuid_int |= version << 76
+
+    # Set the variant (2 bit) to RFC 4122.
+    uuid_int &= ~(0xC000 << 48)
+    uuid_int |= 0x8000 << 48
+
+    return UUID(int=uuid_int)
+
+
+def generate_new_uuid(instant: datetime | None = None) -> UUID:
+    """Generate new UUID for an instant of time. Each function call returns a new UUID value.
+
+    UUID version is an implementation detail, and **should not** be relied on.
+    For now it is [UUIDv7](https://datatracker.ietf.org/doc/rfc9562/), so for increasing instant values,
+    returned UUID is always greater than previous one.
+
+    Using uuid6 lib implementation (MIT License), with few changes:
+    * https://github.com/oittaa/uuid6-python/blob/4f879849178b8a7a564f7cb76c3f7a6e5228d9ed/src/uuid6/__init__.py#L128-L147 # noqa
+    * https://github.com/oittaa/uuid6-python/blob/4f879849178b8a7a564f7cb76c3f7a6e5228d9ed/src/uuid6/__init__.py#L46-L51
+
+
+    :param instant: instant of time used to generate UUID. If not provided, current time is used.
+    :return: UUID
+    """
+
+    timestamp_ms = (
+        int(instant.timestamp() * 1000) if instant else time.time_ns() // 10**6
+    )
+    node = secrets.randbits(76)
+    return _build_uuidv7(timestamp_ms, node)

--- a/pyatlan/utils.py
+++ b/pyatlan/utils.py
@@ -151,6 +151,7 @@ class EndPoint(EndpointMixin, Enum):
     HEKA = "api/sql/", "http://heka-service.heka.svc.cluster.local/"
     IMPERSONATION = "", "http://keycloak-http.keycloak.svc.cluster.local/"
     HERACLES = "api/service/", "http://heracles-service.heracles.svc.cluster.local/"
+    CHRONOS = "events/openlineage/", "http://chronos-service.kong.svc.cluster.local/"
 
 
 class HTTPMethod(Enum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ tenacity==8.2.3
 urllib3>=1.26.0,<3
 lazy_loader~=0.4
 nanoid==2.0.0
+pytz==2024.2
+python-dateutil==2.9.0.post0

--- a/tests/unit/data/open_lineage_requests/event_complete.json
+++ b/tests/unit/data/open_lineage_requests/event_complete.json
@@ -1,0 +1,15 @@
+{
+    "eventTime": "2024-10-07T10:23:52.239783+00:00",
+    "producer": "https://your.orchestrator/unique/id/123",
+    "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+    "eventType": "COMPLETE",
+    "run": {
+      "runId": "01826681-bfaf-7b1a-a5ce-f69f645660d9",
+      "facets": {}
+    },
+    "job": {
+      "namespace": "ol-spark",
+      "name": "dag_123",
+      "facets": {}
+    }
+}

--- a/tests/unit/data/open_lineage_requests/event_start.json
+++ b/tests/unit/data/open_lineage_requests/event_start.json
@@ -1,0 +1,79 @@
+{
+    "eventTime": "2024-10-07T10:23:52.239783+00:00",
+    "producer": "https://your.orchestrator/unique/id/123",
+    "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+    "eventType": "START",
+    "job": {
+      "namespace": "ol-spark",
+      "name": "dag_123",
+      "facets": {}
+    },
+    "run": {
+      "runId": "01826681-bfaf-7b1a-a5ce-f69f645660d9",
+      "facets": {}
+    },
+    "inputs": [
+      {
+        "namespace": "snowflake://abc123.snowflakecomputing.com",
+        "name": "OPS.DEFAULT.RUN_STATS",
+        "facets": {}
+      },
+      {
+        "namespace": "snowflake://abc123.snowflakecomputing.com",
+        "name": "SOME.OTHER.TBL",
+        "facets": {}
+      },
+      {
+        "namespace": "snowflake://abc123.snowflakecomputing.com",
+        "name": "AN.OTHER.TBL",
+        "facets": {}
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "snowflake://abc123.snowflakecomputing.com",
+        "name": "OPS.DEFAULT.FULL_STATS",
+        "facets": {
+          "columnLineage": {
+            "_producer": "https://your.orchestrator/unique/id/123",
+            "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet",
+            "fields": {
+              "COLUMN": {
+                "inputFields": [
+                  {
+                    "namespace": "snowflake://abc123.snowflakecomputing.com",
+                    "name": "OPS.DEFAULT.RUN_STATS",
+                    "field": "COLUMN"
+                  },
+                  {
+                    "namespace": "snowflake://abc123.snowflakecomputing.com",
+                    "name": "OPS.DEFAULT.RUN_STATS",
+                    "field": "ONE"
+                  },
+                  {
+                    "namespace": "snowflake://abc123.snowflakecomputing.com",
+                    "name": "OPS.DEFAULT.RUN_STATS",
+                    "field": "TWO"
+                  }
+                ]
+              },
+              "ANOTHER": {
+                "inputFields": [
+                  {
+                    "namespace": "snowflake://abc123.snowflakecomputing.com",
+                    "name": "OPS.DEFAULT.RUN_STATS",
+                    "field": "THREE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "namespace": "snowflake://abc123.snowflakecomputing.com",
+        "name": "AN.OTHER.VIEW",
+        "facets": {}
+      }
+    ]
+}

--- a/tests/unit/model/open_lineage/open_lineage_test.py
+++ b/tests/unit/model/open_lineage/open_lineage_test.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Atlan Pte. Ltd.
+from json import load, loads
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic.v1 import ValidationError
+
+from pyatlan.client.atlan import AtlanClient
+from pyatlan.client.common import ApiCaller
+from pyatlan.client.open_lineage import OpenLineageClient
+from pyatlan.errors import AtlanError, InvalidRequestError
+from pyatlan.model.enums import AtlanConnectorType, OpenLineageEventType
+from pyatlan.model.fluent_tasks import FluentTasks
+from pyatlan.model.open_lineage import OpenLineageEvent, OpenLineageJob, OpenLineageRun
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent / "data"
+OL_EVENT_START = str(TEST_DATA_DIR / "open_lineage_requests/event_start.json")
+OL_EVENT_COMPLETE = str(TEST_DATA_DIR / "open_lineage_requests/event_complete.json")
+
+PRODUCER = "https://your.orchestrator/unique/id/123"
+NAMESPACE = "snowflake://abc123.snowflakecomputing.com"
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+
+def load_json(filename):
+    with (TEST_DATA_DIR / filename).open() as input_file:
+        return load(input_file)
+
+
+def to_json(model):
+    return loads(model.json(by_alias=True, exclude_unset=True))
+
+
+@pytest.fixture(scope="module")
+def mock_api_caller():
+    return Mock(spec=ApiCaller)
+
+
+@pytest.fixture()
+def client():
+    return AtlanClient()
+
+
+@pytest.fixture()
+def mock_event_time():
+    with patch("pyatlan.model.open_lineage.event.datetime") as mock_datetime:
+        mock_datetime_instance = Mock()
+        mock_datetime_instance.isoformat.return_value = (
+            "2024-10-07T10:23:52.239783+00:00"
+        )
+        mock_datetime.now.return_value = mock_datetime_instance
+        yield mock_datetime
+
+
+@pytest.fixture()
+def mock_run_id():
+    with patch("pyatlan.model.open_lineage.run.generate_new_uuid") as mock_utils:
+        mock_utils.return_value = "01826681-bfaf-7b1a-a5ce-f69f645660d9"
+        yield mock_utils
+
+
+@pytest.fixture()
+def mock_session():
+    with patch.object(AtlanClient, "_session") as mock_session:
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.text = (
+            "Unauthorized: url path not configured to receive data, "
+            "urlPath: /events/openlineage/snowflake/api/v1/lineage"
+        )
+        mock_session.request.return_value = mock_response
+        yield mock_session
+
+
+@pytest.mark.parametrize(
+    "test_request, connector_type, error_msg",
+    [
+        [None, AtlanConnectorType.SPARK, "none is not an allowed value"],
+        ["123", AtlanConnectorType.SPARK, "value is not a valid dict"],
+        [
+            OpenLineageEvent(),
+            "invalid-connector-type",
+            "value is not a valid enumeration member",
+        ],
+        [OpenLineageEvent(), None, "none is not an allowed value"],
+    ],
+)
+def test_ol_client_send_raises_validation_error(
+    test_request, connector_type, error_msg
+):
+    with pytest.raises(ValidationError) as err:
+        OpenLineageClient.send(request=test_request, connector_type=connector_type)
+    assert error_msg in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "test_method, test_client",
+    [["count", [None, 123, "abc"]], ["execute", [None, 123, "abc"]]],
+)
+def test_ol_invalid_client_raises_invalid_request_error(
+    test_method,
+    test_client,
+):
+    client_method = getattr(FluentTasks(), test_method)
+    for invalid_client in test_client:
+        with pytest.raises(
+            InvalidRequestError, match="No Atlan client has been provided."
+        ):
+            client_method(client=invalid_client)
+
+
+def test_ol_client_send(
+    mock_api_caller,
+):
+    mock_api_caller._call_api.side_effect = ["Event recieved"]
+    test_event = OpenLineageEvent()
+    assert (
+        OpenLineageClient(client=mock_api_caller).send(
+            request=test_event, connector_type=AtlanConnectorType.SPARK
+        )
+        is None
+    )
+
+    assert mock_api_caller._call_api.call_count == 1
+    mock_api_caller.reset_mock()
+
+
+def test_ol_client_send_when_ol_not_configured(client, mock_session):
+    expected_error = (
+        "ATLAN-PYTHON-400-064 Requested OpenLineage "
+        "connector type 'snowflake' is not configured. "
+        "Suggestion: You must first run the appropriate "
+        "marketplace package to configure OpenLineage for "
+        "this connector before you can send events for it."
+    )
+    with pytest.raises(AtlanError, match=expected_error):
+        client.open_lineage.send(
+            request=OpenLineageEvent(), connector_type=AtlanConnectorType.SNOWFLAKE
+        )
+
+
+def test_ol_models(mock_run_id, mock_event_time):
+    job = OpenLineageJob.creator(
+        connection_name="ol-spark", job_name="dag_123", producer=PRODUCER
+    )
+    run = OpenLineageRun.creator(job=job)
+
+    id = job.create_input(namespace=NAMESPACE, asset_name="OPS.DEFAULT.RUN_STATS")
+    od = job.create_output(namespace=NAMESPACE, asset_name="OPS.DEFAULT.FULL_STATS")
+    od.to_fields = [
+        {
+            "COLUMN": [
+                id.from_field(field_name="COLUMN"),
+                id.from_field(field_name="ONE"),
+                id.from_field(field_name="TWO"),
+            ]
+        },
+        {
+            "ANOTHER": [
+                id.from_field(field_name="THREE"),
+            ]
+        },
+    ]
+
+    start = OpenLineageEvent.creator(run=run, event_type=OpenLineageEventType.START)
+    start.inputs = [
+        id,
+        job.create_input(namespace=NAMESPACE, asset_name="SOME.OTHER.TBL"),
+        job.create_input(namespace=NAMESPACE, asset_name="AN.OTHER.TBL"),
+    ]
+    start.outputs = [
+        od,
+        job.create_output(namespace=NAMESPACE, asset_name="AN.OTHER.VIEW"),
+    ]
+    assert to_json(start) == load_json(OL_EVENT_START)
+
+    complete = OpenLineageEvent.creator(
+        run=run, event_type=OpenLineageEventType.COMPLETE
+    )
+    assert to_json(complete) == load_json(OL_EVENT_COMPLETE)


### PR DESCRIPTION
### Sample snippet

```py
from pyatlan.model.enums import OpenLineageEventType
from pyatlan.model.open_lineage.event import OpenLineageEvent
from pyatlan.model.open_lineage.job import OpenLineageJob
from pyatlan.model.open_lineage.run import OpenLineageRun
from pyatlan.client.atlan import AtlanClient

client = AtlanClient()
namespace = "snowflake://abc123.snowflakecomputing.com"
producer = "https://your.orchestrator/unique/id/123"

job = OpenLineageJob.creator(
    connection_name="test-2", job_name="dag_123", producer=producer
)

run = OpenLineageRun.creator(job=job)

id = job.create_input(namespace=namespace, asset_name="OPS.DEFAULT.RUN_STATS")
od = job.create_output(namespace=namespace, asset_name="OPS.DEFAULT.FULL_STATS")
od.to_fields = [
    {
        "COLUMN": [
            id.from_field(field_name="COLUMN"),
            id.from_field(field_name="ONE"),
            id.from_field(field_name="TWO"),
        ]
    },
    {
        "ANOTHER": [
            id.from_field(field_name="THREE"),
        ]
    },
]

start = OpenLineageEvent.creator(run=run, event_type=OpenLineageEventType.START)
start.inputs = [
    id,
    job.create_input(namespace=namespace, asset_name="SOME.OTHER.TBL"),
    job.create_input(namespace=namespace, asset_name="AN.OTHER.TBL"),
]
start.outputs = [od, job.create_output(namespace=namespace, asset_name="AN.OTHER.VIEW")]

start.emit()

complete = OpenLineageEvent.creator(run=run, event_type=OpenLineageEventType.COMPLETE)

complete.emit()
```

- Added `OpenLineage` client.
- Implemented initial models to facilitate the sending of `OpenLineage` events.

### TODOs

- [x] Class/Method docstrings.
- [x] Import defines and structure of new OL sub-package.
- [x] Unit tests for implemented `Pydantic` models for `OpenLineage` events  and `OpenLineage` client.
- [x] Update dev portal.
~- [ ] Integration tests (depends on: https://atlanhq.atlassian.net/browse/DVX-653).~
