### PR TITLE
APP-4749: Added support for Python `3.12` and `3.13.1` (latest)

### DIFF
--- a/.github/workflows/pyatlan-pr.yaml
+++ b/.github/workflows/pyatlan-pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.12]
 
     steps:
       - name: Checkout code
@@ -39,7 +39,7 @@ jobs:
       files: ${{ steps.distribute-integration-test-files.outputs.files }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pyatlan-pr.yaml
+++ b/.github/workflows/pyatlan-pr.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.12]
+        # Specify version as a string
+        # https://github.com/actions/setup-python/issues/160"
+        python-version: ["3.8", "3.12", "3.13"]
 
     steps:
       - name: Checkout code
@@ -39,7 +41,9 @@ jobs:
       files: ${{ steps.distribute-integration-test-files.outputs.files }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        # Specify version as a string
+        # https://github.com/actions/setup-python/issues/160"
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout code
@@ -94,7 +98,9 @@ jobs:
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          # Specify version as a string
+          # https://github.com/actions/setup-python/issues/160"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |

--- a/pyatlan/cache/abstract_asset_cache.py
+++ b/pyatlan/cache/abstract_asset_cache.py
@@ -131,7 +131,7 @@ class AbstractAssetCache(ABC):
                 qualified_name,
                 AtlanConnectorType._get_connector_type_from_qualified_name(
                     qualified_name
-                ),
+                ).value,
             )
         return self._get_by_guid(guid=guid, allow_refresh=False)
 

--- a/pyatlan/client/open_lineage.py
+++ b/pyatlan/client/open_lineage.py
@@ -116,6 +116,6 @@ class OpenLineageClient:
                 )
             ):
                 raise ErrorCode.OPENLINEAGE_NOT_CONFIGURED.exception_with_parameters(
-                    connector_type
+                    connector_type.value
                 ) from e
             raise e

--- a/pyatlan/client/workflow.py
+++ b/pyatlan/client/workflow.py
@@ -245,7 +245,7 @@ class WorkflowClient:
                 detail = results[0].source
             else:
                 raise ErrorCode.NO_PRIOR_RUN_AVAILABLE.exception_with_parameters(
-                    workflow
+                    workflow.value
                 )
         elif isinstance(workflow, WorkflowSearchResult):
             detail = workflow.source

