### PR TITLE
APP-5054: Increased default read timeout to `15` minutes for `AtlanClient`

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -144,8 +144,8 @@ class AtlanClient(BaseSettings):
     _default_client: "ClassVar[Optional[AtlanClient]]" = None
     base_url: Union[Literal["INTERNAL"], HttpUrl]
     api_key: str
-    connect_timeout: float = 30.0
-    read_timeout: float = 120.0
+    connect_timeout: float = 30.0  # 30 secs
+    read_timeout: float = 900.0  # 15 mins
     retry: Retry = DEFAULT_RETRY
     _session: requests.Session = PrivateAttr(default_factory=get_session)
     _request_params: dict = PrivateAttr()


### PR DESCRIPTION
As discussed, for valid cases in the lineage listing API that may take longer, we've decided to increase the default `read` timeout of the client to 15 minutes.