### PR TITLE
FT-778: Add credential list endpoint to the SDKs

### DIFF
--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -488,6 +488,12 @@ GET_CREDENTIAL_BY_GUID = API(
     HTTPStatus.OK,
     endpoint=EndPoint.HERACLES,
 )
+GET_ALL_CREDENTIALS = API(
+    CREDENTIALS_API, 
+    HTTPMethod.GET, 
+    HTTPStatus.OK, 
+    endpoint=EndPoint.HERACLES
+)
 UPDATE_CREDENTIAL_BY_GUID = API(
     CREDENTIALS_API + "/{credential_guid}",
     HTTPMethod.POST,

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -489,10 +489,7 @@ GET_CREDENTIAL_BY_GUID = API(
     endpoint=EndPoint.HERACLES,
 )
 GET_ALL_CREDENTIALS = API(
-    CREDENTIALS_API, 
-    HTTPMethod.GET, 
-    HTTPStatus.OK, 
-    endpoint=EndPoint.HERACLES
+    CREDENTIALS_API, HTTPMethod.GET, HTTPStatus.OK, endpoint=EndPoint.HERACLES
 )
 UPDATE_CREDENTIAL_BY_GUID = API(
     CREDENTIALS_API + "/{credential_guid}",

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -78,7 +78,11 @@ class CredentialClient:
         raw_json = self._client._call_api(GET_ALL_CREDENTIALS, query_params=params)
 
         if not isinstance(raw_json, dict) or "records" not in raw_json:
-            raise ErrorCode.JSON_ERROR.exception_with_parameters("No records found in response", 400, "API response did not contain the expected 'records' key")
+            raise ErrorCode.JSON_ERROR.exception_with_parameters(
+                "No records found in response",
+                400,
+                "API response did not contain the expected 'records' key",
+            )
 
         return CredentialResponseList(**raw_json)
 

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -78,9 +78,7 @@ class CredentialClient:
         raw_json = self._client._call_api(GET_ALL_CREDENTIALS, query_params=params)
 
         if not isinstance(raw_json, dict) or "records" not in raw_json:
-            raise ErrorCode.INVALID_RESPONSE.exception_with_parameters(
-                "Expected a dictionary containing 'records'"
-            )
+            raise ErrorCode.JSON_ERROR.exception_with_parameters("No records found in response", 400, "API response did not contain the expected 'records' key")
 
         return CredentialResponseList(**raw_json)
 

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -1,11 +1,13 @@
+from typing import Any, Dict, Optional
+
 from pydantic.v1 import validate_arguments
 
 from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import (
+    GET_ALL_CREDENTIALS,
     GET_CREDENTIAL_BY_GUID,
     TEST_CREDENTIAL,
-    GET_ALL_CREDENTIALS,
-    UPDATE_CREDENTIAL_BY_GUID
+    UPDATE_CREDENTIAL_BY_GUID,
 )
 from pyatlan.errors import ErrorCode
 from pyatlan.model.credential import (
@@ -48,19 +50,25 @@ class CredentialClient:
         if not isinstance(raw_json, dict):
             return raw_json
         return CredentialResponse(**raw_json)
-    
+
     @validate_arguments
-    def get_all(self, filter: Dict[str, Any], limit: int = None, offset: int = None) -> CredentialResponseList:
+    def get_all(
+        self,
+        filter: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> CredentialResponseList:
         """
         Retrieves all credentials based on the provided filter and optional pagination parameters.
 
-        :param filter: dictionary specifying the filter criteria. 
+        :param filter: dictionary specifying the filter criteria.
         :param limit: (optional) maximum number of credentials to retrieve.
         :param offset:  (optional) number of credentials to skip before starting retrieval.
         :returns: CredentialResponseList instance.
         :raises: AtlanError on any error during API invocation.
-         """
-   if filter is not None:
+        """
+        params = {}
+        if filter is not None:
             params["filter"] = filter
         if limit is not None:
             params["limit"] = limit

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -54,10 +54,10 @@ class CredentialClient:
         """
         Retrieves all credentials based on the provided filter and optional pagination parameters.
 
-        :param filter: A dictionary specifying the filter criteria (required).
-        :param limit: Maximum number of credentials to retrieve (optional).
-        :param offset: Number of credentials to skip before starting retrieval (optional).
-        :returns: A CredentialResponseList instance.
+        :param filter: dictionary specifying the filter criteria. 
+        :param limit: (optional) maximum number of credentials to retrieve.
+        :param offset:  (optional) number of credentials to skip before starting retrieval.
+        :returns: CredentialResponseList instance.
         :raises: AtlanError on any error during API invocation.
          """
         params = {"filter": filter}

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -50,7 +50,7 @@ class CredentialClient:
         return CredentialResponse(**raw_json)
     
     @validate_arguments
-    def get_all(self, filter: dict, limit: int = None, offset: int = None) -> CredentialResponseList:
+    def get_all(self, filter: Dict[str, Any], limit: int = None, offset: int = None) -> CredentialResponseList:
         """
         Retrieves all credentials based on the provided filter and optional pagination parameters.
 

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -60,7 +60,8 @@ class CredentialClient:
         :returns: CredentialResponseList instance.
         :raises: AtlanError on any error during API invocation.
          """
-        params = {"filter": filter}
+   if filter is not None:
+            params["filter"] = filter
         if limit is not None:
             params["limit"] = limit
         if offset is not None:

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -67,7 +67,7 @@ class CredentialClient:
         :returns: CredentialResponseList instance.
         :raises: AtlanError on any error during API invocation.
         """
-        params = {}
+        params: Dict[str, Any] = {}
         if filter is not None:
             params["filter"] = filter
         if limit is not None:

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -4,12 +4,14 @@ from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import (
     GET_CREDENTIAL_BY_GUID,
     TEST_CREDENTIAL,
-    UPDATE_CREDENTIAL_BY_GUID,
+    GET_ALL_CREDENTIALS,
+    UPDATE_CREDENTIAL_BY_GUID
 )
 from pyatlan.errors import ErrorCode
 from pyatlan.model.credential import (
     Credential,
     CredentialResponse,
+    CredentialResponseList,
     CredentialTestResponse,
 )
 
@@ -46,6 +48,32 @@ class CredentialClient:
         if not isinstance(raw_json, dict):
             return raw_json
         return CredentialResponse(**raw_json)
+    
+    @validate_arguments
+    def get_all(self, filter: dict, limit: int = None, offset: int = None) -> CredentialResponseList:
+        """
+        Retrieves all credentials based on the provided filter and optional pagination parameters.
+
+        :param filter: A dictionary specifying the filter criteria (required).
+        :param limit: Maximum number of credentials to retrieve (optional).
+        :param offset: Number of credentials to skip before starting retrieval (optional).
+        :returns: A CredentialResponseList instance.
+        :raises: AtlanError on any error during API invocation.
+         """
+        params = {"filter": filter}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        raw_json = self._client._call_api(GET_ALL_CREDENTIALS, query_params=params)
+
+        if not isinstance(raw_json, dict) or "records" not in raw_json:
+            raise ErrorCode.INVALID_RESPONSE.exception_with_parameters(
+                "Expected a dictionary containing 'records'"
+            )
+
+        return CredentialResponseList(**raw_json)
 
     @validate_arguments
     def test(self, credential: Credential) -> CredentialTestResponse:

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -1,3 +1,4 @@
+from json import dumps
 from typing import Any, Dict, Optional
 
 from pydantic.v1 import validate_arguments
@@ -61,7 +62,7 @@ class CredentialClient:
         """
         Retrieves all credentials based on the provided filter and optional pagination parameters.
 
-        :param filter: dictionary specifying the filter criteria.
+        :param filter: (optional) dictionary specifying the filter criteria.
         :param limit: (optional) maximum number of credentials to retrieve.
         :param offset:  (optional) number of credentials to skip before starting retrieval.
         :returns: CredentialResponseList instance.
@@ -69,13 +70,15 @@ class CredentialClient:
         """
         params: Dict[str, Any] = {}
         if filter is not None:
-            params["filter"] = filter
+            params["filter"] = dumps(filter)
         if limit is not None:
             params["limit"] = limit
         if offset is not None:
             params["offset"] = offset
 
-        raw_json = self._client._call_api(GET_ALL_CREDENTIALS, query_params=params)
+        raw_json = self._client._call_api(
+            GET_ALL_CREDENTIALS.format_path_with_params(), query_params=params
+        )
 
         if not isinstance(raw_json, dict) or "records" not in raw_json:
             raise ErrorCode.JSON_ERROR.exception_with_parameters(

--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -60,11 +60,11 @@ class CredentialClient:
         offset: Optional[int] = None,
     ) -> CredentialResponseList:
         """
-        Retrieves all credentials based on the provided filter and optional pagination parameters.
+        Retrieves all credentials.
 
         :param filter: (optional) dictionary specifying the filter criteria.
         :param limit: (optional) maximum number of credentials to retrieve.
-        :param offset:  (optional) number of credentials to skip before starting retrieval.
+        :param offset: (optional) number of credentials to skip before starting retrieval.
         :returns: CredentialResponseList instance.
         :raises: AtlanError on any error during API invocation.
         """

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 from pydantic.v1 import Field
 
@@ -54,20 +54,20 @@ class Credential(AtlanObject):
 
 
 class CredentialResponse(AtlanObject):
-    id: str
-    version: str
-    is_active: bool
-    created_at: int
-    updated_at: int
-    created_by: str
-    tenant_id: str
-    name: str
+    id: Optional[str]
+    version: Optional[str]
+    is_active: Optional[bool]
+    created_at: Optional[int]
+    updated_at: Optional[int]
+    created_by: Optional[str]
+    tenant_id: Optional[str]
+    name: Optional[str]
     description: Optional[str]
-    connector_config_name: str
-    connector: str
-    connector_type: str
-    auth_type: str
-    host: str
+    connector_config_name: Optional[str]
+    connector: Optional[str]
+    connector_type: Optional[str]
+    auth_type: Optional[str]
+    host: Optional[str]
     port: Optional[int]
     metadata: Optional[Dict[str, Any]]
     level: Optional[Dict[str, Any]]

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -102,7 +102,7 @@ class CredentialResponseList(AtlanObject):
         records (List[CredentialResponse]): The list of credential records returned.
     """
     
-    records: List[CredentialResponse] = Field(..., description="The list of credential records returned.")
+    records: Optional[List[CredentialResponse]] = Field(default=None, description="list of credential records returned.")
 
 class CredentialTestResponse(AtlanObject):
     code: Optional[int]

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -97,9 +97,6 @@ class CredentialResponse(AtlanObject):
 class CredentialResponseList(AtlanObject):
     """
     Model representing a response containing a list of CredentialResponse objects.
-
-    Attributes:
-        records (List[CredentialResponse]): The list of credential records returned.
     """
     
     records: Optional[List[CredentialResponse]] = Field(default=None, description="list of credential records returned.")

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional,List
 
 from pydantic.v1 import Field
 
@@ -93,6 +93,16 @@ class CredentialResponse(AtlanObject):
             extras=self.extras,  # type: ignore[call-arg]
         )
 
+
+class CredentialResponseList(AtlanObject):
+    """
+    Model representing a response containing a list of CredentialResponse objects.
+
+    Attributes:
+        records (List[CredentialResponse]): The list of credential records returned.
+    """
+    
+    records: List[CredentialResponse] = Field(..., description="The list of credential records returned.")
 
 class CredentialTestResponse(AtlanObject):
     code: Optional[int]

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional,List
+from typing import Any, Dict, Optional, List
 
 from pydantic.v1 import Field
 
@@ -98,8 +98,11 @@ class CredentialResponseList(AtlanObject):
     """
     Model representing a response containing a list of CredentialResponse objects.
     """
-    
-    records: Optional[List[CredentialResponse]] = Field(default=None, description="list of credential records returned.")
+
+    records: Optional[List[CredentialResponse]] = Field(
+        default=None, description="list of credential records returned."
+    )
+
 
 class CredentialTestResponse(AtlanObject):
     code: Optional[int]

--- a/tests/integration/test_workflow_client.py
+++ b/tests/integration/test_workflow_client.py
@@ -13,6 +13,7 @@ from pyatlan.model.packages.snowflake_miner import SnowflakeMiner
 from pyatlan.model.workflow import WorkflowResponse, WorkflowSchedule
 from tests.integration.client import TestId, delete_asset
 from tests.integration.connection_test import create_connection
+from pyatlan.client.atlan import AtlanClient
 
 MODULE_NAME = TestId.make_unique("WorfklowClient")
 WORKFLOW_TEMPLATE_REF = "workflowTemplateRef"
@@ -269,3 +270,76 @@ def test_workflow_add_remove_schedule(client: AtlanClient, workflow: WorkflowRes
     # Now remove the scheduled run
     response = client.workflow.remove_schedule(workflow)
     _assert_remove_schedule(response, workflow)
+
+def test_get_all_credentials(client: AtlanClient):
+    
+    credentials = client.credentials.get_all()
+    assert credentials, "Expected credentials but found None"
+    assert credentials.records is not None, "Expected records but found None"
+    assert len(credentials.records) > 0, "Expected at least one record but found none"
+
+
+def test_get_all_credentials_with_limit_and_offset(client: AtlanClient):
+    limit = 5
+    offset = 2
+    credentials = client.credentials.get_all(limit=limit, offset=offset)
+    assert credentials.records is not None, "Expected records but found None"
+    assert len(credentials.records) <= limit, (
+        f"Expected at most {limit} records, got {len(credentials.records)}"
+    )
+
+
+def test_get_all_credentials_with_filter_limit_offset(client: AtlanClient):
+    filter_criteria = {"connectorType": "rest"}
+    limit = 1
+    offset = 1
+    credentials = client.credentials.get_all(filter=filter_criteria, limit=limit, offset=offset)
+    assert len(credentials.records) <= limit, "Exceeded limit in results"
+    for cred in credentials.records:
+        assert cred.connector_type == "rest"
+
+def test_get_all_credentials_with_multiple_filters(client: AtlanClient):
+    filter_criteria = {
+        "connectorType": "jdbc",
+        "isActive": True
+    }
+
+    credentials = client.credentials.get_all(filter=filter_criteria)
+    assert credentials, "Expected credentials but found None"
+    assert credentials.records is not None, "Expected records but found None"
+    assert len(credentials.records) > 0, "Expected at least one record but found none"
+
+    for record in credentials.records:
+        assert record.connector_type == "jdbc", f"Expected 'jdbc', got {record.connectorType}"
+        assert record.is_active, f"Expected active record, but got inactive: {record}"
+
+def test_get_all_credentials_with_invalid_filter_key(client: AtlanClient):
+    filter_criteria = {
+        "invalidKey": "someValue"
+    }
+    try:
+        credentials = client.credentials.get_all(filter=filter_criteria)
+        pytest.fail("Expected an error due to invalid filter key, but none occurred.")
+    except Exception as e:
+        assert "400" in str(e), f"Expected a 400 error, but got: {e}"
+
+def test_get_all_credentials_with_invalid_filter_value(client: AtlanClient):
+
+    filter_criteria = {
+        "connectorType": 123  # Invalid type (should be a string)
+    }
+
+    try:
+        credentials = client.credentials.get_all(filter=filter_criteria)
+        pytest.fail("Expected an error due to invalid filter value, but none occurred.")
+    except Exception as e:
+        assert "400" in str(e), f"Expected a 400 error, but got: {e}"
+
+def test_get_all_credentials_with_large_limit(client: AtlanClient):
+
+    limit = 100  # Larger than the total number of records
+    credentials = client.credentials.get_all(limit=limit)
+
+    assert credentials, "Expected credentials but found None"
+    assert credentials.records is not None, "Expected records but found None"
+    assert len(credentials.records) <= limit, f"Expected at most {limit} records, but got {len(credentials.records)}"

--- a/tests/integration/test_workflow_client.py
+++ b/tests/integration/test_workflow_client.py
@@ -13,7 +13,6 @@ from pyatlan.model.packages.snowflake_miner import SnowflakeMiner
 from pyatlan.model.workflow import WorkflowResponse, WorkflowSchedule
 from tests.integration.client import TestId, delete_asset
 from tests.integration.connection_test import create_connection
-from pyatlan.client.atlan import AtlanClient
 
 MODULE_NAME = TestId.make_unique("WorfklowClient")
 WORKFLOW_TEMPLATE_REF = "workflowTemplateRef"
@@ -271,12 +270,14 @@ def test_workflow_add_remove_schedule(client: AtlanClient, workflow: WorkflowRes
     response = client.workflow.remove_schedule(workflow)
     _assert_remove_schedule(response, workflow)
 
+
 def test_get_all_credentials(client: AtlanClient):
-    
     credentials = client.credentials.get_all()
     assert credentials, "Expected credentials but found None"
     assert credentials.records is not None, "Expected records but found None"
-    assert len(credentials.records) > 0, "Expected at least one record but found none"
+    assert (
+        len(credentials.records or []) > 0
+    ), "Expected at least one record but found none"
 
 
 def test_get_all_credentials_with_limit_and_offset(client: AtlanClient):
@@ -284,62 +285,66 @@ def test_get_all_credentials_with_limit_and_offset(client: AtlanClient):
     offset = 2
     credentials = client.credentials.get_all(limit=limit, offset=offset)
     assert credentials.records is not None, "Expected records but found None"
-    assert len(credentials.records) <= limit, (
-        f"Expected at most {limit} records, got {len(credentials.records)}"
-    )
+    assert (
+        len(credentials.records or []) <= limit
+    ), f"Expected at most {limit} records, got {len(credentials.records or [])}"
 
 
 def test_get_all_credentials_with_filter_limit_offset(client: AtlanClient):
     filter_criteria = {"connectorType": "rest"}
     limit = 1
     offset = 1
-    credentials = client.credentials.get_all(filter=filter_criteria, limit=limit, offset=offset)
-    assert len(credentials.records) <= limit, "Exceeded limit in results"
-    for cred in credentials.records:
-        assert cred.connector_type == "rest"
+    credentials = client.credentials.get_all(
+        filter=filter_criteria, limit=limit, offset=offset
+    )
+    assert len(credentials.records or []) <= limit, "Exceeded limit in results"
+    for cred in credentials.records or []:
+        assert (
+            cred.connector_type == "rest"
+        ), f"Expected 'rest', got {cred.connector_type}"
+
 
 def test_get_all_credentials_with_multiple_filters(client: AtlanClient):
-    filter_criteria = {
-        "connectorType": "jdbc",
-        "isActive": True
-    }
+    filter_criteria = {"connectorType": "jdbc", "isActive": True}
 
     credentials = client.credentials.get_all(filter=filter_criteria)
     assert credentials, "Expected credentials but found None"
     assert credentials.records is not None, "Expected records but found None"
-    assert len(credentials.records) > 0, "Expected at least one record but found none"
+    assert (
+        len(credentials.records or []) > 0
+    ), "Expected at least one record but found none"
 
-    for record in credentials.records:
-        assert record.connector_type == "jdbc", f"Expected 'jdbc', got {record.connectorType}"
+    for record in credentials.records or []:
+        assert (
+            record.connector_type == "jdbc"
+        ), f"Expected 'jdbc', got {record.connector_type}"
         assert record.is_active, f"Expected active record, but got inactive: {record}"
 
+
 def test_get_all_credentials_with_invalid_filter_key(client: AtlanClient):
-    filter_criteria = {
-        "invalidKey": "someValue"
-    }
+    filter_criteria = {"invalidKey": "someValue"}
     try:
-        credentials = client.credentials.get_all(filter=filter_criteria)
+        client.credentials.get_all(filter=filter_criteria)
         pytest.fail("Expected an error due to invalid filter key, but none occurred.")
     except Exception as e:
         assert "400" in str(e), f"Expected a 400 error, but got: {e}"
 
-def test_get_all_credentials_with_invalid_filter_value(client: AtlanClient):
 
-    filter_criteria = {
-        "connectorType": 123  # Invalid type (should be a string)
-    }
+def test_get_all_credentials_with_invalid_filter_value(client: AtlanClient):
+    filter_criteria = {"connector_type": 123}
 
     try:
-        credentials = client.credentials.get_all(filter=filter_criteria)
+        client.credentials.get_all(filter=filter_criteria)
         pytest.fail("Expected an error due to invalid filter value, but none occurred.")
     except Exception as e:
         assert "400" in str(e), f"Expected a 400 error, but got: {e}"
 
+
 def test_get_all_credentials_with_large_limit(client: AtlanClient):
-
-    limit = 100  # Larger than the total number of records
+    limit = 100
     credentials = client.credentials.get_all(limit=limit)
-
     assert credentials, "Expected credentials but found None"
     assert credentials.records is not None, "Expected records but found None"
-    assert len(credentials.records) <= limit, f"Expected at most {limit} records, but got {len(credentials.records)}"
+    assert (
+        len(credentials.records or []) <= limit
+    ), f"Expected at most {limit} records, but got {len(credentials.records or [])}"

--- a/tests/integration/test_workflow_client.py
+++ b/tests/integration/test_workflow_client.py
@@ -291,7 +291,7 @@ def test_get_all_credentials_with_limit_and_offset(client: AtlanClient):
 
 
 def test_get_all_credentials_with_filter_limit_offset(client: AtlanClient):
-    filter_criteria = {"connectorType": "rest"}
+    filter_criteria = {"connectorType": "jdbc"}
     limit = 1
     offset = 1
     credentials = client.credentials.get_all(
@@ -300,8 +300,8 @@ def test_get_all_credentials_with_filter_limit_offset(client: AtlanClient):
     assert len(credentials.records or []) <= limit, "Exceeded limit in results"
     for cred in credentials.records or []:
         assert (
-            cred.connector_type == "rest"
-        ), f"Expected 'rest', got {cred.connector_type}"
+            cred.connector_type == "jdbc"
+        ), f"Expected 'jdbc', got {cred.connector_type}"
 
 
 def test_get_all_credentials_with_multiple_filters(client: AtlanClient):
@@ -338,13 +338,3 @@ def test_get_all_credentials_with_invalid_filter_value(client: AtlanClient):
         pytest.fail("Expected an error due to invalid filter value, but none occurred.")
     except Exception as e:
         assert "400" in str(e), f"Expected a 400 error, but got: {e}"
-
-
-def test_get_all_credentials_with_large_limit(client: AtlanClient):
-    limit = 100
-    credentials = client.credentials.get_all(limit=limit)
-    assert credentials, "Expected credentials but found None"
-    assert credentials.records is not None, "Expected records but found None"
-    assert (
-        len(credentials.records or []) <= limit
-    ), f"Expected at most {limit} records, but got {len(credentials.records or [])}"


### PR DESCRIPTION
Made the following changes:
1. Add a method called **`get_all()`** 
2. Defined a new model called **`CredentialResponseList`**
3. Added a new constant called **`GET_ALL_CREDENTIALS`**
