### PR TITLE
FT-892: Ensure create_with_prefix sets the s3BucketName attribute

### DIFF
--- a/pyatlan/model/assets/s3_object.py
+++ b/pyatlan/model/assets/s3_object.py
@@ -33,6 +33,7 @@ class S3Object(S3):
         name: str,
         connection_qualified_name: str,
         aws_arn: str,
+        s3_bucket_name: str,
         s3_bucket_qualified_name: str,
     ) -> S3Object:
         validate_required_fields(
@@ -40,14 +41,16 @@ class S3Object(S3):
                 "name",
                 "connection_qualified_name",
                 "aws_arn",
+                "s3_bucket_name",
                 "s3_bucket_qualified_name",
             ],
-            [name, connection_qualified_name, aws_arn, s3_bucket_qualified_name],
+            [name, connection_qualified_name, aws_arn,s3_bucket_name,s3_bucket_qualified_name],
         )
         attributes = S3Object.Attributes.create(
             name=name,
             connection_qualified_name=connection_qualified_name,
             aws_arn=aws_arn,
+            s3_bucket_name=s3_bucket_name,
             s3_bucket_qualified_name=s3_bucket_qualified_name,
         )
         return cls(attributes=attributes)
@@ -60,6 +63,7 @@ class S3Object(S3):
         name: str,
         connection_qualified_name: str,
         aws_arn: str,
+        s3_bucket_name: str,
         s3_bucket_qualified_name: str,
     ) -> S3Object:
         warn(
@@ -74,6 +78,7 @@ class S3Object(S3):
             name=name,
             connection_qualified_name=connection_qualified_name,
             aws_arn=aws_arn,
+            s3_bucket_name=s3_bucket_name,
             s3_bucket_qualified_name=s3_bucket_qualified_name,
         )
 
@@ -85,6 +90,7 @@ class S3Object(S3):
         name: str,
         connection_qualified_name: str,
         prefix: str,
+        s3_bucket_name: str,
         s3_bucket_qualified_name: str,
     ) -> S3Object:
         validate_required_fields(
@@ -92,14 +98,16 @@ class S3Object(S3):
                 "name",
                 "connection_qualified_name",
                 "prefix",
+                "s3_bucket_name",
                 "s3_bucket_qualified_name",
             ],
-            [name, connection_qualified_name, prefix, s3_bucket_qualified_name],
+            [name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name],
         )
         attributes = S3Object.Attributes.create_with_prefix(
             name=name,
             connection_qualified_name=connection_qualified_name,
             prefix=prefix,
+            s3_bucket_name=s3_bucket_name,
             s3_bucket_qualified_name=s3_bucket_qualified_name,
         )
         return cls(attributes=attributes)
@@ -332,6 +340,7 @@ class S3Object(S3):
             name: str,
             connection_qualified_name: str,
             aws_arn: str,
+            s3_bucket_name: str,
             s3_bucket_qualified_name: str,
         ) -> S3Object.Attributes:
             validate_required_fields(
@@ -339,9 +348,10 @@ class S3Object(S3):
                     "name",
                     "connection_qualified_name",
                     "aws_arn",
+                    "s3_bucket_name",
                     "s3_bucket_qualified_name",
                 ],
-                [name, connection_qualified_name, aws_arn, s3_bucket_qualified_name],
+                [name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name],
             )
             fields = connection_qualified_name.split("/")
             if len(fields) != 3:
@@ -360,6 +370,7 @@ class S3Object(S3):
                 connection_qualified_name=connection_qualified_name,
                 qualified_name=f"{connection_qualified_name}/{aws_arn}",
                 connector_name=connector_type.value,
+                s3_bucket_name= s3_bucket_name,
                 s3_bucket_qualified_name=s3_bucket_qualified_name,
                 bucket=S3Bucket.ref_by_qualified_name(s3_bucket_qualified_name),
             )
@@ -372,6 +383,7 @@ class S3Object(S3):
             name: str,
             connection_qualified_name: str,
             prefix: str,
+            s3_bucket_name: str,
             s3_bucket_qualified_name: str,
         ) -> S3Object.Attributes:
             validate_required_fields(
@@ -379,9 +391,10 @@ class S3Object(S3):
                     "name",
                     "connection_qualified_name",
                     "prefix",
+                    "s3_bucket_name",
                     "s3_bucket_qualified_name",
                 ],
-                [name, connection_qualified_name, prefix, s3_bucket_qualified_name],
+                [name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name],
             )
             fields = connection_qualified_name.split("/")
             if len(fields) != 3:
@@ -401,6 +414,7 @@ class S3Object(S3):
                 connection_qualified_name=connection_qualified_name,
                 qualified_name=f"{connection_qualified_name}/{object_key}",
                 connector_name=connector_type.value,
+                s3_bucket_name=s3_bucket_name,
                 s3_bucket_qualified_name=s3_bucket_qualified_name,
                 bucket=S3Bucket.ref_by_qualified_name(s3_bucket_qualified_name),
             )

--- a/pyatlan/model/assets/s3_object.py
+++ b/pyatlan/model/assets/s3_object.py
@@ -44,7 +44,13 @@ class S3Object(S3):
                 "s3_bucket_name",
                 "s3_bucket_qualified_name",
             ],
-            [name, connection_qualified_name, aws_arn,s3_bucket_name,s3_bucket_qualified_name],
+            [
+                name,
+                connection_qualified_name,
+                aws_arn,
+                s3_bucket_name,
+                s3_bucket_qualified_name,
+            ],
         )
         attributes = S3Object.Attributes.create(
             name=name,
@@ -101,7 +107,13 @@ class S3Object(S3):
                 "s3_bucket_name",
                 "s3_bucket_qualified_name",
             ],
-            [name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name],
+            [
+                name,
+                connection_qualified_name,
+                prefix,
+                s3_bucket_name,
+                s3_bucket_qualified_name,
+            ],
         )
         attributes = S3Object.Attributes.create_with_prefix(
             name=name,
@@ -351,7 +363,13 @@ class S3Object(S3):
                     "s3_bucket_name",
                     "s3_bucket_qualified_name",
                 ],
-                [name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name],
+                [
+                    name,
+                    connection_qualified_name,
+                    aws_arn,
+                    s3_bucket_name,
+                    s3_bucket_qualified_name,
+                ],
             )
             fields = connection_qualified_name.split("/")
             if len(fields) != 3:
@@ -370,7 +388,7 @@ class S3Object(S3):
                 connection_qualified_name=connection_qualified_name,
                 qualified_name=f"{connection_qualified_name}/{aws_arn}",
                 connector_name=connector_type.value,
-                s3_bucket_name= s3_bucket_name,
+                s3_bucket_name=s3_bucket_name,
                 s3_bucket_qualified_name=s3_bucket_qualified_name,
                 bucket=S3Bucket.ref_by_qualified_name(s3_bucket_qualified_name),
             )
@@ -394,7 +412,13 @@ class S3Object(S3):
                     "s3_bucket_name",
                     "s3_bucket_qualified_name",
                 ],
-                [name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name],
+                [
+                    name,
+                    connection_qualified_name,
+                    prefix,
+                    s3_bucket_name,
+                    s3_bucket_qualified_name,
+                ],
             )
             fields = connection_qualified_name.split("/")
             if len(fields) != 3:

--- a/tests/integration/s3_asset_test.py
+++ b/tests/integration/s3_asset_test.py
@@ -138,7 +138,7 @@ def _assert_object(s3object, bucket, with_name=False):
     assert s3object.qualified_name
     assert s3object.name == OBJECT_NAME
     assert s3object.connector_name == AtlanConnectorType.S3.value
-    assert s3object.s3_bucket_name == bucket.name    
+    assert s3object.s3_bucket_name == bucket.name
     assert s3object.s3_bucket_qualified_name == bucket.qualified_name
     if with_name:
         assert s3object.aws_arn is None

--- a/tests/integration/s3_asset_test.py
+++ b/tests/integration/s3_asset_test.py
@@ -90,6 +90,7 @@ def s3object(
         name=OBJECT_NAME,
         connection_qualified_name=connection.qualified_name,
         aws_arn=OBJECT_ARN,
+        s3_bucket_name=bucket.name,
         s3_bucket_qualified_name=bucket.qualified_name,
     )
     response = client.asset.save(to_create)
@@ -110,6 +111,7 @@ def s3object_with_name(
         name=OBJECT_NAME,
         connection_qualified_name=connection.qualified_name,
         prefix=OBJECT_PREFIX,
+        s3_bucket_name=bucket_with_name.name,
         s3_bucket_qualified_name=bucket_with_name.qualified_name,
     )
     response = client.asset.save(to_create)
@@ -136,6 +138,7 @@ def _assert_object(s3object, bucket, with_name=False):
     assert s3object.qualified_name
     assert s3object.name == OBJECT_NAME
     assert s3object.connector_name == AtlanConnectorType.S3.value
