### PR TITLE
FT-853: Implement query rewrite for Searchlog responses

### DIFF
--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -77,7 +77,7 @@ class SearchLogClient:
         sorts: List[SortItem],
     ) -> List[SortItem]:
         """
-        Ensures that sorting by creation timestamp is prioritized for Search Log bulk searches.
+        Ensures that sorting by creation timestamp is prioritized for search Log bulk searches.
         :param sorts: List of existing sorting options.
         :returns: A modified list of sorting options with creation timestamp as the top priority.
         """
@@ -88,7 +88,7 @@ class SearchLogClient:
     def _get_search_log_bulk_search_log_message(self, bulk):
         return (
             (
-                "Search Log bulk search option is enabled. "
+                "Search log bulk search option is enabled. "
                 if bulk
                 else "Result size (%s) exceeds threshold (%s). "
             )
@@ -119,6 +119,7 @@ class SearchLogClient:
         :raises AtlanError: on any API communication issue
         :returns: the results of the search
         """
+        # import ipdb; ipdb.set_trace()
         if bulk:
             if criteria.dsl.sort and len(criteria.dsl.sort) > 2:
                 raise ErrorCode.UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS.exception_with_parameters()

--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -73,19 +73,20 @@ class SearchLogClient:
         return self._client._call_api(SEARCH_LOG, request_obj=criteria)
 
     @staticmethod
-    def _prepare_sorts_for_search_log_bulk_search(
+    def _prepare_sorts_for_sl_bulk_search(
         sorts: List[SortItem],
     ) -> List[SortItem]:
         """
-        Ensures that sorting by creation timestamp is prioritized for search Log bulk searches.
-        :param sorts: List of existing sorting options.
-        :returns: A modified list of sorting options with creation timestamp as the top priority.
+        Ensures that sorting by creation timestamp is prioritized for search log bulk searches.
+
+        :param sorts: list of existing sorting options.
+        :returns: a modified list of sorting options with creation timestamp as the top priority.
         """
         if not SearchLogResults.presorted_by_timestamp(sorts):
             return SearchLogResults.sort_by_timestamp_first(sorts)
         return sorts
 
-    def _get_search_log_bulk_search_log_message(self, bulk):
+    def _get_bulk_search_log_message(self, bulk):
         return (
             (
                 "Search log bulk search option is enabled. "
@@ -100,12 +101,12 @@ class SearchLogClient:
         self, criteria: SearchLogRequest, bulk=False
     ) -> Union[SearchLogViewResults, SearchLogResults]:
         """
-        Search for assets using the provided criteria.
+        Search for search logs using the provided criteria.
         `Note:` if the number of results exceeds the predefined threshold
-        (10,000 assets) this will be automatically converted into an search log `bulk` search.
+        (10,000 search logs) this will be automatically converted into an search log `bulk` search.
 
         :param criteria: detailing the search query, parameters, and so on to run
-        :param bulk: whether to run the search to retrieve assets that match the supplied criteria,
+        :param bulk: whether to run the search to retrieve search logs that match the supplied criteria,
         for large numbers of results (> `10,000`), defaults to `False`. Note: this will reorder the results
         (based on creation timestamp) in order to iterate through a large number (more than `10,000`) results.
         :raises InvalidRequestError:
@@ -122,10 +123,10 @@ class SearchLogClient:
         if bulk:
             if criteria.dsl.sort and len(criteria.dsl.sort) > 2:
                 raise ErrorCode.UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS.exception_with_parameters()
-            criteria.dsl.sort = self._prepare_sorts_for_search_log_bulk_search(
+            criteria.dsl.sort = self._prepare_sorts_for_sl_bulk_search(
                 criteria.dsl.sort
             )
-            LOGGER.debug(self._get_search_log_bulk_search_log_message(bulk))
+            LOGGER.debug(self._get_bulk_search_log_message(bulk))
         user_views = []
         asset_views = []
         log_entries = []
@@ -190,11 +191,11 @@ class SearchLogClient:
         ):
             if criteria.dsl.sort and len(criteria.dsl.sort) > 2:
                 raise ErrorCode.UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS.exception_with_parameters()
-            criteria.dsl.sort = self._prepare_sorts_for_search_log_bulk_search(
+            criteria.dsl.sort = self._prepare_sorts_for_sl_bulk_search(
                 criteria.dsl.sort
             )
             LOGGER.debug(
-                self._get_search_log_bulk_search_log_message(bulk),
+                self._get_bulk_search_log_message(bulk),
                 count,
                 SearchLogResults._MASS_EXTRACT_THRESHOLD,
             )

--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Union
 
 from pydantic.v1 import ValidationError, parse_obj_as, validate_arguments
@@ -5,6 +6,7 @@ from pydantic.v1 import ValidationError, parse_obj_as, validate_arguments
 from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import SEARCH_LOG
 from pyatlan.errors import ErrorCode
+from pyatlan.model.search import SortItem
 from pyatlan.model.search_log import (
     AssetViews,
     SearchLogEntry,
@@ -16,6 +18,7 @@ from pyatlan.model.search_log import (
 
 UNIQUE_USERS = "uniqueUsers"
 UNIQUE_ASSETS = "uniqueAssets"
+LOGGER = logging.getLogger(__name__)
 
 
 class SearchLogClient:
@@ -67,27 +70,68 @@ class SearchLogClient:
         :param criteria: An instance of SearchLogRequest detailing the search query, parameters, etc.
         :return: A dictionary representing the raw JSON response from the search API.
         """
-        return self._client._call_api(
-            SEARCH_LOG,
-            request_obj=criteria,
+        return self._client._call_api(SEARCH_LOG, request_obj=criteria)
+
+    @staticmethod
+    def _prepare_sorts_for_search_log_bulk_search(
+        sorts: List[SortItem],
+    ) -> List[SortItem]:
+        """
+        Ensures that sorting by creation timestamp is prioritized for Search Log bulk searches.
+        :param sorts: List of existing sorting options.
+        :returns: A modified list of sorting options with creation timestamp as the top priority.
+        """
+        if not SearchLogResults.presorted_by_timestamp(sorts):
+            return SearchLogResults.sort_by_timestamp_first(sorts)
+        return sorts
+
+    def _get_search_log_bulk_search_log_message(self, bulk):
+        return (
+            (
+                "Search Log bulk search option is enabled. "
+                if bulk
+                else "Result size (%s) exceeds threshold (%s). "
+            )
+            + "Ignoring requests for offset-based paging and using timestamp-based paging instead."
         )
 
     @validate_arguments
     def search(
-        self, criteria: SearchLogRequest
+        self, criteria: SearchLogRequest, bulk=False
     ) -> Union[SearchLogViewResults, SearchLogResults]:
         """
         Search for assets using the provided criteria.
+        `Note:` if the number of results exceeds the predefined threshold
+        (10,000 assets) this will be automatically converted into an search log `bulk` search.
 
         :param criteria: detailing the search query, parameters, and so on to run
-        :returns: the results of the search
+        :param bulk: whether to run the search to retrieve assets that match the supplied criteria,
+        for large numbers of results (> `10,000`), defaults to `False`. Note: this will reorder the results
+        (based on creation timestamp) in order to iterate through a large number (more than `10,000`) results.
+        :raises InvalidRequestError:
+
+            - if search log bulk search is enabled (`bulk=True`) and any
+              user-specified sorting options are found in the search request.
+            - if search log bulk search is disabled (`bulk=False`) and the number of results
+              exceeds the predefined threshold (i.e: `10,000` assets)
+              and any user-specified sorting options are found in the search request.
+
         :raises AtlanError: on any API communication issue
+        :returns: the results of the search
         """
+        if bulk:
+            if criteria.dsl.sort and len(criteria.dsl.sort) > 2:
+                raise ErrorCode.UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS.exception_with_parameters()
+            criteria.dsl.sort = self._prepare_sorts_for_search_log_bulk_search(
+                criteria.dsl.sort
+            )
+            LOGGER.debug(self._get_search_log_bulk_search_log_message(bulk))
         user_views = []
         asset_views = []
         log_entries = []
         raw_json = self._call_search_api(criteria)
         count = raw_json.get("approximateCount", 0)
+
         if "aggregations" in raw_json and UNIQUE_USERS in raw_json.get(
             "aggregations", {}
         ):
@@ -140,6 +184,21 @@ class SearchLogClient:
                 raise ErrorCode.JSON_ERROR.exception_with_parameters(
                     raw_json, 200, str(err)
                 ) from err
+        if (
+            count > SearchLogResults._MASS_EXTRACT_THRESHOLD
+            and not SearchLogResults.presorted_by_timestamp(criteria.dsl.sort)
+        ):
+            if criteria.dsl.sort and len(criteria.dsl.sort) > 2:
+                raise ErrorCode.UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS.exception_with_parameters()
+            criteria.dsl.sort = self._prepare_sorts_for_search_log_bulk_search(
+                criteria.dsl.sort
+            )
+            LOGGER.debug(
+                self._get_search_log_bulk_search_log_message(bulk),
+                count,
+                SearchLogResults._MASS_EXTRACT_THRESHOLD,
+            )
+            return self.search(criteria)
         return SearchLogResults(
             client=self._client,
             criteria=criteria,
@@ -148,4 +207,5 @@ class SearchLogClient:
             count=count,
             log_entries=log_entries,
             aggregations={},
+            bulk=bulk,
         )

--- a/pyatlan/client/search_log.py
+++ b/pyatlan/client/search_log.py
@@ -119,7 +119,6 @@ class SearchLogClient:
         :raises AtlanError: on any API communication issue
         :returns: the results of the search
         """
-        # import ipdb; ipdb.set_trace()
         if bulk:
             if criteria.dsl.sort and len(criteria.dsl.sort) > 2:
                 raise ErrorCode.UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS.exception_with_parameters()

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -579,6 +579,14 @@ class ErrorCode(Enum):
         + "audit search request when performing a bulk search.",
         InvalidRequestError,
     )
+    UNABLE_TO_RUN_SEARCH_LOG_BULK_WITH_SORTS = (
+        400,
+        "ATLAN-PYTHON-400-067",
+        "Unable to execute search log bulk search with user-defined sorting options.",
+        "Please ensure that no sorting options are included in your "
+        + "search log search request when performing a bulk search.",
+        InvalidRequestError,
+    )
     MISSING_NAME = (
         400,
         "ATLAN-PYTHON-400-065",

--- a/pyatlan/model/search_log.py
+++ b/pyatlan/model/search_log.py
@@ -585,8 +585,8 @@ class SearchLogResults(Iterable):
         rewritten_sorts = [
             sort
             for sort in sorts
-            # Added a condition to disable TimeStamp sorting when bulk search for logs is enabled,
-            # as sorting is already handled based on createdAt in this case.
+            # Added a condition to disable "timestamp" sorting when bulk search for logs is enabled,
+            # as sorting is already handled based on "createdAt" in this case.
             if (
                 (not sort.field)
                 or (sort.field != Asset.CREATE_TIME.internal_field_name)

--- a/pyatlan/model/search_log.py
+++ b/pyatlan/model/search_log.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Generator, Iterable, List, Optional
+from typing import Any, Dict, Generator, Iterable, List, Optional, Set
 
 from pydantic.v1 import Field, ValidationError, parse_obj_as
 
@@ -9,18 +9,22 @@ from pyatlan.client.common import ApiCaller
 from pyatlan.client.constants import SEARCH_LOG
 from pyatlan.errors import ErrorCode
 from pyatlan.model.aggregation import Aggregation
+from pyatlan.model.assets import Asset
 from pyatlan.model.core import AtlanObject
 from pyatlan.model.enums import UTMTags
 from pyatlan.model.search import (
     DSL,
     Bool,
     Query,
+    Range,
     SearchRequest,
     SortItem,
     SortOrder,
     Term,
     Terms,
 )
+
+BY_TIMESTAMP = [SortItem("timestamp", order=SortOrder.ASCENDING)]
 
 
 class SearchLogRequest(SearchRequest):
@@ -65,7 +69,6 @@ class SearchLogRequest(SearchRequest):
         sort = sort or []
         query_filter = query_filter or []
         exclude_users = exclude_users or []
-        BY_TIMESTAMP = [SortItem("timestamp", order=SortOrder.ASCENDING)]
         return dict(
             size=size,
             from_=from_,
@@ -362,6 +365,9 @@ class SearchLogViewResults:
 class SearchLogResults(Iterable):
     """Captures the response from a search against Atlan's recent search logs."""
 
+    _DEFAULT_SIZE = DSL.__fields__.get("size").default or 300  # type: ignore[union-attr]
+    _MASS_EXTRACT_THRESHOLD = 10000 - _DEFAULT_SIZE
+
     def __init__(
         self,
         client: ApiCaller,
@@ -371,15 +377,21 @@ class SearchLogResults(Iterable):
         count: int,
         log_entries: List[SearchLogEntry],
         aggregations: Dict[str, Aggregation],
+        bulk: bool = False,
     ):
         self._client = client
         self._endpoint = SEARCH_LOG
         self._criteria = criteria
         self._start = start
         self._size = size
-        self._count = count
         self._log_entries = log_entries
+        self._count = count
+        self._approximate_count = count
         self._aggregations = aggregations
+        self._bulk = bulk
+        self._first_record_creation_time = -2
+        self._last_record_creation_time = -2
+        self._processed_entity_keys: Set[str] = set()
 
     @property
     def count(self) -> int:
@@ -393,6 +405,11 @@ class SearchLogResults(Iterable):
         """
         return self._log_entries
 
+    # Generating a unique key by combining entity_guids_all[0] with the timestamp to differentiate between logs.
+    # This is necessary as the API call lacks a unique identifier.
+    def _generate_unique_key(self, entity: SearchLogEntry) -> str:
+        return f"{entity.entity_guids_all[0]}:{entity.timestamp}"
+
     def next_page(self, start=None, size=None) -> bool:
         """
         Indicates whether there is a next page of results.
@@ -400,8 +417,21 @@ class SearchLogResults(Iterable):
         :returns: True if there is a next page of results, otherwise False
         """
         self._start = start or self._start + self._size
+        is_bulk_search = (
+            self._bulk or self._approximate_count > self._MASS_EXTRACT_THRESHOLD
+        )
         if size:
             self._size = size
+
+        if is_bulk_search:
+            # Used in the "timestamp-based" paging approach
+            # to check if search log with the unique key "_generate_unique_key()" has already been processed
+            # in a previous page of results.
+            # If it has,then exclude it from the current results;
+            # otherwise, we may encounter duplicate search log entity records.
+            self._processed_entity_keys.update(
+                self._generate_unique_key(entity) for entity in self._log_entries
+            )
         return self._get_next_page() if self._log_entries else False
 
     def _get_next_page(self):
@@ -410,14 +440,21 @@ class SearchLogResults(Iterable):
 
         :returns: True if the next page of results was fetched, False if there was no next page
         """
+        query = self._criteria.dsl.query
         self._criteria.dsl.from_ = self._start
         self._criteria.dsl.size = self._size
-        if raw_json := self._get_next_page_json():
+        is_bulk_search = (
+            self._bulk or self._approximate_count > self._MASS_EXTRACT_THRESHOLD
+        )
+        if is_bulk_search:
+            self._prepare_query_for_timestamp_paging(query)
+
+        if raw_json := self._get_next_page_json(is_bulk_search):
             self._count = raw_json.get("approximateCount", 0)
             return True
         return False
 
-    def _get_next_page_json(self):
+    def _get_next_page_json(self, is_bulk_search: bool = False):
         """
         Fetches the next page of results and returns the raw JSON of the retrieval.
 
@@ -432,11 +469,131 @@ class SearchLogResults(Iterable):
             return None
         try:
             self._log_entries = parse_obj_as(List[SearchLogEntry], raw_json["logs"])
+            if is_bulk_search:
+                self._update_first_last_record_creation_times()
+                self._filter_processed_entities()
             return raw_json
         except ValidationError as err:
             raise ErrorCode.JSON_ERROR.exception_with_parameters(
                 raw_json, 200, str(err)
             ) from err
+
+    def _filter_processed_entities(self):
+        """
+        Removes entities that have already been processed to avoid duplicates.
+        """
+        self._log_entries = [
+            entity
+            for entity in self._log_entries
+            if self._generate_unique_key(entity) not in self._processed_entity_keys
+        ]
+
+    def _prepare_query_for_timestamp_paging(self, query: Query):
+        """
+        Adjusts the query to include timestamp filters for search log bulk extraction.
+        """
+        rewritten_filters = []
+        if isinstance(query, Bool):
+            for filter_ in query.filter:
+                if self._is_paging_timestamp_query(filter_):
+                    continue
+                rewritten_filters.append(filter_)
+
+        if self._first_record_creation_time != self._last_record_creation_time:
+            rewritten_filters.append(
+                self._get_paging_timestamp_query(self._last_record_creation_time)
+            )
+            if isinstance(query, Bool):
+                rewritten_query = Bool(
+                    filter=rewritten_filters,
+                    must=query.must,
+                    must_not=query.must_not,
+                    should=query.should,
+                    boost=query.boost,
+                    minimum_should_match=query.minimum_should_match,
+                )
+            else:
+                # If a Term, Range, etc query type is found
+                # in the DSL, append it to the Bool `filter`.
+                rewritten_filters.append(query)
+                rewritten_query = Bool(filter=rewritten_filters)
+            self._criteria.dsl.from_ = 0
+            self._criteria.dsl.query = rewritten_query
+        else:
+            # Ensure that when switching to offset-based paging, if the first and last record timestamps are the same,
+            # we do not include a created timestamp filter (ie: Range(field='__timestamp', gte=VALUE)) in the query.
+            # Instead, ensure the search runs with only SortItem(field='__timestamp', order=<SortOrder.ASCENDING>).
+            # Failing to do so can lead to incomplete results (less than the approximate count) when running the search
+            # with a small page size.
+            if isinstance(query, Bool):
+                for filter_ in query.filter:
+                    if self._is_paging_timestamp_query(filter_):
+                        query.filter.remove(filter_)
+
+            # Always ensure that the offset is set to the length of the processed assets
+            # instead of the default (start + size), as the default may skip some assets
+            # and result in incomplete results (less than the approximate count)
+            self._criteria.dsl.from_ = len(self._processed_entity_keys)
+
+    @staticmethod
+    def _get_paging_timestamp_query(last_timestamp: int) -> Query:
+        return Range(field="createdAt", gte=last_timestamp)
+
+    @staticmethod
+    def _is_paging_timestamp_query(filter_: Query) -> bool:
+        return (
+            isinstance(filter_, Range)
+            and filter_.field == "createdAt"
+            and filter_.gte is not None
+        )
+
+    def _update_first_last_record_creation_times(self):
+        if self._log_entries and len(self._log_entries) > 1:
+            self._first_record_creation_time = self._log_entries[0].created_at
+            self._last_record_creation_time = self._log_entries[-1].created_at
+
+    @staticmethod
+    def presorted_by_timestamp(sorts: Optional[List[SortItem]]) -> bool:
+        """
+        Checks if the sorting options prioritize creation time in ascending order.
+        :param sorts: list of sorting options or None.
+        :returns: True if sorting is already prioritized by creation time, False otherwise.
+        """
+        if sorts and isinstance(sorts[0], SortItem):
+            return (
+                sorts[0].field == "createdAt" and sorts[0].order == SortOrder.ASCENDING
+            )
+        return False
+
+    @staticmethod
+    def sort_by_timestamp_first(sorts: List[SortItem]) -> List[SortItem]:
+        """
+        Rewrites the sorting options to ensure that
+        sorting by creation time, ascending, is the top
+        priority. Adds this condition if it does not
+        already exist, or moves it up to the top sorting
+        priority if it does already exist in the list.
+
+        :param sorts: list of sorting options
+        :returns: sorting options, making sorting by
+        creation time in ascending order the top priority
+        """
+        creation_asc_sort = [SortItem("createdAt", order=SortOrder.ASCENDING)]
+        if not sorts:
+            return creation_asc_sort
+
+        rewritten_sorts = [
+            sort
+            for sort in sorts
+            # Added a condition to disable TimeStamp sorting when bulk search for logs is enabled,
+            # as sorting is already handled based on createdAt in this case.
+            if (
+                (not sort.field)
+                or (sort.field != Asset.CREATE_TIME.internal_field_name)
+            )
+            and (sort not in BY_TIMESTAMP)
+        ]
+        return creation_asc_sort + rewritten_sorts
 
     def __iter__(self) -> Generator[SearchLogEntry, None, None]:
         """

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -7,7 +7,8 @@ import pytest
 from pydantic.v1 import StrictStr
 
 from pyatlan.client.atlan import AtlanClient
-from pyatlan.client.audit import LOGGER
+from pyatlan.client.audit import LOGGER as AUDIT_LOGGER
+from pyatlan.client.search_log import LOGGER as SEARCH_LOG_LOGGER
 from pyatlan.client.search_log import (
     AssetViews,
     SearchLogRequest,
@@ -610,7 +611,7 @@ def _assert_audit_search_results(results, expected_sorts, size, total_count):
 
 
 @pytest.mark.order(after="test_audit_find_by_user")
-@patch.object(LOGGER, "debug")
+@patch.object(AUDIT_LOGGER, "debug")
 def test_audit_search_pagination(
     mock_logger, audit_info: AuditInfo, client: AtlanClient
 ):
@@ -920,6 +921,106 @@ def test_search_log_views_by_guid(
         pytest.fail("Failed to retrieve asset detailed log entries")
     assert response.count == 0
     assert len(response.current_page()) == 0
+
+
+@pytest.mark.order(before="test_search_log_pagination")
+def test_generate_search_logs(client: AtlanClient, sl_glossary: AtlasGlossary):
+    log_count = 10
+
+    for _ in range(log_count):
+        _view_test_glossary_by_search(client, sl_glossary)
+        time.sleep(1)
+
+    request = SearchLogRequest.views_by_guid(guid=sl_glossary.guid, size=20)
+    response = client.search_log.search(request)
+    assert (
+        response.count >= log_count
+    ), f"Expected at least {log_count} logs, but got {response.count}."
+
+
+def _assert_search_log_results(results, expected_sorts, size, total_count):
+    assert results.count > size
+    assert len(results.current_page()) == size
+    assert results.count == total_count
+    assert results._criteria.dsl.sort == expected_sorts
+
+
+@pytest.mark.order(after="test_search_log_views_by_guid")
+@patch.object(SEARCH_LOG_LOGGER, "debug")
+def test_search_log_pagination(
+    mock_logger, sl_glossary: AtlasGlossary, client: AtlanClient
+):
+    size = 2
+    # Test search logs by GUID with default offset-based pagination
+    search_log_request = SearchLogRequest.views_by_guid(
+        guid=sl_glossary.guid,
+        size=size,
+        exclude_users=[],
+    )
+    results = client.search_log.search(criteria=search_log_request, bulk=False)
+    total_count = results.count
+    expected_sorts = [
+        SortItem(field="timestamp", order=SortOrder.ASCENDING),
+        SortItem(field="entityGuidsAll", order=SortOrder.ASCENDING),
+    ]
+    _assert_search_log_results(results, expected_sorts, size, total_count)
+
+    # Test search logs by GUID with `bulk` option using timestamp-based pagination
+    results = client.search_log.search(criteria=search_log_request, bulk=True)
+    total_count = results.count
+    expected_sorts = [
+        SortItem(field="createdAt", order=SortOrder.ASCENDING),
+        SortItem(field="entityGuidsAll", order=SortOrder.ASCENDING),
+    ]
+    _assert_search_log_results(results, expected_sorts, size, total_count)
+    assert mock_logger.call_count == 1
+    assert (
+        "Search log bulk search option is enabled."
+        in mock_logger.call_args_list[0][0][0]
+    )
+    mock_logger.reset_mock()
+
+    # When the number of results exceeds the predefined threshold and bulk=True
+    with patch.object(SearchLogResults, "_MASS_EXTRACT_THRESHOLD", -1):
+        search_log_request = SearchLogRequest.views_by_guid(
+            guid=sl_glossary.guid,
+            size=size,
+            exclude_users=[],
+        )
+        results = client.search_log.search(criteria=search_log_request, bulk=True)
+        total_count = results.count
+        expected_sorts = [
+            SortItem(field="createdAt", order=SortOrder.ASCENDING),
+            SortItem(field="entityGuidsAll", order=SortOrder.ASCENDING),
+        ]
+        _assert_search_log_results(results, expected_sorts, size, total_count)
+        assert mock_logger.call_count < total_count
+        assert (
+            "Search log bulk search option is enabled."
+            in mock_logger.call_args_list[0][0][0]
+        )
+        mock_logger.reset_mock()
+
+    # When results exceed threshold and bulk=False, SDK auto-switches to bulk search
+    with patch.object(SearchLogResults, "_MASS_EXTRACT_THRESHOLD", -1):
+        search_log_request = SearchLogRequest.views_by_guid(
+            guid=sl_glossary.guid,
+            size=size,
+            exclude_users=[],
+        )
+        results = client.search_log.search(criteria=search_log_request, bulk=False)
+        total_count = results.count
+        expected_sorts = [
+            SortItem(field="createdAt", order=SortOrder.ASCENDING),
+            SortItem(field="entityGuidsAll", order=SortOrder.ASCENDING),
+        ]
+        _assert_search_log_results(results, expected_sorts, size, total_count)
+        assert mock_logger.call_count < total_count
+        assert (
+            "Result size (%s) exceeds threshold (%s)."
+            in mock_logger.call_args_list[0][0][0]
+        )
+        mock_logger.reset_mock()
 
 
 def test_search_log_default_sorting(client: AtlanClient, sl_glossary: AtlasGlossary):

--- a/tests/unit/data/search_responses/search_log_search_paging.json
+++ b/tests/unit/data/search_responses/search_log_search_paging.json
@@ -1,0 +1,79 @@
+{
+    "approximateCount": 2,
+    "logs": [
+      {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        "host": "fieldtec34.atlan.com",
+        "ipAddress": "10.159.1.190",
+        "userName": "aryaman",
+        "entityGuidsAll": ["2be6f58d-fd8a-44fe-a43e-f97b150cd1dd"],
+        "entityQFNamesAll": ["W7YoLhzkzLnaqWpLg2k5M@LwP6giikgVbDg1lDyiZzx"],
+        "entityGuidsAllowed": ["2be6f58d-fd8a-44fe-a43e-f97b150cd1dd"],
+        "entityQFNamesAllowed": ["W7YoLhzkzLnaqWpLg2k5M@LwP6giikgVbDg1lDyiZzx"],
+        "entityTypeNamesAll": ["AtlasGlossaryTerm"],
+        "entityTypeNamesAllowed": ["AtlasGlossaryTerm"],
+        "utmTags": ["project_webapp", "action_asset_viewed", "asset_type_atlasglossaryterm", "page_glossary", "ui_profile"],
+        "hasResult": true,
+        "resultsCount": 1,
+        "responseTime": 63,
+        "createdAt": 1733492035914,
+        "timestamp": 1733492035849,
+        "failed": false,
+        "request.dsl": {
+          "from": 0,
+          "size": 1,
+          "query": {
+            "bool": {
+              "filter": {
+                "bool": {
+                  "must": {"term": {"__guid": "2be6f58d-fd8a-44fe-a43e-f97b150cd1dd"}},
+                  "must_not": [{"term": {"isPartial": "true"}}]
+                }
+              }
+            }
+          },
+          "sort": []
+        },
+        "request.dslText": "{\"from\":0,\"size\":1,\"query\":{\"bool\":{\"filter\":{\"bool\":{\"must\":{\"term\":{\"__guid\":\"2be6f58d-fd8a-44fe-a43e-f97b150cd1dd\"}},\"must_not\":[{\"term\":{\"isPartial\":\"true\"}}]}}}},\"sort\":[]}",
+        "request.attributes": ["metricTimestampColumn", "termType", "glossaryType"],
+        "request.relationAttributes": ["outputs", "inputs"]
+      },
+      {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        "host": "fieldtec34.atlan.com",
+        "ipAddress": "10.159.1.191",
+        "userName": "raj",
+        "entityGuidsAll": ["2be6f58d-fd8a-44fe-a43e-f97b150cd1de"],
+        "entityQFNamesAll": ["L4YoPiykzWmaqWpLg4k7N@LwP6giikgVbDg1lDyiZzx"],
+        "entityGuidsAllowed": ["2be6f58d-fd8a-44fe-a43e-f97b150cd1de"],
+        "entityQFNamesAllowed": ["L4YoPiykzWmaqWpLg4k7N@LwP6giikgVbDg1lDyiZzx"],
+        "entityTypeNamesAll": ["AtlasGlossaryTerm"],
+        "entityTypeNamesAllowed": ["AtlasGlossaryTerm"],
+        "utmTags": ["project_webapp", "action_asset_viewed", "asset_type_atlasglossaryterm", "page_glossary", "ui_profile"],
+        "hasResult": true,
+        "resultsCount": 1,
+        "responseTime": 99,
+        "createdAt": 1733492069057,
+        "timestamp": 1733492068957,
+        "failed": false,
+        "request.dsl": {
+          "from": 0,
+          "size": 1,
+          "query": {
+            "bool": {
+              "filter": {
+                "bool": {
+                  "must": {"term": {"__guid": "2be6f58d-fd8a-44fe-a43e-f97b150cd1de"}},
+                  "must_not": [{"term": {"isPartial": "true"}}]
+                }
+              }
+            }
+          },
+          "sort": []
+        },
+        "request.dslText": "{\"from\":0,\"size\":1,\"query\":{\"bool\":{\"filter\":{\"bool\":{\"must\":{\"term\":{\"__guid\":\"2be6f58d-fd8a-44fe-a43e-f97b150cd1de\"}},\"must_not\":[{\"term\":{\"isPartial\":\"true\"}}]}}}},\"sort\":[]}",
+        "request.attributes": ["metricTimestampColumn", "termType", "glossaryType"],
+        "request.relationAttributes": ["outputs", "inputs"]
+      }
+    ]
+  }

--- a/tests/unit/data/search_responses/search_log_search_paging.json
+++ b/tests/unit/data/search_responses/search_log_search_paging.json
@@ -1,5 +1,5 @@
 {
-    "approximateCount": 2,
+    "approximateCount": 1,
     "logs": [
       {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
@@ -35,43 +35,6 @@
           "sort": []
         },
         "request.dslText": "{\"from\":0,\"size\":1,\"query\":{\"bool\":{\"filter\":{\"bool\":{\"must\":{\"term\":{\"__guid\":\"2be6f58d-fd8a-44fe-a43e-f97b150cd1dd\"}},\"must_not\":[{\"term\":{\"isPartial\":\"true\"}}]}}}},\"sort\":[]}",
-        "request.attributes": ["metricTimestampColumn", "termType", "glossaryType"],
-        "request.relationAttributes": ["outputs", "inputs"]
-      },
-      {
-        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-        "host": "fieldtec34.atlan.com",
-        "ipAddress": "10.159.1.191",
-        "userName": "raj",
-        "entityGuidsAll": ["2be6f58d-fd8a-44fe-a43e-f97b150cd1de"],
-        "entityQFNamesAll": ["L4YoPiykzWmaqWpLg4k7N@LwP6giikgVbDg1lDyiZzx"],
-        "entityGuidsAllowed": ["2be6f58d-fd8a-44fe-a43e-f97b150cd1de"],
-        "entityQFNamesAllowed": ["L4YoPiykzWmaqWpLg4k7N@LwP6giikgVbDg1lDyiZzx"],
-        "entityTypeNamesAll": ["AtlasGlossaryTerm"],
-        "entityTypeNamesAllowed": ["AtlasGlossaryTerm"],
-        "utmTags": ["project_webapp", "action_asset_viewed", "asset_type_atlasglossaryterm", "page_glossary", "ui_profile"],
-        "hasResult": true,
-        "resultsCount": 1,
-        "responseTime": 99,
-        "createdAt": 1733492069057,
-        "timestamp": 1733492068957,
-        "failed": false,
-        "request.dsl": {
-          "from": 0,
-          "size": 1,
-          "query": {
-            "bool": {
-              "filter": {
-                "bool": {
-                  "must": {"term": {"__guid": "2be6f58d-fd8a-44fe-a43e-f97b150cd1de"}},
-                  "must_not": [{"term": {"isPartial": "true"}}]
-                }
-              }
-            }
-          },
-          "sort": []
-        },
-        "request.dslText": "{\"from\":0,\"size\":1,\"query\":{\"bool\":{\"filter\":{\"bool\":{\"must\":{\"term\":{\"__guid\":\"2be6f58d-fd8a-44fe-a43e-f97b150cd1de\"}},\"must_not\":[{\"term\":{\"isPartial\":\"true\"}}]}}}},\"sort\":[]}",
         "request.attributes": ["metricTimestampColumn", "termType", "glossaryType"],
         "request.relationAttributes": ["outputs", "inputs"]
       }

--- a/tests/unit/test_search_log_search.py
+++ b/tests/unit/test_search_log_search.py
@@ -1,0 +1,153 @@
+from datetime import datetime, timezone
+from json import load
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pyatlan.client.search_log import LOGGER, SearchLogClient
+from pyatlan.errors import InvalidRequestError
+from pyatlan.model.enums import SortOrder
+from pyatlan.model.search import SortItem
+from pyatlan.model.search_log import SearchLogRequest, SearchLogResults
+
+SEARCH_RESPONSES_DIR = Path(__file__).parent / "data" / "search_responses"
+SEARCH_LOGS_JSON = "search_log_search_paging.json"
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://name.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "abkj")
+
+
+@pytest.fixture(scope="module")
+def mock_api_caller():
+    return Mock()
+
+
+@pytest.fixture()
+def search_logs_json():
+    def load_json(filename):
+        with (SEARCH_RESPONSES_DIR / filename).open() as input_file:
+            return load(input_file)
+
+    return load_json(SEARCH_LOGS_JSON)
+
+
+def _assert_search_log_results(results, response_json, sorts, bulk=False):
+    for i, log in enumerate(results.current_page()):
+        assert log.user_name == response_json["logs"][i]["userName"]
+        assert log.user_agent == response_json["logs"][i]["userAgent"]
+        assert log.ip_address == response_json["logs"][i]["ipAddress"]
+        assert log.host == response_json["logs"][i]["host"]
+        expected_timestamp = datetime.fromtimestamp(
+            response_json["logs"][i]["timestamp"] / 1000, tz=timezone.utc
+        )
+        assert log.timestamp == expected_timestamp
+        assert log.entity_guids_all == response_json["logs"][i]["entityGuidsAll"]
+
+    assert results.count == response_json["approximateCount"]
+    assert results._bulk == bulk
+    assert results._criteria.dsl.sort == sorts
+
+
+@patch.object(LOGGER, "debug")
+def test_search_log_pagination(mock_logger, mock_api_caller, search_logs_json):
+    client = SearchLogClient(mock_api_caller)
+    mock_api_caller._call_api.side_effect = [search_logs_json, search_logs_json, {}]
+
+    # Test default pagination
+    search_log_request = SearchLogRequest.views_by_guid(  #
+        guid="some-guid",
+        size=2,
+        exclude_users=["atlansupport"],
+    )
+
+    response = client.search(criteria=search_log_request, bulk=False)
+    expected_sorts = [
+        SortItem(field="timestamp", order=SortOrder.ASCENDING),
+        SortItem(field="entityGuidsAll", order=SortOrder.ASCENDING),
+    ]
+
+    _assert_search_log_results(response, search_logs_json, expected_sorts)
+    assert mock_api_caller._call_api.call_count == 1
+    mock_logger.reset_mock()
+    mock_api_caller.reset_mock()
+
+    # Test bulk pagination
+    response = client.search(criteria=search_log_request, bulk=True)
+    expected_sorts = [
+        SortItem(field="createdAt", order=SortOrder.ASCENDING),
+        SortItem(field="entityGuidsAll", order=SortOrder.ASCENDING),
+    ]
+
+    _assert_search_log_results(response, search_logs_json, expected_sorts, bulk=True)
+    assert mock_logger.call_count == 1
+    assert (
+        "Search log bulk search option is enabled."
+        in mock_logger.call_args_list[0][0][0]
+    )
+    mock_logger.reset_mock()
+    mock_api_caller.reset_mock()
+
+    # Test automatic bulk search conversion when exceeding threshold
+    with patch.object(SearchLogResults, "_MASS_EXTRACT_THRESHOLD", -1):
+        mock_api_caller._call_api.side_effect = [
+            search_logs_json,
+            search_logs_json,
+            {},
+        ]
+        search_log_request = SearchLogRequest.views_by_guid(  #
+            guid="some-guid",
+            size=2,
+            exclude_users=["atlansupport"],
+        )
+        response = client.search(criteria=search_log_request)
+        _assert_search_log_results(
+            response, search_logs_json, expected_sorts, bulk=False
+        )
+        assert mock_logger.call_count == 1
+        assert (
+            "Result size (%s) exceeds threshold (%s)"
+            in mock_logger.call_args_list[0][0][0]
+        )
+
+        # Test exception for bulk=False with user-defined sorting and results exceeding the threshold
+        search_log_request = SearchLogRequest.views_by_guid(
+            guid="some-guid",
+            size=1,
+            sort=[SortItem(field="some-sort1", order=SortOrder.ASCENDING)],
+            exclude_users=["atlansupport"],
+        )
+        with pytest.raises(
+            InvalidRequestError,
+            match=(
+                "ATLAN-PYTHON-400-067 Unable to execute "
+                "search log bulk search with user-defined sorting options. "
+                "Suggestion: Please ensure that no sorting options are "
+                "included in your search log search request when performing a bulk search."
+            ),
+        ):
+            client.search(criteria=search_log_request, bulk=False)
+
+        # Test exception for bulk=True with user-defined sorting
+        search_log_request = SearchLogRequest.views_by_guid(
+            guid="some-guid",
+            size=1,
+            sort=[SortItem(field="some-sort2", order=SortOrder.ASCENDING)],
+            exclude_users=["atlansupport"],
+        )
+        with pytest.raises(
+            InvalidRequestError,
+            match=(
+                "ATLAN-PYTHON-400-067 Unable to execute "
+                "search log bulk search with user-defined sorting options. "
+                "Suggestion: Please ensure that no sorting options are "
+                "included in your search log search request when performing a bulk search."
+            ),
+        ):
+            client.search(criteria=search_log_request, bulk=True)
+
+    mock_logger.reset_mock()
+    mock_api_caller.reset_mock()


### PR DESCRIPTION
Implementing a query rewrite for a time-based pagination approach for search, known as bulk search, based on asset creation timestamps. This approach is used when the number of results exceeds the predefined threshold (i.e: 10,000 assets). Users can explicitly run this search by setting the optional keyword argument bulk=True in the  search_log.search() methods.

- [x] Implementation
- [x] Local Testing
- [x] Unit Tests
- [x] Integration Tests