--- a/pyatlan/model/fields/atlan_fields.py
+++ b/pyatlan/model/fields/atlan_fields.py
@@ -903,7 +903,7 @@ class LineageFilterFieldCM(LineageFilterField):
                 self._cm_field.attribute_def.type_name or "", ComparisonCategory.BOOLEAN
             ):
                 raise ErrorCode.INVALID_QUERY.exception_with_parameters(
-                    AtlanComparisonOperator.EQ,
+                    AtlanComparisonOperator.EQ.value,
                     f"{self._cm_field.set_name}.{self._cm_field.attribute_name}",
                 )
             return LineageFilter(
@@ -977,7 +977,7 @@ class LineageFilterFieldCM(LineageFilterField):
                 self._cm_field.attribute_def.type_name or "", ComparisonCategory.BOOLEAN
             ):
                 raise ErrorCode.INVALID_QUERY.exception_with_parameters(
-                    AtlanComparisonOperator.NEQ,
+                    AtlanComparisonOperator.NEQ.value,
                     f"{self._cm_field.set_name}.{self._cm_field.attribute_name}",
                 )
             return LineageFilter(
@@ -1228,7 +1228,7 @@ class LineageFilterFieldCM(LineageFilterField):
             self._cm_field.attribute_def.type_name or "", ComparisonCategory.NUMBER
         ):
             raise ErrorCode.INVALID_QUERY.exception_with_parameters(
-                comparison_operator,
+                comparison_operator.value,
                 f"{self._cm_field.set_name}.{self._cm_field.attribute_name}",
             )
         return LineageFilter(
@@ -1246,7 +1246,7 @@ class LineageFilterFieldCM(LineageFilterField):
             self._cm_field.attribute_def.type_name or "", ComparisonCategory.STRING
         ):
             raise ErrorCode.INVALID_QUERY.exception_with_parameters(
-                comparison_operator,
+                comparison_operator.value,
                 f"{self._cm_field.set_name}.{self._cm_field.attribute_name}",
             )
         return LineageFilter(

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,10 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Development Status :: 5 - Production/Stable",

--- a/tests/integration/test_file_client.py
+++ b/tests/integration/test_file_client.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Atlan Pte. Ltd.
 
-import imghdr
+import imghdr  # type: ignore[import-not-found]
 import os
 from pathlib import Path
 

--- a/tests/unit/test_audit_search.py
+++ b/tests/unit/test_audit_search.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from pyatlan.client.audit import LOGGER, AuditClient
+from pyatlan.client.common import ApiCaller
 from pyatlan.errors import InvalidRequestError
 from pyatlan.model.audit import AuditSearchRequest, AuditSearchResults
 from pyatlan.model.enums import SortOrder
@@ -24,7 +25,7 @@ def set_env(monkeypatch):
 
 @pytest.fixture(scope="module")
 def mock_api_caller():
-    return Mock()
+    return Mock(spec=ApiCaller)
 
 
 @pytest.fixture()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2151,21 +2151,21 @@ class TestBatch:
         assert [table_3, table_4] == failure.failed_assets
         assert exception == failure.failure_reason
         if custom_metadata_handling == CustomMetadataHandling.IGNORE:
-            mock_atlan_client.asset.save.has_calls(
+            mock_atlan_client.asset.save.assert_has_calls(
                 [
                     call([table_1, table_2], replace_atlan_tags=False),
                     call([table_3, table_4], replace_atlan_tags=False),
                 ]
             )
         elif custom_metadata_handling == CustomMetadataHandling.OVERWRITE:
-            mock_atlan_client.asset.save_replacing_cm.has_calls(
+            mock_atlan_client.asset.save_replacing_cm.assert_has_calls(
                 [
                     call([table_1, table_2], replace_atlan_tags=False),
                     call([table_3, table_4], replace_atlan_tags=False),
                 ]
             )
         else:
-            mock_atlan_client.asset.save_merging_cm.has_calls(
+            mock_atlan_client.asset.save_merging_cm.assert_has_calls(
                 [
                     call([table_1, table_2], replace_atlan_tags=False),
                     call([table_3, table_4], replace_atlan_tags=False),

--- a/tests/unit/test_search_log_search.py
+++ b/tests/unit/test_search_log_search.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from pyatlan.client.common import ApiCaller
 from pyatlan.client.search_log import LOGGER, SearchLogClient
 from pyatlan.errors import InvalidRequestError
 from pyatlan.model.enums import SortOrder
@@ -23,7 +24,7 @@ def set_env(monkeypatch):
 
 @pytest.fixture(scope="module")
 def mock_api_caller():
-    return Mock()
+    return Mock(spec=ApiCaller)
 
 
 @pytest.fixture()

--- a/tests/unit/test_search_model.py
+++ b/tests/unit/test_search_model.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Atlan Pte. Ltd.
 from datetime import datetime
+from re import escape
 from typing import Dict, Literal, Set, Union
 
 import pytest
@@ -111,9 +112,11 @@ INCOMPATIPLE_QUERY: Dict[type, Set[TermAttributes]] = {
     ],
 )
 def test_term_without_parameters_value_raises_exception(parameters, expected):
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(
+        TypeError,
+        match=escape(expected),
+    ):
         Term(**parameters)
-    assert exc_info.value.args[0] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_workflow_client.py
+++ b/tests/unit/test_workflow_client.py
@@ -238,7 +238,7 @@ def test_find_by_type(client: WorkflowClient, mock_api_caller):
     mock_api_caller._call_api.return_value = raw_json
 
     assert client.find_by_type(prefix=WorkflowPackage.FIVETRAN) == []
-    mock_api_caller._call_api.called_once()
+    mock_api_caller._call_api.assert_called_once()
     assert mock_api_caller._call_api.call_args.args[0] == WORKFLOW_INDEX_SEARCH
     assert isinstance(
         mock_api_caller._call_api.call_args.kwargs["request_obj"], WorkflowSearchRequest
@@ -256,7 +256,7 @@ def test_find_by_id(
         client.find_by_id(id="atlan-snowflake-miner-1714638976")
         == search_response.hits.hits[0]
     )
-    mock_api_caller._call_api.called_once()
+    mock_api_caller._call_api.assert_called_once()
     assert mock_api_caller._call_api.call_args.args[0] == WORKFLOW_INDEX_SEARCH
     assert isinstance(
         mock_api_caller._call_api.call_args.kwargs["request_obj"], WorkflowSearchRequest
@@ -274,7 +274,7 @@ def test_find_run_by_id(
         client.find_run_by_id(id="atlan-snowflake-miner-1714638976-mzdza")
         == search_response.hits.hits[0]
     )
-    mock_api_caller._call_api.called_once()
+    mock_api_caller._call_api.assert_called_once()
     assert mock_api_caller._call_api.call_args.args[0] == WORKFLOW_INDEX_RUN_SEARCH
     assert isinstance(
         mock_api_caller._call_api.call_args.kwargs["request_obj"], WorkflowSearchRequest


### PR DESCRIPTION
- Updated the code to use `enum.value` instead of `enum`.

In Python versions < `3.12`, `enum` was implicitly converted to `enum.value` during string test assertions. However, in Python >= `3.12`, this implicit conversion no longer occurs, causing unit test failures. To ensure consistency, we should explicitly use `enum.value` when raising any `AtlanError`.

- Expanded the Python version matrix in the Pyatlan PR CI to include `[3.8, 3.9, 3.10, 3.11, 3.12, 3.13]` for unit testing.