+    assert s3object.s3_bucket_name == bucket.name    
     assert s3object.s3_bucket_qualified_name == bucket.qualified_name
     if with_name:
         assert s3object.aws_arn is None

--- a/tests/unit/model/s3object_test.py
+++ b/tests/unit/model/s3object_test.py
@@ -13,12 +13,13 @@ from tests.unit.model.constants import (
 
 
 @pytest.mark.parametrize(
-    "name, connection_qualified_name, aws_arn, s3_bucket_qualified_name, msg",
+    "name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name, msg",
     [
         (
             None,
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "name is required",
         ),
@@ -26,6 +27,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             None,
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "connection_qualified_name is required",
         ),
@@ -33,6 +35,7 @@ from tests.unit.model.constants import (
             "",
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "name cannot be blank",
         ),
@@ -40,6 +43,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "connection_qualified_name cannot be blank",
         ),
@@ -47,6 +51,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "default/s3/",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -54,6 +59,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "/s3/",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -61,6 +67,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "default/s3/production/TestDb",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -68,6 +75,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "s3/production",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -75,6 +83,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "default/s33/production",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -82,6 +91,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "default/s3",
             None,
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "aws_arn is required",
         ),
@@ -89,6 +99,7 @@ from tests.unit.model.constants import (
             S3_OBJECT_NAME,
             "default/s3",
             "",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "aws_arn cannot be blank",
         ),
@@ -97,36 +108,56 @@ from tests.unit.model.constants import (
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
             None,
-            "s3_bucket_qualified_name is required",
+            BUCKET_QUALIFIED_NAME,
+            "s3_bucket_name is required",
         ),
         (
             S3_OBJECT_NAME,
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
             "",
+            BUCKET_QUALIFIED_NAME,
+            "s3_bucket_name cannot be blank",
+        ),
+        (
+            S3_OBJECT_NAME,
+            S3_CONNECTION_QUALIFIED_NAME,
+            "abc",
+            BUCKET_NAME,
+            None,
+            "s3_bucket_qualified_name is required",
+        ),
+        (
+            S3_OBJECT_NAME,
+            S3_CONNECTION_QUALIFIED_NAME,
+            "abc",
+            BUCKET_NAME,
+            "",
             "s3_bucket_qualified_name cannot be blank",
         ),
     ],
 )
 def test_create_without_required_parameters_raises_validation_error(
-    name, connection_qualified_name, aws_arn, s3_bucket_qualified_name, msg
+    name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name, msg
 ):
     with pytest.raises(ValueError, match=msg):
         S3Object.create(
             name=name,
             connection_qualified_name=connection_qualified_name,
             aws_arn=aws_arn,
+            s3_bucket_name=s3_bucket_name,
             s3_bucket_qualified_name=s3_bucket_qualified_name,
         )
 
 
 @pytest.mark.parametrize(
-    "name, connection_qualified_name, prefix, s3_bucket_qualified_name, msg",
+    "name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name, msg",
     [
         (
             None,
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "name is required",
         ),
@@ -134,6 +165,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             None,
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "connection_qualified_name is required",
         ),
@@ -141,6 +173,7 @@ def test_create_without_required_parameters_raises_validation_error(
             "",
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "name cannot be blank",
         ),
@@ -148,6 +181,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "connection_qualified_name cannot be blank",
         ),
@@ -155,6 +189,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "default/s3/",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -162,6 +197,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "/s3/",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -169,6 +205,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "default/s3/production/TestDb",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -176,6 +213,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "s3/production",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -183,6 +221,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "default/s33/production",
             "abc",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "Invalid connection_qualified_name",
         ),
@@ -190,6 +229,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "default/s3",
             None,
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "prefix is required",
         ),
@@ -197,6 +237,7 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_OBJECT_NAME,
             "default/s3",
             "",
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
             "prefix cannot be blank",
         ),
