### PR TITLE
FT-790: Remove possibility of overrunning search pages when total results are just under the threshold

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -1793,8 +1793,9 @@ class IndexSearchResults(SearchResults, Iterable):
     query.
     """
 
-    DEFAULT_PAGE_SIZE = 300
-    _MASS_EXTRACT_THRESHOLD = 100000 - DEFAULT_PAGE_SIZE
+    field = DSL.__fields__.get("size")
+    default_size = field.default if field is not None else 0
+    _MASS_EXTRACT_THRESHOLD = 100000 - default_size
 
     def __init__(
         self,

--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -1793,7 +1793,7 @@ class IndexSearchResults(SearchResults, Iterable):
     query.
     """
 
-    _MASS_EXTRACT_THRESHOLD = 100000
+    _MASS_EXTRACT_THRESHOLD = 99700 #Note 100000(_MASS_EXTRACT_THRESHOLD) - 300(default page size)
 
     def __init__(
         self,

--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -1793,7 +1793,8 @@ class IndexSearchResults(SearchResults, Iterable):
     query.
     """
 
-    _MASS_EXTRACT_THRESHOLD = 99700 #Note 100000(_MASS_EXTRACT_THRESHOLD) - 300(default page size)
+    DEFAULT_PAGE_SIZE = 300
+    _MASS_EXTRACT_THRESHOLD = 100000 - DEFAULT_PAGE_SIZE
 
     def __init__(
         self,


### PR DESCRIPTION
>  It’s currently possible to hit an edge case where e.g. the total number of results is 9932, but because we page by default at 300 per page we end up sending a request from offset 9900 with a size of 300 <— in total this would take us above the 10000 threshold (to 10200) <— which Elastic will throw an error on.

We should ensure that we properly mitigate this edge case.

Remove possibility of overrunning search pages when total results are just under the threshold:
 - DEFAULT_PAGE_SIZE = 300
  - _MASS_EXTRACT_THRESHOLD = 100000 - DEFAULT_PAGE_SIZE
 