### PR TITLE
FT-831: Updated `CredentialListResponse` fields and handled `None` re…

### DIFF
--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -13,8 +13,8 @@ from pyatlan.client.constants import (
 from pyatlan.errors import ErrorCode
 from pyatlan.model.credential import (
     Credential,
+    CredentialListResponse,
     CredentialResponse,
-    CredentialResponseList,
     CredentialTestResponse,
 )
 
@@ -58,14 +58,14 @@ class CredentialClient:
         filter: Optional[Dict[str, Any]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> CredentialResponseList:
+    ) -> CredentialListResponse:
         """
         Retrieves all credentials.
 
         :param filter: (optional) dictionary specifying the filter criteria.
         :param limit: (optional) maximum number of credentials to retrieve.
         :param offset: (optional) number of credentials to skip before starting retrieval.
-        :returns: CredentialResponseList instance.
+        :returns: CredentialListResponse instance.
         :raises: AtlanError on any error during API invocation.
         """
         params: Dict[str, Any] = {}
@@ -86,8 +86,7 @@ class CredentialClient:
                 400,
                 "API response did not contain the expected 'records' key",
             )
-
-        return CredentialResponseList(**raw_json)
+        return CredentialListResponse(records=raw_json.get("records") or [])
 
     @validate_arguments
     def test(self, credential: Credential) -> CredentialTestResponse:

--- a/pyatlan/model/credential.py
+++ b/pyatlan/model/credential.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic.v1 import Field
 
@@ -70,8 +70,8 @@ class CredentialResponse(AtlanObject):
     host: Optional[str]
     port: Optional[int]
     metadata: Optional[Dict[str, Any]]
-    level: Optional[Dict[str, Any]]
-    connection: Optional[Dict[str, Any]]
+    level: Optional[Union[Dict[str, Any], str]]
+    connection: Optional[Union[Dict[str, Any], str]]
     username: Optional[str]
     extras: Optional[Dict[str, Any]] = Field(default=None, alias="extra")
 
@@ -94,13 +94,13 @@ class CredentialResponse(AtlanObject):
         )
 
 
-class CredentialResponseList(AtlanObject):
+class CredentialListResponse(AtlanObject):
     """
     Model representing a response containing a list of CredentialResponse objects.
     """
 
     records: Optional[List[CredentialResponse]] = Field(
-        default=None, description="list of credential records returned."
+        default_factory=list, description="list of credential records returned."
     )
 
 


### PR DESCRIPTION
- Renamed `CredentialResponseList` to `CredentialListResponse` to ensure consistent response model naming.  
- Updated handling for `records: null` in the response to populate the model with an empty list `[]` instead of `None`, which is non-iterable.  
- Updated `level` and `connection` fields to use `Optional[Union[Dict[str, Any], str]]`, as they can be strings, preventing Pydantic validation errors:

```json
   "level": "user",
   "connection": "default/bigquery/1697545730"
``` 