@@ -205,47 +246,68 @@ def test_create_without_required_parameters_raises_validation_error(
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
             None,
-            "s3_bucket_qualified_name is required",
+            BUCKET_QUALIFIED_NAME,
+            "s3_bucket_name is required",
         ),
         (
             S3_OBJECT_NAME,
             S3_CONNECTION_QUALIFIED_NAME,
             "abc",
             "",
+            BUCKET_QUALIFIED_NAME,
+            "s3_bucket_name cannot be blank",
+        ),
+        (
+            S3_OBJECT_NAME,
+            S3_CONNECTION_QUALIFIED_NAME,
+            "abc",
+            BUCKET_NAME,
+            None,
+            "s3_bucket_qualified_name is required",
+        ),
+        (
+            S3_OBJECT_NAME,
+            S3_CONNECTION_QUALIFIED_NAME,
+            "abc",
+            BUCKET_NAME,
+            "",
             "s3_bucket_qualified_name cannot be blank",
         ),
     ],
 )
 def test_create_with_prefix_without_required_parameters_raises_validation_error(
-    name, connection_qualified_name, prefix, s3_bucket_qualified_name, msg
+    name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name, msg
 ):
     with pytest.raises(ValueError, match=msg):
         S3Object.create_with_prefix(
             name=name,
             connection_qualified_name=connection_qualified_name,
             prefix=prefix,
+            s3_bucket_name=s3_bucket_name,
             s3_bucket_qualified_name=s3_bucket_qualified_name,
         )
 
 
 @pytest.mark.parametrize(
-    "name, connection_qualified_name, aws_arn, s3_bucket_qualified_name",
+    "name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name",
     [
         (
-            BUCKET_NAME,
+            S3_OBJECT_NAME,
             S3_CONNECTION_QUALIFIED_NAME,
             AWS_ARN,
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
         ),
     ],
 )
 def test_create_with_required_parameters(
-    name, connection_qualified_name, aws_arn, s3_bucket_qualified_name
+    name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name
 ):
     attributes = S3Object.create(
         name=name,
         connection_qualified_name=connection_qualified_name,
         aws_arn=aws_arn,
+        s3_bucket_name=s3_bucket_name,
         s3_bucket_qualified_name=s3_bucket_qualified_name,
     )
     assert attributes.name == name
@@ -253,27 +315,30 @@ def test_create_with_required_parameters(
     assert attributes.aws_arn == aws_arn
     assert attributes.qualified_name == f"{connection_qualified_name}/{aws_arn}"
     assert attributes.connector_name == connection_qualified_name.split("/")[1]
+    assert attributes.s3_bucket_name == s3_bucket_name
     assert attributes.s3_bucket_qualified_name == s3_bucket_qualified_name
 
 
 @pytest.mark.parametrize(
-    "name, connection_qualified_name, prefix, s3_bucket_qualified_name",
+    "name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name",
     [
         (
-            BUCKET_NAME,
+            S3_OBJECT_NAME,
             S3_CONNECTION_QUALIFIED_NAME,
             S3_OBJECT_PREFIX,
+            BUCKET_NAME,
             BUCKET_QUALIFIED_NAME,
         ),
     ],
 )
 def test_create_with_prefix(
-    name, connection_qualified_name, prefix, s3_bucket_qualified_name
+    name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name
 ):
     attributes = S3Object.create_with_prefix(
         name=name,
         connection_qualified_name=connection_qualified_name,
         prefix=prefix,
+        s3_bucket_name=s3_bucket_name,
         s3_bucket_qualified_name=s3_bucket_qualified_name,
     )
     object_key = f"{prefix}/{name}"

--- a/tests/unit/model/s3object_test.py
+++ b/tests/unit/model/s3object_test.py
@@ -138,7 +138,12 @@ from tests.unit.model.constants import (
     ],
 )
 def test_create_without_required_parameters_raises_validation_error(
-    name, connection_qualified_name, aws_arn, s3_bucket_name, s3_bucket_qualified_name, msg
+    name,
+    connection_qualified_name,
+    aws_arn,
+    s3_bucket_name,
+    s3_bucket_qualified_name,
+    msg,
 ):
     with pytest.raises(ValueError, match=msg):
         S3Object.create(
@@ -276,7 +281,12 @@ def test_create_without_required_parameters_raises_validation_error(
     ],
 )
 def test_create_with_prefix_without_required_parameters_raises_validation_error(
-    name, connection_qualified_name, prefix, s3_bucket_name, s3_bucket_qualified_name, msg
+    name,
+    connection_qualified_name,
+    prefix,
+    s3_bucket_name,
+    s3_bucket_qualified_name,
+    msg,
 ):
     with pytest.raises(ValueError, match=msg):
         S3Object.create_with_prefix(


### PR DESCRIPTION
- Added `s3_bucket_name` parameter in S3Object.create() method
- Added `s3_bucket_name` parameter in S3Object.create_with_prefix() method

- [x] Do the required changes in the code
- [x] Update the unit tests
- [x] Update the integration tests
- [x] Update the docs