### PR TITLE
APP-5519: Migrated `AtlanClient._default_client` to thread-local storage + caches now bound to optional client

### DIFF
--- a/pyatlan/cache/abstract_asset_cache.py
+++ b/pyatlan/cache/abstract_asset_cache.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import threading
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any, Dict
 
 from pyatlan.errors import ErrorCode
 from pyatlan.model.assets import Asset
 from pyatlan.model.enums import AtlanConnectorType
+
+if TYPE_CHECKING:
+    from pyatlan.client.atlan import AtlanClient
 
 
 class AbstractAssetCache(ABC):
@@ -17,17 +20,12 @@ class AbstractAssetCache(ABC):
     to all caches, where a cache is populated entry-by-entry.
     """
 
-    def __init__(self, client):
+    def __init__(self, client: AtlanClient):
         self.client = client
         self.lock = threading.Lock()
-        self.name_to_guid = dict()
-        self.guid_to_asset = dict()
-        self.qualified_name_to_guid = dict()
-
-    @classmethod
-    @abstractmethod
-    def get_cache(cls):
-        """Abstract method to retreive cache."""
+        self.name_to_guid: Dict[str, str] = dict()
+        self.guid_to_asset: Dict[str, Asset] = dict()
+        self.qualified_name_to_guid: Dict[str, str] = dict()
 
     @abstractmethod
     def lookup_by_guid(self, guid: str):
@@ -84,9 +82,9 @@ class AbstractAssetCache(ABC):
         name = asset and self.get_name(asset)
         if not all([name, asset.guid, asset.qualified_name]):
             return
-        self.name_to_guid[name] = asset.guid
-        self.guid_to_asset[asset.guid] = asset
-        self.qualified_name_to_guid[asset.qualified_name] = asset.guid
+        self.name_to_guid[name] = asset.guid  # type: ignore[index]
+        self.guid_to_asset[asset.guid] = asset  # type: ignore[index]
+        self.qualified_name_to_guid[asset.qualified_name] = asset.guid  # type: ignore[index]
 
     def _get_by_guid(self, guid: str, allow_refresh: bool = True):
         """

--- a/pyatlan/cache/atlan_tag_cache.py
+++ b/pyatlan/cache/atlan_tag_cache.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pyatlan.client.atlan import AtlanClient
 
 lock: Lock = Lock()
-thread_local_storage = local()
+atlan_tag_cache_tls = local()  # Thread-local storage (TLS)
 
 
 class AtlanTagCache:
@@ -40,15 +40,15 @@ class AtlanTagCache:
             client = client or AtlanClient.get_default_client()
             cache_key = client.cache_key
 
-            if not hasattr(thread_local_storage, "caches"):
-                thread_local_storage.caches = {}
+            if not hasattr(atlan_tag_cache_tls, "caches"):
+                atlan_tag_cache_tls.caches = {}
 
-            if cache_key not in thread_local_storage.caches:
+            if cache_key not in atlan_tag_cache_tls.caches:
                 cache_instance = AtlanTagCache(client=client)
                 cache_instance._refresh_cache()  # Refresh on new cache instance
-                thread_local_storage.caches[cache_key] = cache_instance
+                atlan_tag_cache_tls.caches[cache_key] = cache_instance
 
-            return thread_local_storage.caches[cache_key]
+            return atlan_tag_cache_tls.caches[cache_key]
 
     @classmethod
     def refresh_cache(cls) -> None:

--- a/pyatlan/cache/connection_cache.py
+++ b/pyatlan/cache/connection_cache.py
@@ -15,10 +15,10 @@ from pyatlan.model.search import Term
 
 if TYPE_CHECKING:
     from pyatlan.client.atlan import AtlanClient
-LOGGER = logging.getLogger(__name__)
 
 lock = threading.Lock()
 connection_cache_tls = local()  # Thread-local storage (TLS)
+LOGGER = logging.getLogger(__name__)
 
 
 class ConnectionCache(AbstractAssetCache):

--- a/pyatlan/cache/connection_cache.py
+++ b/pyatlan/cache/connection_cache.py
@@ -188,7 +188,7 @@ class ConnectionName(AbstractAssetName):
         elif isinstance(connection, str):
             tokens = connection.split("/")
             if len(tokens) > 1:
-                self.type = AtlanConnectorType(tokens[0])  # type: ignore[call-arg]
+                self.type = AtlanConnectorType(tokens[0]).value  # type: ignore[call-arg]
                 self.name = connection[len(tokens[0]) + 1 :]  # noqa
 
     def __hash__(self):

--- a/pyatlan/cache/custom_metadata_cache.py
+++ b/pyatlan/cache/custom_metadata_cache.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pyatlan.client.atlan import AtlanClient
 
 lock: Lock = Lock()
-thread_local_storage = local()
+cm_cache_tls = local()  # Thread-local storage (TLS)
 
 
 class CustomMetadataCache:
@@ -42,15 +42,15 @@ class CustomMetadataCache:
             client = client or AtlanClient.get_default_client()
             cache_key = client.cache_key
 
-            if not hasattr(thread_local_storage, "caches"):
-                thread_local_storage.caches = {}
+            if not hasattr(cm_cache_tls, "caches"):
+                cm_cache_tls.caches = {}
 
-            if cache_key not in thread_local_storage.caches:
+            if cache_key not in cm_cache_tls.caches:
                 cache_instance = CustomMetadataCache(client=client)
                 cache_instance._refresh_cache()  # Refresh on new cache instance
-                thread_local_storage.caches[cache_key] = cache_instance
+                cm_cache_tls.caches[cache_key] = cache_instance
 
-            return thread_local_storage.caches[cache_key]
+            return cm_cache_tls.caches[cache_key]
 
     @classmethod
     def refresh_cache(cls) -> None:

--- a/pyatlan/cache/custom_metadata_cache.py
+++ b/pyatlan/cache/custom_metadata_cache.py
@@ -22,6 +22,18 @@ class CustomMetadataCache:
     and human-readable names for custom metadata (including attributes).
     """
 
+    def __init__(self, client: AtlanClient):
+        self.client: AtlanClient = client
+        self.cache_by_id: Dict[str, CustomMetadataDef] = {}
+        self.attr_cache_by_id: Dict[str, AttributeDef] = {}
+        self.map_id_to_name: Dict[str, str] = {}
+        self.map_name_to_id: Dict[str, str] = {}
+        self.map_attr_id_to_name: Dict[str, Dict[str, str]] = {}
+        self.map_attr_name_to_id: Dict[str, Dict[str, str]] = {}
+        self.archived_attr_ids: Dict[str, str] = {}
+        self.types_by_asset: Dict[str, Set[type]] = {}
+        self.lock: Lock = Lock()
+
     @classmethod
     def get_cache(cls, client: Optional[AtlanClient] = None) -> CustomMetadataCache:
         from pyatlan.client.atlan import AtlanClient
@@ -179,18 +191,6 @@ class CustomMetadataCache:
         :raises NotFoundError: if the custom metadata attribute cannot be found
         """
         return cls.get_cache()._get_attribute_def(attr_id=attr_id)
-
-    def __init__(self, client: AtlanClient):
-        self.client: AtlanClient = client
-        self.cache_by_id: Dict[str, CustomMetadataDef] = {}
-        self.attr_cache_by_id: Dict[str, AttributeDef] = {}
-        self.map_id_to_name: Dict[str, str] = {}
-        self.map_name_to_id: Dict[str, str] = {}
-        self.map_attr_id_to_name: Dict[str, Dict[str, str]] = {}
-        self.map_attr_name_to_id: Dict[str, Dict[str, str]] = {}
-        self.archived_attr_ids: Dict[str, str] = {}
-        self.types_by_asset: Dict[str, Set[type]] = {}
-        self.lock: Lock = Lock()
 
     def _refresh_cache(self) -> None:
         """

--- a/pyatlan/cache/group_cache.py
+++ b/pyatlan/cache/group_cache.py
@@ -2,14 +2,13 @@
 # Copyright 2025 Atlan Pte. Ltd.
 from __future__ import annotations
 
-from threading import Lock, local
+from threading import Lock
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 if TYPE_CHECKING:
     from pyatlan.client.atlan import AtlanClient
 
 lock: Lock = Lock()
-group_cache_tls = local()  # Thread-local storage (TLS)
 
 
 class GroupCache:
@@ -26,62 +25,40 @@ class GroupCache:
         self.map_alias_to_id: Dict[str, str] = {}
         self.lock: Lock = Lock()
 
-    @classmethod
-    def get_cache(cls, client: Optional[AtlanClient] = None) -> GroupCache:
-        from pyatlan.client.atlan import AtlanClient
-
-        with lock:
-            client = client or AtlanClient.get_default_client()
-            cache_key = client.cache_key
-
-            if not hasattr(group_cache_tls, "caches"):
-                group_cache_tls.caches = {}
-
-            if cache_key not in group_cache_tls.caches:
-                cache_instance = GroupCache(client=client)
-                cache_instance._refresh_cache()  # Refresh on new cache instance
-                group_cache_tls.caches[cache_key] = cache_instance
-
-            return group_cache_tls.caches[cache_key]
-
-    @classmethod
-    def get_id_for_name(cls, name: str) -> Optional[str]:
+    def get_id_for_name(self, name: str) -> Optional[str]:
         """
         Translate the provided internal group name to its GUID.
 
         :param name: human-readable name of the group
         :returns: unique identifier (GUID) of the group
         """
-        return cls.get_cache()._get_id_for_name(name=name)
+        return self._get_id_for_name(name=name)
 
-    @classmethod
-    def get_id_for_alias(cls, alias: str) -> Optional[str]:
+    def get_id_for_alias(self, alias: str) -> Optional[str]:
         """
         Translate the provided human-readable group name to its GUID.
 
         :param alias: name of the group as it appears in the UI
         :returns: unique identifier (GUID) of the group
         """
-        return cls.get_cache()._get_id_for_alias(alias=alias)
+        return self._get_id_for_alias(alias=alias)
 
-    @classmethod
-    def get_name_for_id(cls, idstr: str) -> Optional[str]:
+    def get_name_for_id(self, idstr: str) -> Optional[str]:
         """
         Translate the provided group GUID to the internal group name.
 
         :param idstr: unique identifier (GUID) of the group
         :returns: human-readable name of the group
         """
-        return cls.get_cache()._get_name_for_id(idstr=idstr)
+        return self._get_name_for_id(idstr=idstr)
 
-    @classmethod
-    def validate_aliases(cls, aliases: Iterable[str]):
+    def validate_aliases(self, aliases: Iterable[str]):
         """
         Validate that the given (internal) group names are valid. A ValueError will be raised in any are not.
 
         :param aliases: a collection of (internal) group names to be checked
         """
-        return cls.get_cache()._validate_aliases(aliases)
+        return self._validate_aliases(aliases)
 
     def _refresh_cache(self) -> None:
         with self.lock:

--- a/pyatlan/cache/role_cache.py
+++ b/pyatlan/cache/role_cache.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Atlan Pte. Ltd.
-from threading import Lock
-from typing import Dict, Iterable, Optional
+# Copyright 2025 Atlan Pte. Ltd.
+from __future__ import annotations
 
-from pyatlan.client.role import RoleClient
+from threading import Lock, local
+from typing import TYPE_CHECKING, Dict, Iterable, Optional
+
 from pyatlan.model.role import AtlanRole
 
+if TYPE_CHECKING:
+    from pyatlan.client.atlan import AtlanClient
+
 lock: Lock = Lock()
+role_cache_tls = local()  # Thread-local storage (TLS)
 
 
 class RoleCache:
@@ -14,18 +19,30 @@ class RoleCache:
     Lazily-loaded cache for translating Atlan-internal roles into their various IDs.
     """
 
-    caches: Dict[int, "RoleCache"] = {}
+    def __init__(self, client: AtlanClient):
+        self.client: AtlanClient = client
+        self.cache_by_id: Dict[str, AtlanRole] = {}
+        self.map_id_to_name: Dict[str, str] = {}
+        self.map_name_to_id: Dict[str, str] = {}
+        self.lock: Lock = Lock()
 
     @classmethod
-    def get_cache(cls) -> "RoleCache":
+    def get_cache(cls, client: Optional[AtlanClient] = None) -> RoleCache:
         from pyatlan.client.atlan import AtlanClient
 
         with lock:
-            client = AtlanClient.get_default_client()
+            client = client or AtlanClient.get_default_client()
             cache_key = client.cache_key
-            if cache_key not in cls.caches:
-                cls.caches[cache_key] = RoleCache(role_client=client.role)
-            return cls.caches[cache_key]
+
+            if not hasattr(role_cache_tls, "caches"):
+                role_cache_tls.caches = {}
+
+            if cache_key not in role_cache_tls.caches:
+                cache_instance = RoleCache(client=client)
+                cache_instance._refresh_cache()  # Refresh on new cache instance
+                role_cache_tls.caches[cache_key] = cache_instance
+
+            return role_cache_tls.caches[cache_key]
 
     @classmethod
     def get_id_for_name(cls, name: str) -> Optional[str]:
@@ -56,28 +73,22 @@ class RoleCache:
         """
         return cls.get_cache()._validate_idstrs(idstrs=idstrs)
 
-    def __init__(self, role_client: RoleClient):
-        self.role_client: RoleClient = role_client
-        self.cache_by_id: Dict[str, AtlanRole] = {}
-        self.map_id_to_name: Dict[str, str] = {}
-        self.map_name_to_id: Dict[str, str] = {}
-        self.lock: Lock = Lock()
-
     def _refresh_cache(self) -> None:
         with self.lock:
-            response = self.role_client.get(
+            response = self.client.role.get(
                 limit=100, post_filter='{"name":{"$ilike":"$%"}}'
             )
-            if response is not None:
-                self.cache_by_id = {}
-                self.map_id_to_name = {}
-                self.map_name_to_id = {}
-                for role in response.records:
-                    role_id = role.id
-                    role_name = role.name
-                    self.cache_by_id[role_id] = role
-                    self.map_id_to_name[role_id] = role_name
-                    self.map_name_to_id[role_name] = role_id
+            if not response:
+                return
+            self.cache_by_id = {}
+            self.map_id_to_name = {}
+            self.map_name_to_id = {}
+            for role in response.records:
+                role_id = role.id
+                role_name = role.name
+                self.cache_by_id[role_id] = role
+                self.map_id_to_name[role_id] = role_name
+                self.map_name_to_id[role_name] = role_id
 
     def _get_id_for_name(self, name: str) -> Optional[str]:
         """

--- a/pyatlan/cache/source_tag_cache.py
+++ b/pyatlan/cache/source_tag_cache.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 import threading
 from threading import local
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 from pyatlan.cache.abstract_asset_cache import AbstractAssetCache, AbstractAssetName
-from pyatlan.cache.connection_cache import ConnectionCache, ConnectionName
+from pyatlan.cache.connection_cache import ConnectionName
 from pyatlan.errors import AtlanError
 from pyatlan.model.assets import Asset, Tag
 from pyatlan.model.fluent_search import FluentSearch
@@ -41,25 +41,7 @@ class SourceTagCache(AbstractAssetCache):
     def __init__(self, client: AtlanClient):
         super().__init__(client)
 
-    @classmethod
-    def get_cache(cls, client: Optional[AtlanClient] = None) -> SourceTagCache:
-        from pyatlan.client.atlan import AtlanClient
-
-        with lock:
-            client = client or AtlanClient.get_default_client()
-            cache_key = client.cache_key
-
-            if not hasattr(source_tag_cache_tls, "caches"):
-                source_tag_cache_tls.caches = {}
-
-            if cache_key not in source_tag_cache_tls.caches:
-                cache_instance = SourceTagCache(client=client)
-                source_tag_cache_tls.caches[cache_key] = cache_instance
-
-            return source_tag_cache_tls.caches[cache_key]
-
-    @classmethod
-    def get_by_guid(cls, guid: str, allow_refresh: bool = True) -> Tag:
+    def get_by_guid(self, guid: str, allow_refresh: bool = True) -> Tag:
         """
         Retrieve a source tag from the cache by its UUID.
         If the asset is not found, it will be looked up and added to the cache.
@@ -71,11 +53,10 @@ class SourceTagCache(AbstractAssetCache):
         :raises NotFoundError: if the source tag cannot be found (does not exist) in Atlan
         :raises InvalidRequestError: if no UUID was provided for the source tag to retrieve
         """
-        return cls.get_cache()._get_by_guid(guid=guid, allow_refresh=allow_refresh)
+        return self._get_by_guid(guid=guid, allow_refresh=allow_refresh)
 
-    @classmethod
     def get_by_qualified_name(
-        cls, qualified_name: str, allow_refresh: bool = True
+        self, qualified_name: str, allow_refresh: bool = True
     ) -> Tag:
         """
         Retrieve a source tag from the cache by its unique Atlan-internal name.
@@ -89,12 +70,11 @@ class SourceTagCache(AbstractAssetCache):
         :raises NotFoundError: if the source tag cannot be found (does not exist) in Atlan
         :raises InvalidRequestError: if no qualified_name was provided for the source tag to retrieve
         """
-        return cls.get_cache()._get_by_qualified_name(
+        return self._get_by_qualified_name(
             qualified_name=qualified_name, allow_refresh=allow_refresh
         )
 
-    @classmethod
-    def get_by_name(cls, name: SourceTagName, allow_refresh: bool = True) -> Tag:
+    def get_by_name(self, name: SourceTagName, allow_refresh: bool = True) -> Tag:
         """
         Retrieve an connection from the cache by its uniquely identifiable name.
 
@@ -107,7 +87,7 @@ class SourceTagCache(AbstractAssetCache):
         :raises NotFoundError: if the object cannot be found (does not exist) in Atlan
         :raises InvalidRequestError: if no name was provided for the object to retrieve
         """
-        return cls.get_cache()._get_by_name(name=name, allow_refresh=allow_refresh)
+        return self._get_by_name(name=name, allow_refresh=allow_refresh)
 
     def lookup_by_guid(self, guid: str) -> None:
         if not guid:
@@ -149,7 +129,9 @@ class SourceTagCache(AbstractAssetCache):
         if not isinstance(stn, SourceTagName):
             return
         connection_name = stn.connection
-        connection_qn = ConnectionCache.get_by_name(connection_name).qualified_name  # type: ignore[arg-type]
+        connection_qn = self.client.connection_cache.get_by_name(
+            connection_name  # type: ignore[arg-type]
+        ).qualified_name
         source_tag_qn = f"{connection_qn}/{stn.partial_tag_name}"
 
         with self.lock:
@@ -202,10 +184,16 @@ class SourceTagName(AbstractAssetName):
         # "DbtTag" extends "Dbt" (unlike other tags like "SnowflakeTag" that extend the "Tag" model),
         # preventing Dbt tags from being excluded from caching:
         if isinstance(tag, Asset):
+            from pyatlan.client.atlan import AtlanClient
+
             source_tag_qn = tag.qualified_name or ""
             tokens = source_tag_qn.split("/")
             connection_qn = "/".join(tokens[:3]) if len(tokens) >= 3 else ""
-            conn = ConnectionCache.get_by_qualified_name(connection_qn)
+            conn = (
+                AtlanClient.get_current_client().connection_cache.get_by_qualified_name(
+                    connection_qn
+                )
+            )
             self.connection = ConnectionName(conn)
             self.partial_tag_name = source_tag_qn[len(connection_qn) + 1 :]  # noqa
 

--- a/pyatlan/cache/source_tag_cache.py
+++ b/pyatlan/cache/source_tag_cache.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import threading
-from threading import local
 from typing import TYPE_CHECKING, Union
 
 from pyatlan.cache.abstract_asset_cache import AbstractAssetCache, AbstractAssetName
@@ -18,7 +17,6 @@ if TYPE_CHECKING:
     from pyatlan.client.atlan import AtlanClient
 
 lock = threading.Lock()
-source_tag_cache_tls = local()  # Thread-local storage (TLS)
 LOGGER = logging.getLogger(__name__)
 
 

--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -389,7 +389,7 @@ class AssetClient:
         if (attributes and len(attributes)) or (
             related_attributes and len(related_attributes)
         ):
-            client = AtlanClient.get_default_client()
+            client = AtlanClient.get_current_client()
             search = (
                 FluentSearch().select().where(Asset.QUALIFIED_NAME.eq(qualified_name))
             )
@@ -462,7 +462,7 @@ class AssetClient:
         if (attributes and len(attributes)) or (
             related_attributes and len(related_attributes)
         ):
-            client = AtlanClient.get_default_client()
+            client = AtlanClient.get_current_client()
             search = FluentSearch().select().where(Asset.GUID.eq(guid))
             for attribute in attributes:
                 search = search.include_on_results(attribute)
@@ -962,9 +962,13 @@ class AssetClient:
         :param atlan_tag_name: human-readable name of the Atlan tag to remove from the asset
         :raises AtlanError: on any API communication issue
         """
-        from pyatlan.cache.atlan_tag_cache import AtlanTagCache
+        from pyatlan.client.atlan import AtlanClient
 
-        classification_id = AtlanTagCache.get_id_for_name(atlan_tag_name)
+        classification_id = (
+            AtlanClient.get_current_client().atlan_tag_cache.get_id_for_name(
+                atlan_tag_name
+            )
+        )
         if not classification_id:
             raise ErrorCode.ATLAN_TAG_NOT_FOUND_BY_NAME.exception_with_parameters(
                 atlan_tag_name
@@ -1334,7 +1338,7 @@ class AssetClient:
         from pyatlan.client.atlan import AtlanClient
         from pyatlan.model.fluent_search import FluentSearch
 
-        client = AtlanClient.get_default_client()
+        client = AtlanClient.get_current_client()
         if guid:
             if qualified_name:
                 raise ErrorCode.QN_OR_GUID_NOT_BOTH.exception_with_parameters()
@@ -1413,7 +1417,7 @@ class AssetClient:
         from pyatlan.client.atlan import AtlanClient
         from pyatlan.model.fluent_search import FluentSearch
 
-        client = AtlanClient.get_default_client()
+        client = AtlanClient.get_current_client()
         if guid:
             if qualified_name:
                 raise ErrorCode.QN_OR_GUID_NOT_BOTH.exception_with_parameters()
@@ -1494,7 +1498,7 @@ class AssetClient:
         from pyatlan.client.atlan import AtlanClient
         from pyatlan.model.fluent_search import FluentSearch
 
-        client = AtlanClient.get_default_client()
+        client = AtlanClient.get_current_client()
         if guid:
             if qualified_name:
                 raise ErrorCode.QN_OR_GUID_NOT_BOTH.exception_with_parameters()

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -42,6 +42,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from pyatlan.cache.atlan_tag_cache import AtlanTagCache
+from pyatlan.cache.connection_cache import ConnectionCache
 from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.cache.enum_cache import EnumCache
 from pyatlan.cache.group_cache import GroupCache
@@ -182,6 +183,7 @@ class AtlanClient(BaseSettings):
     _role_cache: Optional[RoleCache] = PrivateAttr(default=None)
     _user_cache: Optional[UserCache] = PrivateAttr(default=None)
     _custom_metadata_cache: Optional[CustomMetadataCache] = PrivateAttr(default=None)
+    _connection_cache: Optional[ConnectionCache] = PrivateAttr(default=None)
 
     class Config:
         env_prefix = "atlan_"
@@ -366,6 +368,12 @@ class AtlanClient(BaseSettings):
         if self._custom_metadata_cache is None:
             self._custom_metadata_cache = CustomMetadataCache.get_cache(client=self)
         return self._custom_metadata_cache
+
+    @property
+    def connection_cache(self) -> ConnectionCache:
+        if self._connection_cache is None:
+            self._connection_cache = ConnectionCache.get_cache(client=self)
+        return self._connection_cache
 
     def update_headers(self, header: Dict[str, str]):
         self._session.headers.update(header)

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -46,6 +46,7 @@ from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.cache.enum_cache import EnumCache
 from pyatlan.cache.group_cache import GroupCache
 from pyatlan.cache.role_cache import RoleCache
+from pyatlan.cache.user_cache import UserCache
 from pyatlan.client.admin import AdminClient
 from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageListResults
 from pyatlan.client.audit import AuditClient
@@ -179,6 +180,7 @@ class AtlanClient(BaseSettings):
     _enum_cache: Optional[EnumCache] = PrivateAttr(default=None)
     _group_cache: Optional[GroupCache] = PrivateAttr(default=None)
     _role_cache: Optional[RoleCache] = PrivateAttr(default=None)
+    _user_cache: Optional[UserCache] = PrivateAttr(default=None)
     _custom_metadata_cache: Optional[CustomMetadataCache] = PrivateAttr(default=None)
 
     class Config:
@@ -352,6 +354,12 @@ class AtlanClient(BaseSettings):
         if self._role_cache is None:
             self._role_cache = RoleCache.get_cache(client=self)
         return self._role_cache
+
+    @property
+    def user_cache(self) -> UserCache:
+        if self._user_cache is None:
+            self._user_cache = UserCache.get_cache(client=self)
+        return self._user_cache
 
     @property
     def custom_metadata_cache(self) -> CustomMetadataCache:

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -44,6 +44,7 @@ from urllib3.util.retry import Retry
 from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.cache.enum_cache import EnumCache
+from pyatlan.cache.group_cache import GroupCache
 from pyatlan.client.admin import AdminClient
 from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageListResults
 from pyatlan.client.audit import AuditClient
@@ -175,6 +176,7 @@ class AtlanClient(BaseSettings):
     _open_lineage_client: Optional[OpenLineageClient] = PrivateAttr(default=None)
     _atlan_tag_cache: Optional[AtlanTagCache] = PrivateAttr(default=None)
     _enum_cache: Optional[EnumCache] = PrivateAttr(default=None)
+    _group_cache: Optional[GroupCache] = PrivateAttr(default=None)
     _custom_metadata_cache: Optional[CustomMetadataCache] = PrivateAttr(default=None)
 
     class Config:
@@ -336,6 +338,12 @@ class AtlanClient(BaseSettings):
         if self._enum_cache is None:
             self._enum_cache = EnumCache.get_cache(client=self)
         return self._enum_cache
+
+    @property
+    def group_cache(self) -> GroupCache:
+        if self._group_cache is None:
+            self._group_cache = GroupCache.get_cache(client=self)
+        return self._group_cache
 
     @property
     def custom_metadata_cache(self) -> CustomMetadataCache:

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -47,6 +47,7 @@ from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.cache.enum_cache import EnumCache
 from pyatlan.cache.group_cache import GroupCache
 from pyatlan.cache.role_cache import RoleCache
+from pyatlan.cache.source_tag_cache import SourceTagCache
 from pyatlan.cache.user_cache import UserCache
 from pyatlan.client.admin import AdminClient
 from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageListResults
@@ -184,6 +185,7 @@ class AtlanClient(BaseSettings):
     _user_cache: Optional[UserCache] = PrivateAttr(default=None)
     _custom_metadata_cache: Optional[CustomMetadataCache] = PrivateAttr(default=None)
     _connection_cache: Optional[ConnectionCache] = PrivateAttr(default=None)
+    _source_tag_cache: Optional[SourceTagCache] = PrivateAttr(default=None)
 
     class Config:
         env_prefix = "atlan_"
@@ -374,6 +376,12 @@ class AtlanClient(BaseSettings):
         if self._connection_cache is None:
             self._connection_cache = ConnectionCache.get_cache(client=self)
         return self._connection_cache
+
+    @property
+    def source_tag_cache(self) -> SourceTagCache:
+        if self._source_tag_cache is None:
+            self._source_tag_cache = SourceTagCache.get_cache(client=self)
+        return self._source_tag_cache
 
     def update_headers(self, header: Dict[str, str]):
         self._session.headers.update(header)

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -42,6 +42,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from pyatlan.cache.atlan_tag_cache import AtlanTagCache
+from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.client.admin import AdminClient
 from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageListResults
 from pyatlan.client.audit import AuditClient
@@ -172,6 +173,7 @@ class AtlanClient(BaseSettings):
     _contract_client: Optional[ContractClient] = PrivateAttr(default=None)
     _open_lineage_client: Optional[OpenLineageClient] = PrivateAttr(default=None)
     _atlan_tag_cache: Optional[AtlanTagCache] = PrivateAttr(default=None)
+    _custom_metadata_cache: Optional[CustomMetadataCache] = PrivateAttr(default=None)
 
     class Config:
         env_prefix = "atlan_"
@@ -326,6 +328,12 @@ class AtlanClient(BaseSettings):
         if self._atlan_tag_cache is None:
             self._atlan_tag_cache = AtlanTagCache.get_cache(client=self)
         return self._atlan_tag_cache
+
+    @property
+    def custom_metadata_cache(self) -> CustomMetadataCache:
+        if self._custom_metadata_cache is None:
+            self._custom_metadata_cache = CustomMetadataCache.get_cache(client=self)
+        return self._custom_metadata_cache
 
     def update_headers(self, header: Dict[str, str]):
         self._session.headers.update(header)

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -222,7 +222,7 @@ class AtlanClient(BaseSettings):
         adapter = HTTPAdapter(max_retries=self.retry)
         session.mount(HTTPS_PREFIX, adapter)
         session.mount(HTTP_PREFIX, adapter)
-        self._current_client_tls.client = None
+        AtlanClient.set_current_client(self)
 
     @property
     def cache_key(self) -> int:

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -45,6 +45,7 @@ from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.cache.enum_cache import EnumCache
 from pyatlan.cache.group_cache import GroupCache
+from pyatlan.cache.role_cache import RoleCache
 from pyatlan.client.admin import AdminClient
 from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageListResults
 from pyatlan.client.audit import AuditClient
@@ -177,6 +178,7 @@ class AtlanClient(BaseSettings):
     _atlan_tag_cache: Optional[AtlanTagCache] = PrivateAttr(default=None)
     _enum_cache: Optional[EnumCache] = PrivateAttr(default=None)
     _group_cache: Optional[GroupCache] = PrivateAttr(default=None)
+    _role_cache: Optional[RoleCache] = PrivateAttr(default=None)
     _custom_metadata_cache: Optional[CustomMetadataCache] = PrivateAttr(default=None)
 
     class Config:
@@ -344,6 +346,12 @@ class AtlanClient(BaseSettings):
         if self._group_cache is None:
             self._group_cache = GroupCache.get_cache(client=self)
         return self._group_cache
+
+    @property
+    def role_cache(self) -> RoleCache:
+        if self._role_cache is None:
+            self._role_cache = RoleCache.get_cache(client=self)
+        return self._role_cache
 
     @property
     def custom_metadata_cache(self) -> CustomMetadataCache:

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -225,10 +225,6 @@ class AtlanClient(BaseSettings):
         AtlanClient.set_current_client(self)
 
     @property
-    def cache_key(self) -> int:
-        return f"{self.base_url}/{self.api_key}".__hash__()
-
-    @property
     def admin(self) -> AdminClient:
         if self._admin_client is None:
             AtlanClient.set_current_client(self)
@@ -357,6 +353,7 @@ class AtlanClient(BaseSettings):
     @property
     def atlan_tag_cache(self) -> AtlanTagCache:
         if self._atlan_tag_cache is None:
+            print("yes... calling cache")
             AtlanClient.set_current_client(self)
             self._atlan_tag_cache = AtlanTagCache(client=self)
         return self._atlan_tag_cache
@@ -698,7 +695,7 @@ class AtlanClient(BaseSettings):
 
         returns: HTTP response received after retrying the request with the refreshed token
         """
-        new_token = self.get_current_client().impersonate.user(user_id=self._user_id)
+        new_token = self.impersonate.user(user_id=self._user_id)
         self.api_key = new_token
         self._has_retried_for_401 = True
         params["headers"]["authorization"] = f"Bearer {self.api_key}"

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -41,6 +41,7 @@ from pydantic.v1 import (
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.client.admin import AdminClient
 from pyatlan.client.asset import A, AssetClient, IndexSearchResults, LineageListResults
 from pyatlan.client.audit import AuditClient
@@ -170,6 +171,7 @@ class AtlanClient(BaseSettings):
     _file_client: Optional[FileClient] = PrivateAttr(default=None)
     _contract_client: Optional[ContractClient] = PrivateAttr(default=None)
     _open_lineage_client: Optional[OpenLineageClient] = PrivateAttr(default=None)
+    _atlan_tag_cache: Optional[AtlanTagCache] = PrivateAttr(default=None)
 
     class Config:
         env_prefix = "atlan_"
@@ -319,6 +321,12 @@ class AtlanClient(BaseSettings):
             self._contract_client = ContractClient(client=self)
         return self._contract_client
 
+    @property
+    def atlan_tag_cache(self) -> AtlanTagCache:
+        if self._atlan_tag_cache is None:
+            self._atlan_tag_cache = AtlanTagCache.get_cache(client=self)
+        return self._atlan_tag_cache
+
     def update_headers(self, header: Dict[str, str]):
         self._session.headers.update(header)
 
@@ -404,7 +412,7 @@ class AtlanClient(BaseSettings):
                         response_ = response.text
                     else:
                         response_ = events if events else response.json()
-                    LOGGER.debug("response: %s", response_)
+                    # TODO: LOGGER.debug("response: %s", response_)
                     return response_
                 except (
                     requests.exceptions.JSONDecodeError,

--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -468,7 +468,7 @@ class AtlanClient(BaseSettings):
                         response_ = response.text
                     else:
                         response_ = events if events else response.json()
-                    # TODO: LOGGER.debug("response: %s", response_)
+                    LOGGER.debug("response: %s", response_)
                     return response_
                 except (
                     requests.exceptions.JSONDecodeError,

--- a/pyatlan/client/open_lineage.py
+++ b/pyatlan/client/open_lineage.py
@@ -47,7 +47,7 @@ class OpenLineageClient:
         """
         from pyatlan.client.atlan import AtlanClient
 
-        client = AtlanClient.get_default_client()
+        client = AtlanClient.get_current_client()
 
         create_credential = Credential()
         create_credential.auth_type = "atlan_api_key"

--- a/pyatlan/client/typedef.py
+++ b/pyatlan/client/typedef.py
@@ -65,18 +65,15 @@ def _build_typedef_request(typedef: TypeDef) -> TypeDefResponse:
 
 
 def _refresh_caches(typedef: TypeDef) -> None:
+    from pyatlan.client.atlan import AtlanClient
+
+    client = AtlanClient.get_current_client()
     if isinstance(typedef, AtlanTagDef):
-        from pyatlan.cache.atlan_tag_cache import AtlanTagCache
-
-        AtlanTagCache.refresh_cache()
+        client.atlan_tag_cache.refresh_cache()
     if isinstance(typedef, CustomMetadataDef):
-        from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
-
-        CustomMetadataCache.refresh_cache()
+        client.custom_metadata_cache.refresh_cache()
     if isinstance(typedef, EnumDef):
-        from pyatlan.cache.enum_cache import EnumCache
-
-        EnumCache.refresh_cache()
+        client.enum_cache.refresh_cache()
 
 
 class TypeDefFactory:
@@ -229,16 +226,15 @@ class TypeDefClient:
         :raises NotFoundError: if the typedef you are trying to delete cannot be found
         :raises AtlanError: on any API communication issue
         """
-        if typedef_type == CustomMetadataDef:
-            from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
+        from pyatlan.client.atlan import AtlanClient
 
-            internal_name = CustomMetadataCache.get_id_for_name(name)
+        client = AtlanClient.get_current_client()
+        if typedef_type == CustomMetadataDef:
+            internal_name = client.custom_metadata_cache.get_id_for_name(name)
         elif typedef_type == EnumDef:
             internal_name = name
         elif typedef_type == AtlanTagDef:
-            from pyatlan.cache.atlan_tag_cache import AtlanTagCache
-
-            internal_name = str(AtlanTagCache.get_id_for_name(name))
+            internal_name = str(client.atlan_tag_cache.get_id_for_name(name))
         else:
             raise ErrorCode.UNABLE_TO_PURGE_TYPEDEF_OF_TYPE.exception_with_parameters(
                 typedef_type
@@ -251,14 +247,8 @@ class TypeDefClient:
             raise ErrorCode.TYPEDEF_NOT_FOUND_BY_NAME.exception_with_parameters(name)
 
         if typedef_type == CustomMetadataDef:
-            from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
-
-            CustomMetadataCache.refresh_cache()
+            client.custom_metadata_cache.refresh_cache()
         elif typedef_type == EnumDef:
-            from pyatlan.cache.enum_cache import EnumCache
-
-            EnumCache.refresh_cache()
+            client.enum_cache.refresh_cache()
         elif typedef_type == AtlanTagDef:
-            from pyatlan.cache.atlan_tag_cache import AtlanTagCache
-
-            AtlanTagCache.refresh_cache()
+            client.atlan_tag_cache.refresh_cache()

--- a/pyatlan/client/user.py
+++ b/pyatlan/client/user.py
@@ -57,12 +57,16 @@ class UserClient:
         :raises AtlanError: on any API communication issue
         :returns: the list of details of created users if `return_info` is `True`, otherwise `None`
         """
-        from pyatlan.cache.role_cache import RoleCache
+        from pyatlan.client.atlan import AtlanClient
 
         cur = CreateUserRequest(users=[])
         for user in users:
             role_name = str(user.workspace_role)
-            if (role_id := RoleCache.get_id_for_name(role_name)) and user.email:
+            if (
+                role_id := AtlanClient.get_current_client().role_cache.get_id_for_name(
+                    role_name
+                )
+            ) and user.email:
                 to_create = CreateUserRequest.CreateUser(
                     email=user.email,
                     role_name=role_name,

--- a/pyatlan/generator/templates/methods/asset/data_product.jinja2
+++ b/pyatlan/generator/templates/methods/asset/data_product.jinja2
@@ -97,7 +97,7 @@
         """
         from pyatlan.client.atlan import AtlanClient
 
-        client = AtlanClient.get_default_client() if not client else client
+        client = AtlanClient.get_current_client() if not client else client
         dp_dsl = self.data_product_assets_d_s_l
         json_object = json.loads(dp_dsl) if dp_dsl else {}
         request = IndexSearchRequest(**json_object.get("query", {}))

--- a/pyatlan/generator/templates/methods/asset/purpose.jinja2
+++ b/pyatlan/generator/templates/methods/asset/purpose.jinja2
@@ -51,10 +51,12 @@
             policy.policy_groups = {"public"}
         else:
             if policy_groups:
-                from pyatlan.cache.group_cache import GroupCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for group_name in policy_groups:
-                    if not GroupCache.get_id_for_name(group_name):
+                    if not AtlanClient.get_current_client().group_cache.get_id_for_name(
+                        group_name
+                    ):
                         raise ValueError(
                             f"Provided group name {group_name} was not found in Atlan."
                         )
@@ -63,10 +65,12 @@
             else:
                 policy.policy_groups = None
             if policy_users:
-                from pyatlan.cache.user_cache import UserCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for username in policy_users:
-                    if not UserCache.get_id_for_name(username):
+                    if not AtlanClient.get_current_client().user_cache.get_id_for_name(
+                        username
+                    ):
                         raise ValueError(
                             f"Provided username {username} was not found in Atlan."
                         )
@@ -108,10 +112,12 @@
             policy.policy_groups = {"public"}
         else:
             if policy_groups:
-                from pyatlan.cache.group_cache import GroupCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for group_name in policy_groups:
-                    if not GroupCache.get_id_for_name(group_name):
+                    if not AtlanClient.get_current_client().group_cache.get_id_for_name(
+                        group_name
+                    ):
                         raise ValueError(
                             f"Provided group name {group_name} was not found in Atlan."
                         )
@@ -120,10 +126,12 @@
             else:
                 policy.policy_groups = None
             if policy_users:
-                from pyatlan.cache.user_cache import UserCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for username in policy_users:
-                    if not UserCache.get_id_for_name(username):
+                    if not AtlanClient.get_current_client().user_cache.get_id_for_name(
+                        username
+                    ):
                         raise ValueError(
                             f"Provided username {username} was not found in Atlan."
                         )

--- a/pyatlan/generator/templates/methods/attribute/connection.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/connection.jinja2
@@ -3,21 +3,30 @@
 
         @validator("admin_users")
         def admin_users_valid(cls, admin_users, values):
-            from pyatlan.cache.user_cache import UserCache
+            from pyatlan.client.atlan import AtlanClient
+
             if values.get("is_loaded", False):
-                UserCache.validate_names(names=admin_users)
+                AtlanClient.get_current_client().user_cache.validate_names(
+                    names=admin_users
+                )
             return admin_users
 
         @validator("admin_roles")
         def admin_roles_valid(cls, admin_roles, values):
-            from pyatlan.cache.role_cache import RoleCache
+            from pyatlan.client.atlan import AtlanClient
+
             if values.get("is_loaded", False):
-                RoleCache.validate_idstrs(idstrs=admin_roles)
+                AtlanClient.get_current_client().role_cache.validate_idstrs(
+                    idstrs=admin_roles
+                )
             return admin_roles
 
         @validator("admin_groups")
         def admin_groups_valid(cls, admin_groups, values):
-            from pyatlan.cache.group_cache import GroupCache
+            from pyatlan.client.atlan import AtlanClient
+
             if values.get("is_loaded", False):
-                GroupCache.validate_aliases(aliases=admin_groups)
+                AtlanClient.get_current_client().group_cache.validate_aliases(
+                    aliases=admin_groups
+                )
                 return admin_groups

--- a/pyatlan/model/assets/badge.py
+++ b/pyatlan/model/assets/badge.py
@@ -140,10 +140,11 @@ class Badge(Asset, type_name="Badge"):
                 ["name", "cm_name", "cm_attribute", "badge_conditions"],
                 [name, cm_name, cm_attribute, badge_conditions],
             )
-            from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
+            from pyatlan.client.atlan import AtlanClient
 
-            cm_id = CustomMetadataCache.get_id_for_name(cm_name)
-            cm_attr_id = CustomMetadataCache.get_attr_id_for_name(
+            client = AtlanClient.get_current_client()
+            cm_id = client.custom_metadata_cache.get_id_for_name(cm_name)
+            cm_attr_id = client.custom_metadata_cache.get_attr_id_for_name(
                 set_name=cm_name, attr_name=cm_attribute
             )
             return Badge.Attributes(

--- a/pyatlan/model/assets/connection.py
+++ b/pyatlan/model/assets/connection.py
@@ -670,26 +670,32 @@ class Connection(Asset, type_name="Connection"):
 
         @validator("admin_users")
         def admin_users_valid(cls, admin_users, values):
-            from pyatlan.cache.user_cache import UserCache
+            from pyatlan.client.atlan import AtlanClient
 
             if values.get("is_loaded", False):
-                UserCache.validate_names(names=admin_users)
+                AtlanClient.get_current_client().user_cache.validate_names(
+                    names=admin_users
+                )
             return admin_users
 
         @validator("admin_roles")
         def admin_roles_valid(cls, admin_roles, values):
-            from pyatlan.cache.role_cache import RoleCache
+            from pyatlan.client.atlan import AtlanClient
 
             if values.get("is_loaded", False):
-                RoleCache.validate_idstrs(idstrs=admin_roles)
+                AtlanClient.get_current_client().role_cache.validate_idstrs(
+                    idstrs=admin_roles
+                )
             return admin_roles
 
         @validator("admin_groups")
         def admin_groups_valid(cls, admin_groups, values):
-            from pyatlan.cache.group_cache import GroupCache
+            from pyatlan.client.atlan import AtlanClient
 
             if values.get("is_loaded", False):
-                GroupCache.validate_aliases(aliases=admin_groups)
+                AtlanClient.get_current_client().group_cache.validate_aliases(
+                    aliases=admin_groups
+                )
                 return admin_groups
 
     attributes: Connection.Attributes = Field(

--- a/pyatlan/model/assets/core/data_product.py
+++ b/pyatlan/model/assets/core/data_product.py
@@ -135,7 +135,7 @@ class DataProduct(DataMesh):
         """
         from pyatlan.client.atlan import AtlanClient
 
-        client = AtlanClient.get_default_client() if not client else client
+        client = AtlanClient.get_current_client() if not client else client
         dp_dsl = self.data_product_assets_d_s_l
         json_object = json.loads(dp_dsl) if dp_dsl else {}
         request = IndexSearchRequest(**json_object.get("query", {}))

--- a/pyatlan/model/assets/core/referenceable.py
+++ b/pyatlan/model/assets/core/referenceable.py
@@ -87,12 +87,13 @@ class Referenceable(AtlanObject):
 
     @property
     def atlan_tag_names(self) -> List[str]:
-        from pyatlan.cache.atlan_tag_cache import AtlanTagCache
+        from pyatlan.client.atlan import AtlanClient
         from pyatlan.model.constants import DELETED_
 
         if self.classification_names:
             return [
-                AtlanTagCache.get_name_for_id(tag_id) or DELETED_
+                AtlanClient.get_current_client().atlan_tag_cache.get_name_for_id(tag_id)
+                or DELETED_
                 for tag_id in self.classification_names
             ]
         return []

--- a/pyatlan/model/assets/purpose.py
+++ b/pyatlan/model/assets/purpose.py
@@ -80,10 +80,12 @@ class Purpose(AccessControl):
             policy.policy_groups = {"public"}
         else:
             if policy_groups:
-                from pyatlan.cache.group_cache import GroupCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for group_name in policy_groups:
-                    if not GroupCache.get_id_for_name(group_name):
+                    if not AtlanClient.get_current_client().group_cache.get_id_for_name(
+                        group_name
+                    ):
                         raise ValueError(
                             f"Provided group name {group_name} was not found in Atlan."
                         )
@@ -92,10 +94,12 @@ class Purpose(AccessControl):
             else:
                 policy.policy_groups = None
             if policy_users:
-                from pyatlan.cache.user_cache import UserCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for username in policy_users:
-                    if not UserCache.get_id_for_name(username):
+                    if not AtlanClient.get_current_client().user_cache.get_id_for_name(
+                        username
+                    ):
                         raise ValueError(
                             f"Provided username {username} was not found in Atlan."
                         )
@@ -137,10 +141,12 @@ class Purpose(AccessControl):
             policy.policy_groups = {"public"}
         else:
             if policy_groups:
-                from pyatlan.cache.group_cache import GroupCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for group_name in policy_groups:
-                    if not GroupCache.get_id_for_name(group_name):
+                    if not AtlanClient.get_current_client().group_cache.get_id_for_name(
+                        group_name
+                    ):
                         raise ValueError(
                             f"Provided group name {group_name} was not found in Atlan."
                         )
@@ -149,10 +155,12 @@ class Purpose(AccessControl):
             else:
                 policy.policy_groups = None
             if policy_users:
-                from pyatlan.cache.user_cache import UserCache
+                from pyatlan.client.atlan import AtlanClient
 
                 for username in policy_users:
-                    if not UserCache.get_id_for_name(username):
+                    if not AtlanClient.get_current_client().user_cache.get_id_for_name(
+                        username
+                    ):
                         raise ValueError(
                             f"Provided username {username} was not found in Atlan."
                         )

--- a/pyatlan/model/custom_metadata.py
+++ b/pyatlan/model/custom_metadata.py
@@ -119,17 +119,17 @@ class CustomMetadataProxy:
         if self._business_attributes is None:
             return
         self._metadata = {}
-        self._client = AtlanClient.get_current_client()
+        client = AtlanClient.get_current_client()
         for cm_id, cm_attributes in self._business_attributes.items():
             try:
-                cm_name = self._client.custom_metadata_cache.get_name_for_id(cm_id)
+                cm_name = client.custom_metadata_cache.get_name_for_id(cm_id)
                 attribs = CustomMetadataDict(name=cm_name)
                 for attr_id, properties in cm_attributes.items():
-                    attr_name = self._client.custom_metadata_cache.get_attr_name_for_id(
+                    attr_name = client.custom_metadata_cache.get_attr_name_for_id(
                         cm_id, attr_id
                     )
                     # Only set active custom metadata attributes
-                    if not self._client.custom_metadata_cache.is_attr_archived(
+                    if not client.custom_metadata_cache.is_attr_archived(
                         attr_id=attr_id
                     ):
                         attribs[attr_name] = properties
@@ -164,8 +164,10 @@ class CustomMetadataProxy:
     @property
     def business_attributes(self) -> Optional[Dict[str, Any]]:
         if self.modified and self._metadata is not None:
+            from pyatlan.client.atlan import AtlanClient
+
             return {
-                self._client.custom_metadata_cache.get_id_for_name(
+                AtlanClient.get_current_client().custom_metadata_cache.get_id_for_name(
                     key
                 ): value.business_attributes
                 for key, value in self._metadata.items()

--- a/pyatlan/model/custom_metadata.py
+++ b/pyatlan/model/custom_metadata.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional, Set
 
 from pydantic.v1 import PrivateAttr
 
-from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.errors import NotFoundError
 from pyatlan.model.constants import DELETED_, DELETED_SENTINEL
 from pyatlan.model.core import AtlanObject
@@ -32,16 +31,19 @@ class CustomMetadataDict(UserDict):
 
     def __init__(self, name: str):
         """Inits CustomMetadataDict with a string containing the human-readable name of a set of custom metadata"""
+        from pyatlan.client.atlan import AtlanClient
+
         super().__init__()
         self._name = name
         self._modified = False
-        _id = CustomMetadataCache.get_id_for_name(name)
+        self._client = AtlanClient.get_current_client()
+        _id = self._client.custom_metadata_cache.get_id_for_name(name)
         self._names = {
             value
-            for key, value in CustomMetadataCache.get_cache()
-            .map_attr_id_to_name[_id]
-            .items()
-            if not CustomMetadataCache.is_attr_archived(attr_id=key)
+            for key, value in self._client.custom_metadata_cache.map_attr_id_to_name[
+                _id
+            ].items()
+            if not self._client.custom_metadata_cache.is_attr_archived(attr_id=key)
         }
 
     @classmethod
@@ -100,27 +102,36 @@ class CustomMetadataDict(UserDict):
         """Returns a dict containing the metadata set with the human-readable set name and property names resolved
         to their internal values"""
         return {
-            CustomMetadataCache.get_attr_id_for_name(self._name, key): value
+            self._client.custom_metadata_cache.get_attr_id_for_name(
+                self._name, key
+            ): value
             for (key, value) in self.data.items()
         }
 
 
 class CustomMetadataProxy:
     def __init__(self, business_attributes: Optional[Dict[str, Any]]):
+        from pyatlan.client.atlan import AtlanClient
+
         self._metadata: Optional[Dict[str, CustomMetadataDict]] = None
         self._business_attributes = business_attributes
         self._modified = False
         if self._business_attributes is None:
             return
         self._metadata = {}
+        self._client = AtlanClient.get_current_client()
         for cm_id, cm_attributes in self._business_attributes.items():
             try:
-                cm_name = CustomMetadataCache.get_name_for_id(cm_id)
+                cm_name = self._client.custom_metadata_cache.get_name_for_id(cm_id)
                 attribs = CustomMetadataDict(name=cm_name)
                 for attr_id, properties in cm_attributes.items():
-                    attr_name = CustomMetadataCache.get_attr_name_for_id(cm_id, attr_id)
+                    attr_name = self._client.custom_metadata_cache.get_attr_name_for_id(
+                        cm_id, attr_id
+                    )
                     # Only set active custom metadata attributes
-                    if not CustomMetadataCache.is_attr_archived(attr_id=attr_id):
+                    if not self._client.custom_metadata_cache.is_attr_archived(
+                        attr_id=attr_id
+                    ):
                         attribs[attr_name] = properties
                 attribs._modified = False
             except NotFoundError:
@@ -154,7 +165,9 @@ class CustomMetadataProxy:
     def business_attributes(self) -> Optional[Dict[str, Any]]:
         if self.modified and self._metadata is not None:
             return {
-                CustomMetadataCache.get_id_for_name(key): value.business_attributes
+                self._client.custom_metadata_cache.get_id_for_name(
+                    key
+                ): value.business_attributes
                 for key, value in self._metadata.items()
             }
         return self._business_attributes
@@ -166,9 +179,13 @@ class CustomMetadataRequest(AtlanObject):
 
     @classmethod
     def create(cls, custom_metadata_dict: CustomMetadataDict):
+        from pyatlan.client.atlan import AtlanClient
+
         ret_val = cls(__root__=custom_metadata_dict.business_attributes)
-        ret_val._set_id = CustomMetadataCache.get_id_for_name(
-            custom_metadata_dict._name
+        ret_val._set_id = (
+            AtlanClient.get_current_client().custom_metadata_cache.get_id_for_name(
+                custom_metadata_dict._name
+            )
         )
         return ret_val
 

--- a/pyatlan/model/fields/atlan_fields.py
+++ b/pyatlan/model/fields/atlan_fields.py
@@ -636,22 +636,27 @@ class CustomMetadataField(SearchableField):
     attribute_def: AttributeDef
 
     def __init__(self, set_name: str, attribute_name: str):
-        from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
+        from pyatlan.client.atlan import AtlanClient
 
+        client = AtlanClient.get_current_client()
         super().__init__(
             StrictStr(
-                CustomMetadataCache.get_attribute_for_search_results(
+                client.custom_metadata_cache.get_attribute_for_search_results(
                     set_name, attribute_name
                 )
             ),
             StrictStr(
-                CustomMetadataCache.get_attr_id_for_name(set_name, attribute_name)
+                client.custom_metadata_cache.get_attr_id_for_name(
+                    set_name, attribute_name
+                )
             ),
         )
         self.set_name = set_name
         self.attribute_name = attribute_name
-        self.attribute_def = CustomMetadataCache.get_attribute_def(
-            self.elastic_field_name
+        self.attribute_def = (
+            AtlanClient.get_current_client().custom_metadata_cache.get_attribute_def(
+                self.elastic_field_name
+            )
         )
 
     def eq(self, value: SearchFieldType, case_insensitive: bool = False) -> Query:

--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -5,7 +5,6 @@ import dataclasses
 import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
-from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.client.asset import IndexSearchResults
 from pyatlan.errors import ErrorCode
 from pyatlan.model.aggregation import Aggregation
@@ -110,12 +109,17 @@ class CompoundQuery:
                          even propagated tags will suffice
         :returns: a query that will only match assets that have at least one of the Atlan tags provided
         """
-        from pyatlan.cache.atlan_tag_cache import AtlanTagCache
+        from pyatlan.client.atlan import AtlanClient
 
         values: List[str] = []
         if with_one_of:
             for name in with_one_of:
-                if tag_id := AtlanTagCache.get_id_for_name(name):
+                if (
+                    tag_id
+                    := AtlanClient.get_current_client().atlan_tag_cache.get_id_for_name(
+                        name
+                    )
+                ):
                     values.append(tag_id)
                 else:
                     raise ErrorCode.ATLAN_TAG_NOT_FOUND_BY_NAME.exception_with_parameters(
@@ -167,8 +171,8 @@ class CompoundQuery:
 
         big_spans = []
         little_spans = []
-        tag_id = AtlanTagCache.get_id_for_name(atlan_tag_name) or ""
-        client = AtlanClient.get_default_client()
+        client = AtlanClient.get_current_client()
+        tag_id = client.atlan_tag_cache.get_id_for_name(atlan_tag_name) or ""
         synced_tags = [
             tag
             for tag in (

--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import logging
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
 from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.client.asset import IndexSearchResults
@@ -23,6 +23,9 @@ from pyatlan.model.search import (
     SpanWithin,
     Term,
 )
+
+if TYPE_CHECKING:
+    from pyatlan.client.atlan import AtlanClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -160,6 +163,8 @@ class CompoundQuery:
         :returns: a query that will only match assets that have
         a particular value assigned for the given Atlan tag
         """
+        from pyatlan.client.atlan import AtlanClient
+
         big_spans = []
         little_spans = []
         tag_id = AtlanTagCache.get_id_for_name(atlan_tag_name) or ""
@@ -523,6 +528,3 @@ class FluentSearch(CompoundQuery):
         :returns: an iterable list of assets that match the supplied criteria, lazily-fetched
         """
         return client.asset.search(criteria=self.to_request(), bulk=bulk)
-
-
-from pyatlan.client.atlan import AtlanClient  # noqa: E402

--- a/pyatlan/model/open_lineage/event.py
+++ b/pyatlan/model/open_lineage/event.py
@@ -79,7 +79,7 @@ class OpenLineageEvent(OpenLineageBaseEvent):
         """
         from pyatlan.client.atlan import AtlanClient
 
-        client = client or AtlanClient.get_default_client()
+        client = client or AtlanClient.get_current_client()
         return client.open_lineage.send(
             request=self, connector_type=AtlanConnectorType.SPARK
         )

--- a/pyatlan/model/search.py
+++ b/pyatlan/model/search.py
@@ -181,10 +181,13 @@ class Exists(Query):
     @classmethod
     @validate_arguments()
     def with_custom_metadata(cls, set_name: StrictStr, attr_name: StrictStr):
-        from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
+        from pyatlan.client.atlan import AtlanClient
 
-        if attr_id := CustomMetadataCache.get_attr_id_for_name(
-            set_name=set_name, attr_name=attr_name
+        if (
+            attr_id
+            := AtlanClient.get_current_client().custom_metadata_cache.get_attr_id_for_name(
+                set_name=set_name, attr_name=attr_name
+            )
         ):
             return cls(field=attr_id)
         else:
@@ -368,10 +371,13 @@ class Term(Query):
     def with_custom_metadata(
         cls, set_name: StrictStr, attr_name: StrictStr, value: SearchFieldType
     ):
-        from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
+        from pyatlan.client.atlan import AtlanClient
 
-        if attr_id := CustomMetadataCache.get_attr_id_for_name(
-            set_name=set_name, attr_name=attr_name
+        if (
+            attr_id
+            := AtlanClient.get_current_client().custom_metadata_cache.get_attr_id_for_name(
+                set_name=set_name, attr_name=attr_name
+            )
         ):
             return cls(field=attr_id, value=value)
         else:

--- a/pyatlan/model/structs.py
+++ b/pyatlan/model/structs.py
@@ -134,7 +134,7 @@ class SourceTagAttachment(AtlanObject):
         is_source_tag_synced: Optional[bool] = None,
         source_tag_sync_error: Optional[str] = None,
     ):
-        from pyatlan.cache.source_tag_cache import SourceTagCache
+        from pyatlan.client.atlan import AtlanClient
 
         """
         Create a source-synced tag attachment with
@@ -150,7 +150,7 @@ class SourceTagAttachment(AtlanObject):
         :raises AtlanError: on any error communicating via the underlying APIs
         :raises NotFoundError: if the source-synced tag cannot be resolved
         """
-        tag = SourceTagCache.get_by_name(name)
+        tag = AtlanClient.get_current_client().source_tag_cache.get_by_name(name)
         tag_connector_name = AtlanConnectorType._get_connector_type_from_qualified_name(
             tag.qualified_name or ""
         )
@@ -178,8 +178,6 @@ class SourceTagAttachment(AtlanObject):
         is_source_tag_synced: Optional[bool] = None,
         source_tag_sync_error: Optional[str] = None,
     ):
-        from pyatlan.cache.source_tag_cache import SourceTagCache
-
         """
         Create a source-synced tag attachment with
         a particular value when the attachment is synced to the source.
@@ -194,7 +192,11 @@ class SourceTagAttachment(AtlanObject):
         :raises AtlanError: on any error communicating via the underlying APIs
         :raises NotFoundError: if the source-synced tag cannot be resolved
         """
-        tag = SourceTagCache.get_by_qualified_name(source_tag_qualified_name)
+        from pyatlan.client.atlan import AtlanClient
+
+        tag = AtlanClient.get_current_client().source_tag_cache.get_by_qualified_name(
+            source_tag_qualified_name
+        )
         tag_connector_name = AtlanConnectorType._get_connector_type_from_qualified_name(
             source_tag_qualified_name or ""
         )

--- a/pyatlan/model/suggestions.py
+++ b/pyatlan/model/suggestions.py
@@ -6,7 +6,6 @@ from typing import ClassVar, List, Optional
 
 from pydantic.v1 import Field
 
-from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.client.asset import Batch
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.aggregation import AggregationBucketResult, Aggregations
@@ -61,7 +60,7 @@ class Suggestions(AtlanObject):
     AGG_TERMS: ClassVar[str] = "group_by_terms"
 
     client: AtlanClient = Field(
-        default_factory=lambda: AtlanClient.get_default_client()
+        default_factory=lambda: AtlanClient.get_current_client()
     )
     """Client through which to find suggestions."""
     asset: Optional[Asset] = Field(default=None)
@@ -222,7 +221,7 @@ class Suggestions(AtlanObject):
         :return: the start of a suggestion finder
         for the provided asset, against the specified tenant
         """
-        client = AtlanClient.get_default_client() if not client else client
+        client = AtlanClient.get_current_client() if not client else client
         self.client = client
         self.asset = asset
         return self
@@ -343,7 +342,7 @@ class Suggestions(AtlanObject):
             for bucket in result.buckets:
                 count = bucket.doc_count
                 value = bucket.key
-                name = AtlanTagCache.get_name_for_id(value)
+                name = self.client.atlan_tag_cache.get_name_for_id(value)
                 if count and name:
                     results.append(
                         SuggestionResponse.SuggestedItem(count=count, value=name)

--- a/pyatlan/model/suggestions.py
+++ b/pyatlan/model/suggestions.py
@@ -58,10 +58,6 @@ class Suggestions(AtlanObject):
     AGG_OWNER_GROUPS: ClassVar[str] = "group_by_ownerGroups"
     AGG_ATLAN_TAGS: ClassVar[str] = "group_by_tags"
     AGG_TERMS: ClassVar[str] = "group_by_terms"
-
-    client: AtlanClient = Field(
-        default_factory=lambda: AtlanClient.get_current_client()
-    )
     """Client through which to find suggestions."""
     asset: Optional[Asset] = Field(default=None)
     """Asset for which to find suggestions."""
@@ -211,24 +207,22 @@ class Suggestions(AtlanObject):
         clone.where_nots.append(query)
         return clone
 
-    def finder(self, asset: Asset, client: Optional[AtlanClient] = None) -> Suggestions:
+    def finder(self, asset: Asset) -> Suggestions:
         """
         Build a suggestion finder against
         the provided Atlan tenant for the provided asset
 
-        :param: client connectivity to an Atlan tenant
         :param: asset for which to find suggestions
         :return: the start of a suggestion finder
         for the provided asset, against the specified tenant
         """
-        client = AtlanClient.get_current_client() if not client else client
-        self.client = client
         self.asset = asset
         return self
 
-    def get(self) -> SuggestionResponse:
+    def get(self, client: Optional[AtlanClient] = None) -> SuggestionResponse:
         asset_name = ""
         all_types = []
+        client = client or AtlanClient.get_current_client()
 
         if self.asset and self.asset.name:
             asset_name = self.asset.name
@@ -302,12 +296,17 @@ class Suggestions(AtlanObject):
                 )
 
             search_request = search.to_request()
-            search_response = self.client.search(criteria=search_request)
+            search_response = client.search(criteria=search_request)
             aggregations = search_response.aggregations
             suggestion_response = SuggestionResponse()
 
             for include in self.includes:
-                self._build_response(include, suggestion_response, aggregations)
+                self._build_response(
+                    client,
+                    include,
+                    suggestion_response,
+                    aggregations,
+                )
         return suggestion_response
 
     def _get_descriptions(self, result: Aggregations, field: AtlanField):
@@ -336,13 +335,13 @@ class Suggestions(AtlanObject):
                     )
         return results
 
-    def _get_tags(self, result: Aggregations):
+    def _get_tags(self, client: AtlanClient, result: Aggregations):
         results = []
         if isinstance(result, AggregationBucketResult):
             for bucket in result.buckets:
                 count = bucket.doc_count
                 value = bucket.key
-                name = self.client.atlan_tag_cache.get_name_for_id(value)
+                name = client.atlan_tag_cache.get_name_for_id(value)
                 if count and name:
                     results.append(
                         SuggestionResponse.SuggestedItem(count=count, value=name)
@@ -361,7 +360,7 @@ class Suggestions(AtlanObject):
                     )
         return results
 
-    def _build_response(self, include, suggestion_response, aggregations):
+    def _build_response(self, client, include, suggestion_response, aggregations):
         if include == Suggestions.TYPE.SYSTEM_DESCRIPTION:
             suggestion_response.system_descriptions.extend(
                 self._get_descriptions(
@@ -390,9 +389,7 @@ class Suggestions(AtlanObject):
             )
         elif include == Suggestions.TYPE.TAGS:
             suggestion_response.atlan_tags.extend(
-                self._get_tags(
-                    aggregations.get(Suggestions.AGG_ATLAN_TAGS),
-                )
+                self._get_tags(client, aggregations.get(Suggestions.AGG_ATLAN_TAGS))
             )
         elif include == Suggestions.TYPE.TERMS:
             suggestion_response.assigned_terms.extend(
@@ -402,7 +399,10 @@ class Suggestions(AtlanObject):
             )
 
     def apply(
-        self, allow_multiple: bool = False, batch: Optional[Batch] = None
+        self,
+        allow_multiple: bool = False,
+        batch: Optional[Batch] = None,
+        client: Optional[AtlanClient] = None,
     ) -> Optional[AssetMutationResponse]:
         """
         Find the requested suggestions and apply the top suggestions as changes to the asset.
@@ -416,14 +416,16 @@ class Suggestions(AtlanObject):
         :param allow_multiple: if `True`, allow multiple suggestions to be applied
         to the asset (up to `max_suggestions` requested), i.e: for owners, terms and tags
         :param batch: (optional) the batch in which you want to apply the top suggestions as changes to the asset
+        :param client: (optional) client connectivity to an Atlan tenant
         """
+        client = client or AtlanClient.get_current_client()
         if batch:
-            return batch.add(self._apply(allow_multiple).asset)
-        result = self._apply(allow_multiple)
-        return self.client.save(result.asset, result.include_tags)
+            return batch.add(self._apply(client, allow_multiple).asset)
+        result = self._apply(client, allow_multiple)
+        return client.save(result.asset, result.include_tags)
 
-    def _apply(self, allow_multiple: bool):
-        response = self.get()
+    def _apply(self, client: AtlanClient, allow_multiple: bool):
+        response = self.get(client)
         asset = self.asset.trim_to_required()  # type: ignore[union-attr]
 
         description_to_apply = self._get_description_to_apply(response)

--- a/pyatlan/test_utils/__init__.py
+++ b/pyatlan/test_utils/__init__.py
@@ -8,7 +8,6 @@ from typing import List, Optional, Type
 from nanoid import generate as generate_nanoid  # type: ignore
 from pydantic.v1 import StrictStr
 
-from pyatlan.cache.role_cache import RoleCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.api_tokens import ApiToken
 from pyatlan.model.assets import (
@@ -106,7 +105,7 @@ def delete_asset(client: AtlanClient, asset_type: Type[A], guid: str) -> None:
 def create_connection(
     client: AtlanClient, name: str, connector_type: AtlanConnectorType
 ) -> Connection:
-    admin_role_guid = str(RoleCache.get_id_for_name("$admin"))
+    admin_role_guid = str(client.role_cache.get_id_for_name("$admin"))
     to_create = Connection.create(
         name=name, connector_type=connector_type, admin_roles=[admin_role_guid]
     )

--- a/tests/integration/admin_test.py
+++ b/tests/integration/admin_test.py
@@ -6,7 +6,6 @@ from typing import Generator
 import pytest
 from pydantic.v1 import StrictStr
 
-from pyatlan.cache.role_cache import RoleCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.group import AtlanGroup, CreateGroupResponse, GroupRequest
 from pyatlan.model.keycloak_events import AdminEventRequest, KeycloakEventRequest
@@ -35,7 +34,7 @@ def delete_group(client: AtlanClient, guid: str) -> None:
 
 
 def test_retrieve_roles(client: AtlanClient):
-    admin_role_guid = RoleCache.get_id_for_name("$admin")
+    admin_role_guid = client.role_cache.get_id_for_name("$admin")
     assert admin_role_guid
 
 

--- a/tests/integration/atlan_tag_test.py
+++ b/tests/integration/atlan_tag_test.py
@@ -8,7 +8,6 @@ from typing import Callable, Generator, Optional
 
 import pytest
 
-from pyatlan.cache.atlan_tag_cache import AtlanTagCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.errors import AtlanError
 from pyatlan.model.atlan_image import AtlanImage
@@ -116,12 +115,12 @@ def test_atlan_tag_with_image(atlan_tag_with_image):
     assert atlan_tag_with_image.options.get("iconType") == TagIconType.IMAGE.value
 
 
-def test_atlan_tag_cache(atlan_tag_with_image):
+def test_atlan_tag_cache(client: AtlanClient, atlan_tag_with_image):
     cls_name = CLS_IMAGE
-    cls_id = AtlanTagCache.get_id_for_name(cls_name)
+    cls_id = client.atlan_tag_cache.get_id_for_name(cls_name)
     assert cls_id
     assert cls_id == atlan_tag_with_image.name
-    cls_name_found = AtlanTagCache.get_name_for_id(cls_id)
+    cls_name_found = client.atlan_tag_cache.get_name_for_id(cls_id)
     assert cls_name_found
     assert cls_name_found == cls_name
 

--- a/tests/integration/connection_test.py
+++ b/tests/integration/connection_test.py
@@ -2,7 +2,6 @@
 # Copyright 2022 Atlan Pte. Ltd.
 import pytest
 
-from pyatlan.cache.role_cache import RoleCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.assets import Connection
 from pyatlan.model.enums import AtlanConnectorType
@@ -14,7 +13,7 @@ MODULE_NAME = TestId.make_unique("CONN")
 def create_connection(
     client: AtlanClient, name: str, connector_type: AtlanConnectorType
 ) -> Connection:
-    admin_role_guid = str(RoleCache.get_id_for_name("$admin"))
+    admin_role_guid = str(client.role_cache.get_id_for_name("$admin"))
     to_create = Connection.create(
         name=name, connector_type=connector_type, admin_roles=[admin_role_guid]
     )

--- a/tests/integration/custom_metadata_test.py
+++ b/tests/integration/custom_metadata_test.py
@@ -6,7 +6,6 @@ from typing import Generator, List, Optional, Tuple
 
 import pytest
 
-from pyatlan.cache.custom_metadata_cache import CustomMetadataCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.assets import (
     Asset,
@@ -623,7 +622,7 @@ def test_search_by_any_accountable(
     term: AtlasGlossaryTerm,
 ):
     attributes = ["name", "anchor"]
-    cm_attributes = CustomMetadataCache.get_attributes_for_search_results(
+    cm_attributes = client.custom_metadata_cache.get_attributes_for_search_results(
         set_name=CM_RACI
     )
     assert cm_attributes
@@ -724,7 +723,7 @@ def test_remove_term_cm_ipr(
 def test_remove_attribute(client: AtlanClient, cm_raci: CustomMetadataDef):
     global _removal_epoch
     cm_name = CM_RACI
-    existing = CustomMetadataCache.get_custom_metadata_def(name=cm_name)
+    existing = client.custom_metadata_cache.get_custom_metadata_def(name=cm_name)
     existing_attrs = existing.attribute_defs
     updated_attrs = []
     for existing_attr in existing_attrs:
@@ -758,7 +757,7 @@ def test_remove_attribute(client: AtlanClient, cm_raci: CustomMetadataDef):
 @pytest.mark.order(after="test_remove_attribute")
 def test_retrieve_structures(client: AtlanClient, cm_raci: CustomMetadataDef):
     global _removal_epoch
-    custom_attributes = CustomMetadataCache.get_all_custom_attributes()
+    custom_attributes = client.custom_metadata_cache.get_all_custom_attributes()
     assert custom_attributes
     assert len(custom_attributes) >= 3
     assert CM_RACI in custom_attributes.keys()
@@ -766,7 +765,7 @@ def test_retrieve_structures(client: AtlanClient, cm_raci: CustomMetadataDef):
     assert CM_QUALITY in custom_attributes.keys()
     extra = _validate_raci_structure(custom_attributes.get(CM_RACI), 4)
     assert not extra
-    custom_attributes = CustomMetadataCache.get_all_custom_attributes(
+    custom_attributes = client.custom_metadata_cache.get_all_custom_attributes(
         include_deleted=True
     )
     assert custom_attributes
@@ -785,7 +784,7 @@ def test_retrieve_structures(client: AtlanClient, cm_raci: CustomMetadataDef):
 
 @pytest.mark.order(after="test_retrieve_structures")
 def test_recreate_attribute(client: AtlanClient, cm_raci: CustomMetadataDef):
-    existing = CustomMetadataCache.get_custom_metadata_def(name=CM_RACI)
+    existing = client.custom_metadata_cache.get_custom_metadata_def(name=CM_RACI)
     existing_attrs = existing.attribute_defs
     updated_attrs = []
     for existing_attr in existing_attrs:
@@ -819,7 +818,7 @@ def test_recreate_attribute(client: AtlanClient, cm_raci: CustomMetadataDef):
 def test_retrieve_structure_without_archived(
     client: AtlanClient, cm_raci: CustomMetadataDef
 ):
-    custom_attributes = CustomMetadataCache.get_all_custom_attributes()
+    custom_attributes = client.custom_metadata_cache.get_all_custom_attributes()
     assert custom_attributes
     assert len(custom_attributes) >= 3
     assert CM_RACI in custom_attributes.keys()
@@ -838,7 +837,7 @@ def test_retrieve_structure_without_archived(
 def test_retrieve_structure_with_archived(
     client: AtlanClient, cm_raci: CustomMetadataDef
 ):
-    custom_attributes = CustomMetadataCache.get_all_custom_attributes(
+    custom_attributes = client.custom_metadata_cache.get_all_custom_attributes(
         include_deleted=True
     )
     assert custom_attributes

--- a/tests/integration/test_open_lineage.py
+++ b/tests/integration/test_open_lineage.py
@@ -2,7 +2,6 @@ import time
 
 import pytest
 
-from pyatlan.cache.role_cache import RoleCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.assets import Asset, Connection, Process, SparkJob
 from pyatlan.model.audit import AuditSearchRequest
@@ -17,7 +16,7 @@ MODULE_NAME = TestId.make_unique("OL")
 
 @pytest.fixture(scope="module")
 def connection(client: AtlanClient):
-    admin_role_guid = RoleCache.get_id_for_name("$admin")
+    admin_role_guid = client.role_cache.get_id_for_name("$admin")
     assert admin_role_guid
     response = client.open_lineage.create_connection(
         name=MODULE_NAME, admin_roles=[admin_role_guid]

--- a/tests/integration/test_sql_assets.py
+++ b/tests/integration/test_sql_assets.py
@@ -5,7 +5,6 @@ from typing import Callable, List, Optional, Type
 
 import pytest
 
-from pyatlan.cache.role_cache import RoleCache
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.assets import (
     Asset,
@@ -76,7 +75,7 @@ class TestConnection:
         client: AtlanClient,
         upsert: Callable[[Asset], AssetMutationResponse],
     ):
-        role = RoleCache.get_id_for_name("$admin")
+        role = client.role_cache.get_id_for_name("$admin")
         assert role
         connection_name = TestId.make_unique("INT")
         c = Connection.create(

--- a/tests/unit/model/connection_test.py
+++ b/tests/unit/model/connection_test.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -8,6 +8,47 @@ from pyatlan.client.token import TokenClient
 from pyatlan.model.assets import Connection
 from pyatlan.model.enums import AtlanConnectorType
 from tests.unit.model.constants import CONNECTION_NAME, CONNECTION_QUALIFIED_NAME
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+
+@pytest.fixture()
+def client():
+    return AtlanClient()
+
+
+@pytest.fixture()
+def current_client(client, monkeypatch):
+    monkeypatch.setattr(
+        AtlanClient,
+        "get_current_client",
+        lambda: client,
+    )
+
+
+@pytest.fixture()
+def mock_group_cache(current_client, monkeypatch):
+    mock_cache = MagicMock()
+    monkeypatch.setattr(AtlanClient, "group_cache", mock_cache)
+    return mock_cache
+
+
+@pytest.fixture()
+def mock_user_cache(current_client, monkeypatch):
+    mock_cache = MagicMock()
+    monkeypatch.setattr(AtlanClient, "user_cache", mock_cache)
+    return mock_cache
+
+
+@pytest.fixture()
+def mock_role_cache(current_client, monkeypatch):
+    mock_cache = MagicMock()
+    monkeypatch.setattr(AtlanClient, "role_cache", mock_cache)
+    return mock_cache
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Atlan Pte. Ltd.
+import threading
+import time
 from importlib.resources import read_text
 from json import load, loads
 from pathlib import Path
@@ -2070,6 +2072,62 @@ def test_atlan_call_api_server_error_messages_with_causes(
             match=escape(str(error_info)),
         ):
             client.asset.save(glossary)
+
+
+@pytest.mark.parametrize("thread_count", [3])  # Run with three threads
+def test_atlan_client_tls(thread_count):
+    """Tests that AtlanClient instances remain isolated across multiple threads."""
+    validation_results = {}
+    results_lock = threading.Lock()
+
+    def _test_atlan_client_isolation(name, api_key1, api_key2, api_key3):
+        """Creates three AtlanClient instances within the same thread and verifies isolation."""
+        # Instantiate three separate AtlanClient instances
+        client1 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key1)
+        time.sleep(0.2)
+        observed1 = client1.get_default_client().api_key  # Should match api_key1
+
+        client2 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key2)
+        time.sleep(0.2)
+        observed2 = client2.get_default_client().api_key  # Should match api_key2
+
+        client3 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key3)
+        time.sleep(0.2)
+        observed3 = client3.get_default_client().api_key  # Should match api_key3
+
+        # Store results in a thread-safe way
+        with results_lock:
+            validation_results[name] = (observed1, observed2, observed3)
+
+    # Define unique API keys for each thread
+    api_keys = [
+        ("API_KEY_1A", "API_KEY_1B", "API_KEY_1C"),
+        ("API_KEY_2A", "API_KEY_2B", "API_KEY_2C"),
+        ("API_KEY_3A", "API_KEY_3B", "API_KEY_3C"),
+    ]
+
+    threads = []
+    for i in range(thread_count):
+        thread = threading.Thread(
+            target=_test_atlan_client_isolation,
+            args=(f"thread{i + 1}", *api_keys[i]),
+        )
+        threads.append(thread)
+        thread.start()
+
+    # Wait for all threads to finish
+    for thread in threads:
+        thread.join()
+
+    # Validate that each thread's clients retained their assigned API keys
+    for i in range(thread_count):
+        thread_name = f"thread{i + 1}"
+        expected_keys = api_keys[i]
+
+        assert validation_results[thread_name] == expected_keys, (
+            f"Clients were overwritten across threads! "
+            f"{thread_name} saw {validation_results[thread_name]} instead of {expected_keys}"
+        )
 
 
 class TestBatch:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Atlan Pte. Ltd.
+import threading
+import time
 from importlib.resources import read_text
 from json import load, loads
 from pathlib import Path
@@ -2092,60 +2094,60 @@ def test_atlan_call_api_server_error_messages_with_causes(
             client.asset.save(glossary)
 
 
-# @pytest.mark.parametrize("thread_count", [3])  # Run with three threads
-# def test_atlan_client_tls(thread_count):
-#     """Tests that AtlanClient instances remain isolated across multiple threads."""
-#     validation_results = {}
-#     results_lock = threading.Lock()
+@pytest.mark.parametrize("thread_count", [3])  # Run with three threads
+def test_atlan_client_tls(thread_count):
+    """Tests that AtlanClient instances remain isolated across multiple threads."""
+    validation_results = {}
+    results_lock = threading.Lock()
 
-#     def _test_atlan_client_isolation(name, api_key1, api_key2, api_key3):
-#         """Creates three AtlanClient instances within the same thread and verifies isolation."""
-#         # Instantiate three separate AtlanClient instances
-#         client1 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key1)
-#         time.sleep(0.2)
-#         observed1 = client1.get_current_client().api_key  # Should match api_key1
+    def _test_atlan_client_isolation(name, api_key1, api_key2, api_key3):
+        """Creates three AtlanClient instances within the same thread and verifies isolation."""
+        # Instantiate three separate AtlanClient instances
+        client1 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key1)
+        time.sleep(0.2)
+        observed1 = client1.get_current_client().api_key  # Should match api_key1
 
-#         client2 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key2)
-#         time.sleep(0.2)
-#         observed2 = client2.get_current_client().api_key  # Should match api_key2
+        client2 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key2)
+        time.sleep(0.2)
+        observed2 = client2.get_current_client().api_key  # Should match api_key2
 
-#         client3 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key3)
-#         time.sleep(0.2)
-#         observed3 = client3.get_current_client().api_key  # Should match api_key3
+        client3 = AtlanClient(base_url="https://test.atlan.com", api_key=api_key3)
+        time.sleep(0.2)
+        observed3 = client3.get_current_client().api_key  # Should match api_key3
 
-#         # Store results in a thread-safe way
-#         with results_lock:
-#             validation_results[name] = (observed1, observed2, observed3)
+        # Store results in a thread-safe way
+        with results_lock:
+            validation_results[name] = (observed1, observed2, observed3)
 
-#     # Define unique API keys for each thread
-#     api_keys = [
-#         ("API_KEY_1A", "API_KEY_1B", "API_KEY_1C"),
-#         ("API_KEY_2A", "API_KEY_2B", "API_KEY_2C"),
-#         ("API_KEY_3A", "API_KEY_3B", "API_KEY_3C"),
-#     ]
+    # Define unique API keys for each thread
+    api_keys = [
+        ("API_KEY_1A", "API_KEY_1B", "API_KEY_1C"),
+        ("API_KEY_2A", "API_KEY_2B", "API_KEY_2C"),
+        ("API_KEY_3A", "API_KEY_3B", "API_KEY_3C"),
+    ]
 
-#     threads = []
-#     for i in range(thread_count):
-#         thread = threading.Thread(
-#             target=_test_atlan_client_isolation,
-#             args=(f"thread{i + 1}", *api_keys[i]),
-#         )
-#         threads.append(thread)
-#         thread.start()
+    threads = []
+    for i in range(thread_count):
+        thread = threading.Thread(
+            target=_test_atlan_client_isolation,
+            args=(f"thread{i + 1}", *api_keys[i]),
+        )
+        threads.append(thread)
+        thread.start()
 
-#     # Wait for all threads to finish
-#     for thread in threads:
-#         thread.join()
+    # Wait for all threads to finish
+    for thread in threads:
+        thread.join()
 
-#     # Validate that each thread's clients retained their assigned API keys
-#     for i in range(thread_count):
-#         thread_name = f"thread{i + 1}"
-#         expected_keys = api_keys[i]
+    # Validate that each thread's clients retained their assigned API keys
+    for i in range(thread_count):
+        thread_name = f"thread{i + 1}"
+        expected_keys = api_keys[i]
 
-#         assert validation_results[thread_name] == expected_keys, (
-#             f"Clients were overwritten across threads! "
-#             f"{thread_name} saw {validation_results[thread_name]} instead of {expected_keys}"
-#         )
+        assert validation_results[thread_name] == expected_keys, (
+            f"Clients were overwritten across threads! "
+            f"{thread_name} saw {validation_results[thread_name]} instead of {expected_keys}"
+        )
 
 
 class TestBatch:

--- a/tests/unit/test_connection_cache.py
+++ b/tests/unit/test_connection_cache.py
@@ -1,259 +1,259 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Atlan Pte. Ltd.
-from unittest.mock import Mock, patch
+# # SPDX-License-Identifier: Apache-2.0
+# # Copyright 2024 Atlan Pte. Ltd.
+# from unittest.mock import Mock, patch
 
-import pytest
+# import pytest
 
-from pyatlan.cache.connection_cache import ConnectionCache, ConnectionName
-from pyatlan.client.atlan import AtlanClient
-from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
-from pyatlan.model.assets import Connection
-
-
-@pytest.fixture(autouse=True)
-def set_env(monkeypatch):
-    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
-    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+# from pyatlan.cache.connection_cache import ConnectionCache, ConnectionName
+# from pyatlan.client.atlan import AtlanClient
+# from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
+# from pyatlan.model.assets import Connection
 
 
-def test_get_by_guid_with_not_found_error(monkeypatch):
-    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-        ConnectionCache.get_by_guid("")
+# @pytest.fixture(autouse=True)
+# def set_env(monkeypatch):
+#     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+#     monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
 
 
-@patch.object(ConnectionCache, "lookup_by_guid")
-@patch.object(
-    ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-)
-def test_get_by_guid_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_guid):
-    test_guid = "test-guid-123"
-    with pytest.raises(
-        NotFoundError,
-        match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
-    ):
-        ConnectionCache.get_by_guid(test_guid)
-    mock_get_cache.assert_called_once()
+# def test_get_by_guid_with_not_found_error(monkeypatch):
+#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+#         ConnectionCache.get_by_guid("")
 
 
-def test_get_by_qualified_name_with_not_found_error(monkeypatch):
-    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-        ConnectionCache.get_by_qualified_name("")
+# @patch.object(ConnectionCache, "lookup_by_guid")
+# @patch.object(
+#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
+# )
+# def test_get_by_guid_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_guid):
+#     test_guid = "test-guid-123"
+#     with pytest.raises(
+#         NotFoundError,
+#         match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
+#     ):
+#         ConnectionCache.get_by_guid(test_guid)
+#     mock_get_cache.assert_called_once()
 
 
-@patch.object(ConnectionCache, "lookup_by_qualified_name")
-@patch.object(
-    ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-)
-def test_get_by_qualified_name_with_no_invalid_request_error(
-    mock_get_cache, mock_lookup_by_qualified_name
-):
-    test_qn = "default/snowflake/123456789"
-    test_connector = "snowflake"
-    with pytest.raises(
-        NotFoundError,
-        match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
-            test_qn, test_connector
-        ),
-    ):
-        ConnectionCache.get_by_qualified_name(test_qn)
-    mock_get_cache.assert_called_once()
+# def test_get_by_qualified_name_with_not_found_error(monkeypatch):
+#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+#         ConnectionCache.get_by_qualified_name("")
 
 
-def test_get_by_name_with_not_found_error(monkeypatch):
-    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
-        ConnectionCache.get_by_name("")
+# @patch.object(ConnectionCache, "lookup_by_qualified_name")
+# @patch.object(
+#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
+# )
+# def test_get_by_qualified_name_with_no_invalid_request_error(
+#     mock_get_cache, mock_lookup_by_qualified_name
+# ):
+#     test_qn = "default/snowflake/123456789"
+#     test_connector = "snowflake"
+#     with pytest.raises(
+#         NotFoundError,
+#         match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
+#             test_qn, test_connector
+#         ),
+#     ):
+#         ConnectionCache.get_by_qualified_name(test_qn)
+#     mock_get_cache.assert_called_once()
 
 
-@patch.object(ConnectionCache, "lookup_by_name")
-@patch.object(
-    ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-)
-def test_get_by_name_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_name):
-    test_name = ConnectionName("snowflake/test")
-    with pytest.raises(
-        NotFoundError,
-        match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
-            ConnectionName._TYPE_NAME,
-            test_name,
-        ),
-    ):
-        ConnectionCache.get_by_name(test_name)
-    mock_get_cache.assert_called_once()
+# def test_get_by_name_with_not_found_error(monkeypatch):
+#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
+#         ConnectionCache.get_by_name("")
 
 
-@patch.object(ConnectionCache, "lookup_by_guid")
-@patch.object(
-    ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-)
-def test_get_by_guid(mock_get_cache, mock_lookup_by_guid):
-    test_guid = "test-guid-123"
-    test_qn = "test-qualified-name"
-    conn = Connection()
-    conn.guid = test_guid
-    conn.qualified_name = test_qn
-    test_asset = conn
-
-    mock_guid_to_asset = Mock()
-    mock_name_to_guid = Mock()
-    mock_qualified_name_to_guid = Mock()
-
-    # 1 - Not found in the cache, triggers a lookup call
-    # 2, 3, 4 - Uses the cached entry from the map
-    mock_guid_to_asset.get.side_effect = [
-        None,
-        test_asset,
-        test_asset,
-        test_asset,
-    ]
-    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
-    mock_qualified_name_to_guid.get.side_effect = [
-        test_guid,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
-
-    # Assign mock caches to the return value of get_cache
-    mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-    mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-    mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
-
-    connection = ConnectionCache.get_by_guid(test_guid)
-
-    # Multiple calls with the same GUID result in no additional API lookups
-    # as the object is already cached
-    connection = ConnectionCache.get_by_guid(test_guid)
-    connection = ConnectionCache.get_by_guid(test_guid)
-
-    assert test_guid == connection.guid
-    assert test_qn == connection.qualified_name
-
-    # The method is called three times, but the lookup is triggered only once
-    assert mock_get_cache.call_count == 3
-    mock_lookup_by_guid.assert_called_once()
+# @patch.object(ConnectionCache, "lookup_by_name")
+# @patch.object(
+#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
+# )
+# def test_get_by_name_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_name):
+#     test_name = ConnectionName("snowflake/test")
+#     with pytest.raises(
+#         NotFoundError,
+#         match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
+#             ConnectionName._TYPE_NAME,
+#             test_name,
+#         ),
+#     ):
+#         ConnectionCache.get_by_name(test_name)
+#     mock_get_cache.assert_called_once()
 
 
-@patch.object(ConnectionCache, "lookup_by_guid")
-@patch.object(ConnectionCache, "lookup_by_qualified_name")
-@patch.object(
-    ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-)
-def test_get_by_qualified_name(mock_get_cache, mock_lookup_by_qn, mock_lookup_by_guid):
-    test_guid = "test-guid-123"
-    test_qn = "test-qualified-name"
-    conn = Connection()
-    conn.guid = test_guid
-    conn.qualified_name = test_qn
-    test_asset = conn
+# @patch.object(ConnectionCache, "lookup_by_guid")
+# @patch.object(
+#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
+# )
+# def test_get_by_guid(mock_get_cache, mock_lookup_by_guid):
+#     test_guid = "test-guid-123"
+#     test_qn = "test-qualified-name"
+#     conn = Connection()
+#     conn.guid = test_guid
+#     conn.qualified_name = test_qn
+#     test_asset = conn
 
-    mock_guid_to_asset = Mock()
-    mock_name_to_guid = Mock()
-    mock_qualified_name_to_guid = Mock()
+#     mock_guid_to_asset = Mock()
+#     mock_name_to_guid = Mock()
+#     mock_qualified_name_to_guid = Mock()
 
-    # 1 - Not found in the cache, triggers a lookup call
-    # 2, 3, 4 - Uses the cached entry from the map
-    mock_qualified_name_to_guid.get.side_effect = [
-        None,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
+#     # 1 - Not found in the cache, triggers a lookup call
+#     # 2, 3, 4 - Uses the cached entry from the map
+#     mock_guid_to_asset.get.side_effect = [
+#         None,
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#     ]
+#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+#     mock_qualified_name_to_guid.get.side_effect = [
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
 
-    # Other caches will be populated once
-    # the lookup call for get_by_qualified_name is made
-    mock_guid_to_asset.get.side_effect = [
-        test_asset,
-        test_asset,
-        test_asset,
-        test_asset,
-    ]
-    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+#     # Assign mock caches to the return value of get_cache
+#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
+#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
+#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
 
-    mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-    mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-    mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+#     connection = ConnectionCache.get_by_guid(test_guid)
 
-    connection = ConnectionCache.get_by_qualified_name(test_qn)
+#     # Multiple calls with the same GUID result in no additional API lookups
+#     # as the object is already cached
+#     connection = ConnectionCache.get_by_guid(test_guid)
+#     connection = ConnectionCache.get_by_guid(test_guid)
 
-    # Multiple calls with the same
-    # qualified name result in no additional API lookups
-    # as the object is already cached
-    connection = ConnectionCache.get_by_qualified_name(test_qn)
-    connection = ConnectionCache.get_by_qualified_name(test_qn)
+#     assert test_guid == connection.guid
+#     assert test_qn == connection.qualified_name
 
-    assert test_guid == connection.guid
-    assert test_qn == connection.qualified_name
-
-    # The method is called three times
-    # but the lookup is triggered only once
-    assert mock_get_cache.call_count == 3
-    mock_lookup_by_qn.assert_called_once()
-
-    # No call to guid lookup since the object is already in the cache
-    assert mock_lookup_by_guid.call_count == 0
+#     # The method is called three times, but the lookup is triggered only once
+#     assert mock_get_cache.call_count == 3
+#     mock_lookup_by_guid.assert_called_once()
 
 
-@patch.object(ConnectionCache, "lookup_by_guid")
-@patch.object(ConnectionCache, "lookup_by_name")
-@patch.object(
-    ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-)
-def test_get_by_name(mock_get_cache, mock_lookup_by_name, mock_lookup_by_guid):
-    test_name = ConnectionName("snowflake/test")
-    test_guid = "test-guid-123"
-    test_qn = "test-qualified-name"
-    conn = Connection()
-    conn.guid = test_guid
-    conn.qualified_name = test_qn
-    test_asset = conn
+# @patch.object(ConnectionCache, "lookup_by_guid")
+# @patch.object(ConnectionCache, "lookup_by_qualified_name")
+# @patch.object(
+#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
+# )
+# def test_get_by_qualified_name(mock_get_cache, mock_lookup_by_qn, mock_lookup_by_guid):
+#     test_guid = "test-guid-123"
+#     test_qn = "test-qualified-name"
+#     conn = Connection()
+#     conn.guid = test_guid
+#     conn.qualified_name = test_qn
+#     test_asset = conn
 
-    mock_guid_to_asset = Mock()
-    mock_name_to_guid = Mock()
-    mock_qualified_name_to_guid = Mock()
+#     mock_guid_to_asset = Mock()
+#     mock_name_to_guid = Mock()
+#     mock_qualified_name_to_guid = Mock()
 
-    # 1 - Not found in the cache, triggers a lookup call
-    # 2, 3, 4 - Uses the cached entry from the map
-    mock_name_to_guid.get.side_effect = [
-        None,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
+#     # 1 - Not found in the cache, triggers a lookup call
+#     # 2, 3, 4 - Uses the cached entry from the map
+#     mock_qualified_name_to_guid.get.side_effect = [
+#         None,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
 
-    # Other caches will be populated once
-    # the lookup call for get_by_qualified_name is made
-    mock_guid_to_asset.get.side_effect = [
-        test_asset,
-        test_asset,
-        test_asset,
-        test_asset,
-    ]
-    mock_qualified_name_to_guid.get.side_effect = [
-        test_guid,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
+#     # Other caches will be populated once
+#     # the lookup call for get_by_qualified_name is made
+#     mock_guid_to_asset.get.side_effect = [
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#     ]
+#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
 
-    mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-    mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-    mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
+#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
+#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
 
-    connection = ConnectionCache.get_by_name(test_name)
+#     connection = ConnectionCache.get_by_qualified_name(test_qn)
 
-    # Multiple calls with the same
-    # qualified name result in no additional API lookups
-    # as the object is already cached
-    connection = ConnectionCache.get_by_name(test_name)
-    connection = ConnectionCache.get_by_name(test_name)
+#     # Multiple calls with the same
+#     # qualified name result in no additional API lookups
+#     # as the object is already cached
+#     connection = ConnectionCache.get_by_qualified_name(test_qn)
+#     connection = ConnectionCache.get_by_qualified_name(test_qn)
 
-    assert test_guid == connection.guid
-    assert test_qn == connection.qualified_name
+#     assert test_guid == connection.guid
+#     assert test_qn == connection.qualified_name
 
-    # The method is called three times
-    # but the lookup is triggered only once
-    assert mock_get_cache.call_count == 3
-    mock_lookup_by_name.assert_called_once()
+#     # The method is called three times
+#     # but the lookup is triggered only once
+#     assert mock_get_cache.call_count == 3
+#     mock_lookup_by_qn.assert_called_once()
 
-    # No call to guid lookup since the object is already in the cache
-    assert mock_lookup_by_guid.call_count == 0
+#     # No call to guid lookup since the object is already in the cache
+#     assert mock_lookup_by_guid.call_count == 0
+
+
+# @patch.object(ConnectionCache, "lookup_by_guid")
+# @patch.object(ConnectionCache, "lookup_by_name")
+# @patch.object(
+#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
+# )
+# def test_get_by_name(mock_get_cache, mock_lookup_by_name, mock_lookup_by_guid):
+#     test_name = ConnectionName("snowflake/test")
+#     test_guid = "test-guid-123"
+#     test_qn = "test-qualified-name"
+#     conn = Connection()
+#     conn.guid = test_guid
+#     conn.qualified_name = test_qn
+#     test_asset = conn
+
+#     mock_guid_to_asset = Mock()
+#     mock_name_to_guid = Mock()
+#     mock_qualified_name_to_guid = Mock()
+
+#     # 1 - Not found in the cache, triggers a lookup call
+#     # 2, 3, 4 - Uses the cached entry from the map
+#     mock_name_to_guid.get.side_effect = [
+#         None,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
+
+#     # Other caches will be populated once
+#     # the lookup call for get_by_qualified_name is made
+#     mock_guid_to_asset.get.side_effect = [
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#     ]
+#     mock_qualified_name_to_guid.get.side_effect = [
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
+
+#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
+#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
+#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+
+#     connection = ConnectionCache.get_by_name(test_name)
+
+#     # Multiple calls with the same
+#     # qualified name result in no additional API lookups
+#     # as the object is already cached
+#     connection = ConnectionCache.get_by_name(test_name)
+#     connection = ConnectionCache.get_by_name(test_name)
+
+#     assert test_guid == connection.guid
+#     assert test_qn == connection.qualified_name
+
+#     # The method is called three times
+#     # but the lookup is triggered only once
+#     assert mock_get_cache.call_count == 3
+#     mock_lookup_by_name.assert_called_once()
+
+#     # No call to guid lookup since the object is already in the cache
+#     assert mock_lookup_by_guid.call_count == 0

--- a/tests/unit/test_connection_cache.py
+++ b/tests/unit/test_connection_cache.py
@@ -1,259 +1,263 @@
-# # SPDX-License-Identifier: Apache-2.0
-# # Copyright 2024 Atlan Pte. Ltd.
-# from unittest.mock import Mock, patch
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Atlan Pte. Ltd.
+from unittest.mock import Mock, patch
 
-# import pytest
+import pytest
 
-# from pyatlan.cache.connection_cache import ConnectionCache, ConnectionName
-# from pyatlan.client.atlan import AtlanClient
-# from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
-# from pyatlan.model.assets import Connection
-
-
-# @pytest.fixture(autouse=True)
-# def set_env(monkeypatch):
-#     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
-#     monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+from pyatlan.cache.connection_cache import ConnectionCache, ConnectionName
+from pyatlan.client.atlan import AtlanClient
+from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
+from pyatlan.model.assets import Connection
 
 
-# def test_get_by_guid_with_not_found_error(monkeypatch):
-#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-#         ConnectionCache.get_by_guid("")
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
 
 
-# @patch.object(ConnectionCache, "lookup_by_guid")
-# @patch.object(
-#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-# )
-# def test_get_by_guid_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_guid):
-#     test_guid = "test-guid-123"
-#     with pytest.raises(
-#         NotFoundError,
-#         match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
-#     ):
-#         ConnectionCache.get_by_guid(test_guid)
-#     mock_get_cache.assert_called_once()
+@pytest.fixture()
+def client():
+    return AtlanClient()
 
 
-# def test_get_by_qualified_name_with_not_found_error(monkeypatch):
-#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-#         ConnectionCache.get_by_qualified_name("")
+@pytest.fixture()
+def current_client(client, monkeypatch):
+    monkeypatch.setattr(
+        AtlanClient,
+        "get_current_client",
+        lambda: client,
+    )
 
 
-# @patch.object(ConnectionCache, "lookup_by_qualified_name")
-# @patch.object(
-#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-# )
-# def test_get_by_qualified_name_with_no_invalid_request_error(
-#     mock_get_cache, mock_lookup_by_qualified_name
-# ):
-#     test_qn = "default/snowflake/123456789"
-#     test_connector = "snowflake"
-#     with pytest.raises(
-#         NotFoundError,
-#         match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
-#             test_qn, test_connector
-#         ),
-#     ):
-#         ConnectionCache.get_by_qualified_name(test_qn)
-#     mock_get_cache.assert_called_once()
+@pytest.fixture()
+def mock_connection_cache(current_client, monkeypatch):
+    mock_cache = ConnectionCache(current_client)
+    monkeypatch.setattr(AtlanClient, "connection_cache", mock_cache)
+    return mock_cache
 
 
-# def test_get_by_name_with_not_found_error(monkeypatch):
-#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
-#         ConnectionCache.get_by_name("")
+def test_get_by_guid_with_not_found_error(current_client):
+    connection_cache = ConnectionCache(current_client)
+    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+        connection_cache.get_by_guid("")
 
 
-# @patch.object(ConnectionCache, "lookup_by_name")
-# @patch.object(
-#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-# )
-# def test_get_by_name_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_name):
-#     test_name = ConnectionName("snowflake/test")
-#     with pytest.raises(
-#         NotFoundError,
-#         match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
-#             ConnectionName._TYPE_NAME,
-#             test_name,
-#         ),
-#     ):
-#         ConnectionCache.get_by_name(test_name)
-#     mock_get_cache.assert_called_once()
+@patch.object(ConnectionCache, "lookup_by_guid")
+def test_get_by_guid_with_no_invalid_request_error(
+    mock_lookup_by_guid, mock_connection_cache
+):
+    test_guid = "test-guid-123"
+    with pytest.raises(
+        NotFoundError,
+        match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
+    ):
+        mock_connection_cache.get_by_guid(test_guid)
 
 
-# @patch.object(ConnectionCache, "lookup_by_guid")
-# @patch.object(
-#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-# )
-# def test_get_by_guid(mock_get_cache, mock_lookup_by_guid):
-#     test_guid = "test-guid-123"
-#     test_qn = "test-qualified-name"
-#     conn = Connection()
-#     conn.guid = test_guid
-#     conn.qualified_name = test_qn
-#     test_asset = conn
-
-#     mock_guid_to_asset = Mock()
-#     mock_name_to_guid = Mock()
-#     mock_qualified_name_to_guid = Mock()
-
-#     # 1 - Not found in the cache, triggers a lookup call
-#     # 2, 3, 4 - Uses the cached entry from the map
-#     mock_guid_to_asset.get.side_effect = [
-#         None,
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#     ]
-#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
-#     mock_qualified_name_to_guid.get.side_effect = [
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
-
-#     # Assign mock caches to the return value of get_cache
-#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
-
-#     connection = ConnectionCache.get_by_guid(test_guid)
-
-#     # Multiple calls with the same GUID result in no additional API lookups
-#     # as the object is already cached
-#     connection = ConnectionCache.get_by_guid(test_guid)
-#     connection = ConnectionCache.get_by_guid(test_guid)
-
-#     assert test_guid == connection.guid
-#     assert test_qn == connection.qualified_name
-
-#     # The method is called three times, but the lookup is triggered only once
-#     assert mock_get_cache.call_count == 3
-#     mock_lookup_by_guid.assert_called_once()
+def test_get_by_qualified_name_with_not_found_error(mock_connection_cache):
+    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+        mock_connection_cache.get_by_qualified_name("")
 
 
-# @patch.object(ConnectionCache, "lookup_by_guid")
-# @patch.object(ConnectionCache, "lookup_by_qualified_name")
-# @patch.object(
-#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-# )
-# def test_get_by_qualified_name(mock_get_cache, mock_lookup_by_qn, mock_lookup_by_guid):
-#     test_guid = "test-guid-123"
-#     test_qn = "test-qualified-name"
-#     conn = Connection()
-#     conn.guid = test_guid
-#     conn.qualified_name = test_qn
-#     test_asset = conn
-
-#     mock_guid_to_asset = Mock()
-#     mock_name_to_guid = Mock()
-#     mock_qualified_name_to_guid = Mock()
-
-#     # 1 - Not found in the cache, triggers a lookup call
-#     # 2, 3, 4 - Uses the cached entry from the map
-#     mock_qualified_name_to_guid.get.side_effect = [
-#         None,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
-
-#     # Other caches will be populated once
-#     # the lookup call for get_by_qualified_name is made
-#     mock_guid_to_asset.get.side_effect = [
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#     ]
-#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
-
-#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
-
-#     connection = ConnectionCache.get_by_qualified_name(test_qn)
-
-#     # Multiple calls with the same
-#     # qualified name result in no additional API lookups
-#     # as the object is already cached
-#     connection = ConnectionCache.get_by_qualified_name(test_qn)
-#     connection = ConnectionCache.get_by_qualified_name(test_qn)
-
-#     assert test_guid == connection.guid
-#     assert test_qn == connection.qualified_name
-
-#     # The method is called three times
-#     # but the lookup is triggered only once
-#     assert mock_get_cache.call_count == 3
-#     mock_lookup_by_qn.assert_called_once()
-
-#     # No call to guid lookup since the object is already in the cache
-#     assert mock_lookup_by_guid.call_count == 0
+@patch.object(ConnectionCache, "lookup_by_qualified_name")
+def test_get_by_qualified_name_with_no_invalid_request_error(
+    mock_lookup_by_qualified_name, mock_connection_cache
+):
+    test_qn = "default/snowflake/123456789"
+    test_connector = "snowflake"
+    with pytest.raises(
+        NotFoundError,
+        match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
+            test_qn, test_connector
+        ),
+    ):
+        mock_connection_cache.get_by_qualified_name(test_qn)
 
 
-# @patch.object(ConnectionCache, "lookup_by_guid")
-# @patch.object(ConnectionCache, "lookup_by_name")
-# @patch.object(
-#     ConnectionCache, "get_cache", return_value=ConnectionCache(client=AtlanClient())
-# )
-# def test_get_by_name(mock_get_cache, mock_lookup_by_name, mock_lookup_by_guid):
-#     test_name = ConnectionName("snowflake/test")
-#     test_guid = "test-guid-123"
-#     test_qn = "test-qualified-name"
-#     conn = Connection()
-#     conn.guid = test_guid
-#     conn.qualified_name = test_qn
-#     test_asset = conn
+def test_get_by_name_with_not_found_error(mock_connection_cache):
+    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
+        mock_connection_cache.get_by_name("")
 
-#     mock_guid_to_asset = Mock()
-#     mock_name_to_guid = Mock()
-#     mock_qualified_name_to_guid = Mock()
 
-#     # 1 - Not found in the cache, triggers a lookup call
-#     # 2, 3, 4 - Uses the cached entry from the map
-#     mock_name_to_guid.get.side_effect = [
-#         None,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
+@patch.object(ConnectionCache, "lookup_by_name")
+def test_get_by_name_with_no_invalid_request_error(
+    mock_lookup_by_name, mock_connection_cache
+):
+    test_name = ConnectionName("snowflake/test")
+    with pytest.raises(
+        NotFoundError,
+        match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
+            ConnectionName._TYPE_NAME,
+            test_name,
+        ),
+    ):
+        mock_connection_cache.get_by_name(test_name)
 
-#     # Other caches will be populated once
-#     # the lookup call for get_by_qualified_name is made
-#     mock_guid_to_asset.get.side_effect = [
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#     ]
-#     mock_qualified_name_to_guid.get.side_effect = [
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
 
-#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+@patch.object(ConnectionCache, "lookup_by_guid")
+def test_get_by_guid(mock_lookup_by_guid, mock_connection_cache):
+    test_guid = "test-guid-123"
+    test_qn = "test-qualified-name"
+    conn = Connection()
+    conn.guid = test_guid
+    conn.qualified_name = test_qn
+    test_asset = conn
 
-#     connection = ConnectionCache.get_by_name(test_name)
+    mock_guid_to_asset = Mock()
+    mock_name_to_guid = Mock()
+    mock_qualified_name_to_guid = Mock()
 
-#     # Multiple calls with the same
-#     # qualified name result in no additional API lookups
-#     # as the object is already cached
-#     connection = ConnectionCache.get_by_name(test_name)
-#     connection = ConnectionCache.get_by_name(test_name)
+    # 1 - Not found in the cache, triggers a lookup call
+    # 2, 3, 4 - Uses the cached entry from the map
+    mock_guid_to_asset.get.side_effect = [
+        None,
+        test_asset,
+        test_asset,
+        test_asset,
+    ]
+    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+    mock_qualified_name_to_guid.get.side_effect = [
+        test_guid,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
 
-#     assert test_guid == connection.guid
-#     assert test_qn == connection.qualified_name
+    # Assign mock caches to the return value of get_cache
+    mock_connection_cache.guid_to_asset = mock_guid_to_asset
+    mock_connection_cache.name_to_guid = mock_name_to_guid
+    mock_connection_cache.qualified_name_to_guid = mock_qualified_name_to_guid
 
-#     # The method is called three times
-#     # but the lookup is triggered only once
-#     assert mock_get_cache.call_count == 3
-#     mock_lookup_by_name.assert_called_once()
+    connection = mock_connection_cache.get_by_guid(test_guid)
 
-#     # No call to guid lookup since the object is already in the cache
-#     assert mock_lookup_by_guid.call_count == 0
+    # Multiple calls with the same GUID result in no additional API lookups
+    # as the object is already cached
+    connection = mock_connection_cache.get_by_guid(test_guid)
+    connection = mock_connection_cache.get_by_guid(test_guid)
+
+    assert test_guid == connection.guid
+    assert test_qn == connection.qualified_name
+
+    # The method is called four times, but the lookup is triggered only once
+    assert mock_guid_to_asset.get.call_count == 4
+    mock_lookup_by_guid.assert_called_once()
+
+
+@patch.object(ConnectionCache, "lookup_by_guid")
+@patch.object(ConnectionCache, "lookup_by_qualified_name")
+def test_get_by_qualified_name(
+    mock_lookup_by_qn, mock_lookup_by_guid, mock_connection_cache
+):
+    test_guid = "test-guid-123"
+    test_qn = "test-qualified-name"
+    conn = Connection()
+    conn.guid = test_guid
+    conn.qualified_name = test_qn
+    test_asset = conn
+
+    mock_guid_to_asset = Mock()
+    mock_name_to_guid = Mock()
+    mock_qualified_name_to_guid = Mock()
+
+    # 1 - Not found in the cache, triggers a lookup call
+    # 2, 3, 4 - Uses the cached entry from the map
+    mock_qualified_name_to_guid.get.side_effect = [
+        None,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
+
+    # Other caches will be populated once
+    # the lookup call for get_by_qualified_name is made
+    mock_guid_to_asset.get.side_effect = [
+        test_asset,
+        test_asset,
+        test_asset,
+        test_asset,
+    ]
+    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+
+    mock_connection_cache.guid_to_asset = mock_guid_to_asset
+    mock_connection_cache.name_to_guid = mock_name_to_guid
+    mock_connection_cache.qualified_name_to_guid = mock_qualified_name_to_guid
+
+    connection = mock_connection_cache.get_by_qualified_name(test_qn)
+
+    # Multiple calls with the same
+    # qualified name result in no additional API lookups
+    # as the object is already cached
+    connection = mock_connection_cache.get_by_qualified_name(test_qn)
+    connection = mock_connection_cache.get_by_qualified_name(test_qn)
+
+    assert test_guid == connection.guid
+    assert test_qn == connection.qualified_name
+
+    # The method is found four times
+    # but the lookup is triggered only once
+    assert mock_qualified_name_to_guid.get.call_count == 4
+    mock_lookup_by_qn.assert_called_once()
+
+
+@patch.object(ConnectionCache, "lookup_by_guid")
+@patch.object(ConnectionCache, "lookup_by_name")
+def test_get_by_name(mock_lookup_by_name, mock_lookup_by_guid, mock_connection_cache):
+    test_name = ConnectionName("snowflake/test")
+    test_guid = "test-guid-123"
+    test_qn = "test-qualified-name"
+    conn = Connection()
+    conn.guid = test_guid
+    conn.qualified_name = test_qn
+    test_asset = conn
+
+    mock_guid_to_asset = Mock()
+    mock_name_to_guid = Mock()
+    mock_qualified_name_to_guid = Mock()
+
+    # 1 - Not found in the cache, triggers a lookup call
+    # 2, 3, 4 - Uses the cached entry from the map
+    mock_name_to_guid.get.side_effect = [
+        None,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
+
+    # Other caches will be populated once
+    # the lookup call for get_by_qualified_name is made
+    mock_guid_to_asset.get.side_effect = [
+        test_asset,
+        test_asset,
+        test_asset,
+        test_asset,
+    ]
+    mock_qualified_name_to_guid.get.side_effect = [
+        test_guid,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
+
+    mock_connection_cache.guid_to_asset = mock_guid_to_asset
+    mock_connection_cache.name_to_guid = mock_name_to_guid
+    mock_connection_cache.qualified_name_to_guid = mock_qualified_name_to_guid
+
+    connection = mock_connection_cache.get_by_name(test_name)
+
+    # Multiple calls with the same
+    # qualified name result in no additional API lookups
+    # as the object is already cached
+    connection = mock_connection_cache.get_by_name(test_name)
+    connection = mock_connection_cache.get_by_name(test_name)
+
+    assert test_guid == connection.guid
+    assert test_qn == connection.qualified_name
+
+    # The method is called four times
+    # but the lookup is triggered only once
+    assert mock_name_to_guid.get.call_count == 4
+    mock_lookup_by_name.assert_called_once()
+
+    # No call to guid lookup since the object is already in the cache
+    assert mock_lookup_by_guid.call_count == 0

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,14 +1,42 @@
 from __future__ import annotations
 
 from typing import no_type_check
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
 import pytest
 from pydantic.v1 import Field
 
+from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.core import AtlanObject, AtlanTag, AtlanTagName
 
 DISPLAY_TEXT = "Something"
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+
+
+@pytest.fixture()
+def client():
+    return AtlanClient()
+
+
+@pytest.fixture()
+def current_client(client, monkeypatch):
+    monkeypatch.setattr(
+        AtlanClient,
+        "get_current_client",
+        lambda: client,
+    )
+
+
+@pytest.fixture()
+def mock_tag_cache(current_client, monkeypatch):
+    mock_cache = MagicMock(current_client)
+    monkeypatch.setattr(AtlanClient, "atlan_tag_cache", mock_cache)
+    return mock_cache
 
 
 class TestAtlanTagName:

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Atlan Pte. Ltd.
 from json import load, loads
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -44,6 +45,22 @@ def set_env(monkeypatch):
 @pytest.fixture()
 def client():
     return AtlanClient()
+
+
+@pytest.fixture()
+def current_client(client, monkeypatch):
+    monkeypatch.setattr(
+        AtlanClient,
+        "get_current_client",
+        lambda: client,
+    )
+
+
+@pytest.fixture()
+def mock_tag_cache(current_client, monkeypatch):
+    mock_cache = MagicMock(current_client)
+    monkeypatch.setattr(AtlanClient, "atlan_tag_cache", mock_cache)
+    return mock_cache
 
 
 @pytest.fixture()

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -1,9 +1,10 @@
 from json import load, loads
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pyatlan.client.atlan import AtlanClient
 from pyatlan.errors import InvalidRequestError
 from pyatlan.model.assets.core import Asset
 from pyatlan.model.enums import AssetDeltaHandling, AssetInputHandling, AssetRemovalType
@@ -128,6 +129,47 @@ def mock_connection_guid():
     with patch("pyatlan.utils.random") as mock_random:
         mock_random.random.return_value = 123456789
         yield mock_random
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+
+@pytest.fixture()
+def client():
+    return AtlanClient()
+
+
+@pytest.fixture()
+def current_client(client, monkeypatch):
+    monkeypatch.setattr(
+        AtlanClient,
+        "get_current_client",
+        lambda: client,
+    )
+
+
+@pytest.fixture()
+def mock_group_cache(current_client, monkeypatch):
+    mock_cache = MagicMock()
+    monkeypatch.setattr(AtlanClient, "group_cache", mock_cache)
+    return mock_cache
+
+
+@pytest.fixture()
+def mock_user_cache(current_client, monkeypatch):
+    mock_cache = MagicMock()
+    monkeypatch.setattr(AtlanClient, "user_cache", mock_cache)
+    return mock_cache
+
+
+@pytest.fixture()
+def mock_role_cache(current_client, monkeypatch):
+    mock_cache = MagicMock()
+    monkeypatch.setattr(AtlanClient, "role_cache", mock_cache)
+    return mock_cache
 
 
 @pytest.fixture()

--- a/tests/unit/test_source_cache.py
+++ b/tests/unit/test_source_cache.py
@@ -1,259 +1,244 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Atlan Pte. Ltd.
-from unittest.mock import Mock, patch
+# # SPDX-License-Identifier: Apache-2.0
+# # Copyright 2024 Atlan Pte. Ltd.
+# from unittest.mock import Mock, patch
 
-import pytest
+# import pytest
 
-from pyatlan.cache.source_tag_cache import SourceTagCache, SourceTagName
-from pyatlan.client.atlan import AtlanClient
-from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
-from pyatlan.model.assets import Connection
-
-
-@pytest.fixture(autouse=True)
-def set_env(monkeypatch):
-    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
-    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+# from pyatlan.cache.source_tag_cache import SourceTagCache, SourceTagName
+# from pyatlan.client.atlan import AtlanClient
+# from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
+# from pyatlan.model.assets import Connection
 
 
-def test_get_by_guid_with_not_found_error(monkeypatch):
-    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-        SourceTagCache.get_by_guid("")
+# @pytest.fixture(autouse=True)
+# def set_env(monkeypatch):
+#     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+#     monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
 
 
-@patch.object(SourceTagCache, "lookup_by_guid")
-@patch.object(
-    SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-)
-def test_get_by_guid_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_guid):
-    test_guid = "test-guid-123"
-    with pytest.raises(
-        NotFoundError,
-        match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
-    ):
-        SourceTagCache.get_by_guid(test_guid)
-    mock_get_cache.assert_called_once()
+# def test_get_by_guid_with_not_found_error(monkeypatch):
+#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+#         SourceTagCache.get_by_guid("")
 
 
-def test_get_by_qualified_name_with_not_found_error(monkeypatch):
-    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-        SourceTagCache.get_by_qualified_name("")
+# @patch.object(SourceTagCache, "lookup_by_guid")
+# def test_get_by_guid_with_no_invalid_request_error( mock_lookup_by_guid):
+#     test_guid = "test-guid-123"
+#     with pytest.raises(
+#         NotFoundError,
+#         match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
+#     ):
+#         SourceTagCache(client=AtlanClient()).get_by_guid(test_guid)
 
 
-@patch.object(SourceTagCache, "lookup_by_qualified_name")
-@patch.object(
-    SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-)
-def test_get_by_qualified_name_with_no_invalid_request_error(
-    mock_get_cache, mock_lookup_by_qualified_name
-):
-    test_qn = "default/snowflake/123456789"
-    test_connector = "snowflake"
-    with pytest.raises(
-        NotFoundError,
-        match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
-            test_qn, test_connector
-        ),
-    ):
-        SourceTagCache.get_by_qualified_name(test_qn)
-    mock_get_cache.assert_called_once()
+# def test_get_by_qualified_name_with_not_found_error(monkeypatch):
+#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+#         SourceTagCache.get_by_qualified_name("")
 
 
-def test_get_by_name_with_not_found_error(monkeypatch):
-    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
-        SourceTagCache.get_by_name("")
+# @patch.object(SourceTagCache, "lookup_by_qualified_name")
+# def test_get_by_qualified_name_with_no_invalid_request_error(
+# mock_lookup_by_qualified_name
+# ):
+#     test_qn = "default/snowflake/123456789"
+#     test_connector = "snowflake"
+#     with pytest.raises(
+#         NotFoundError,
+#         match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
+#             test_qn, test_connector
+#         ),
+#     ):
+#         SourceTagCache(client=AtlanClient()).get_by_qualified_name(test_qn)
 
 
-@patch.object(SourceTagCache, "lookup_by_name")
-@patch.object(
-    SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-)
-def test_get_by_name_with_no_invalid_request_error(mock_get_cache, mock_lookup_by_name):
-    test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
-    with pytest.raises(
-        NotFoundError,
-        match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
-            SourceTagName._TYPE_NAME,
-            test_name,
-        ),
-    ):
-        SourceTagCache.get_by_name(test_name)
-    mock_get_cache.assert_called_once()
+# def test_get_by_name_with_not_found_error(monkeypatch):
+#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
+#         SourceTagCache.get_by_name("")
 
 
-@patch.object(SourceTagCache, "lookup_by_guid")
-@patch.object(
-    SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-)
-def test_get_by_guid(mock_get_cache, mock_lookup_by_guid):
-    test_guid = "test-guid-123"
-    test_qn = "test-qualified-name"
-    conn = Connection()
-    conn.guid = test_guid
-    conn.qualified_name = test_qn
-    test_asset = conn
-
-    mock_guid_to_asset = Mock()
-    mock_name_to_guid = Mock()
-    mock_qualified_name_to_guid = Mock()
-
-    # 1 - Not found in the cache, triggers a lookup call
-    # 2, 3, 4 - Uses the cached entry from the map
-    mock_guid_to_asset.get.side_effect = [
-        None,
-        test_asset,
-        test_asset,
-        test_asset,
-    ]
-    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
-    mock_qualified_name_to_guid.get.side_effect = [
-        test_guid,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
-
-    # Assign mock caches to the return value of get_cache
-    mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-    mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-    mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
-
-    connection = SourceTagCache.get_by_guid(test_guid)
-
-    # Multiple calls with the same GUID result in no additional API lookups
-    # as the object is already cached
-    connection = SourceTagCache.get_by_guid(test_guid)
-    connection = SourceTagCache.get_by_guid(test_guid)
-
-    assert test_guid == connection.guid
-    assert test_qn == connection.qualified_name
-
-    # The method is called three times, but the lookup is triggered only once
-    assert mock_get_cache.call_count == 3
-    mock_lookup_by_guid.assert_called_once()
+# @patch.object(SourceTagCache, "lookup_by_name")
+# def test_get_by_name_with_no_invalid_request_error(mock_lookup_by_name):
+#     test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
+#     with pytest.raises(
+#         NotFoundError,
+#         match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
+#             SourceTagName._TYPE_NAME,
+#             test_name,
+#         ),
+#     ):
+#         SourceTagCache.get_by_name(test_name)
 
 
-@patch.object(SourceTagCache, "lookup_by_guid")
-@patch.object(SourceTagCache, "lookup_by_qualified_name")
-@patch.object(
-    SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-)
-def test_get_by_qualified_name(mock_get_cache, mock_lookup_by_qn, mock_lookup_by_guid):
-    test_guid = "test-guid-123"
-    test_qn = "test-qualified-name"
-    conn = Connection()
-    conn.guid = test_guid
-    conn.qualified_name = test_qn
-    test_asset = conn
+# @patch.object(SourceTagCache, "lookup_by_guid")
+# def test_get_by_guid(mock_lookup_by_guid):
+#     test_guid = "test-guid-123"
+#     test_qn = "test-qualified-name"
+#     conn = Connection()
+#     conn.guid = test_guid
+#     conn.qualified_name = test_qn
+#     test_asset = conn
 
-    mock_guid_to_asset = Mock()
-    mock_name_to_guid = Mock()
-    mock_qualified_name_to_guid = Mock()
+#     mock_guid_to_asset = Mock()
+#     mock_name_to_guid = Mock()
+#     mock_qualified_name_to_guid = Mock()
 
-    # 1 - Not found in the cache, triggers a lookup call
-    # 2, 3, 4 - Uses the cached entry from the map
-    mock_qualified_name_to_guid.get.side_effect = [
-        None,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
+#     # 1 - Not found in the cache, triggers a lookup call
+#     # 2, 3, 4 - Uses the cached entry from the map
+#     mock_guid_to_asset.get.side_effect = [
+#         None,
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#     ]
+#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+#     mock_qualified_name_to_guid.get.side_effect = [
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
 
-    # Other caches will be populated once
-    # the lookup call for get_by_qualified_name is made
-    mock_guid_to_asset.get.side_effect = [
-        test_asset,
-        test_asset,
-        test_asset,
-        test_asset,
-    ]
-    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+#     # Assign mock caches to the return value of get_cache
+#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
+#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
+#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
 
-    mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-    mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-    mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+#     connection = SourceTagCache.get_by_guid(test_guid)
 
-    connection = SourceTagCache.get_by_qualified_name(test_qn)
+#     # Multiple calls with the same GUID result in no additional API lookups
+#     # as the object is already cached
+#     connection = SourceTagCache.get_by_guid(test_guid)
+#     connection = SourceTagCache.get_by_guid(test_guid)
 
-    # Multiple calls with the same
-    # qualified name result in no additional API lookups
-    # as the object is already cached
-    connection = SourceTagCache.get_by_qualified_name(test_qn)
-    connection = SourceTagCache.get_by_qualified_name(test_qn)
+#     assert test_guid == connection.guid
+#     assert test_qn == connection.qualified_name
 
-    assert test_guid == connection.guid
-    assert test_qn == connection.qualified_name
-
-    # The method is called three times
-    # but the lookup is triggered only once
-    assert mock_get_cache.call_count == 3
-    mock_lookup_by_qn.assert_called_once()
-
-    # No call to guid lookup since the object is already in the cache
-    assert mock_lookup_by_guid.call_count == 0
+#     # The method is called three times, but the lookup is triggered only once
+#     assert mock_get_cache.call_count == 3
+#     mock_lookup_by_guid.assert_called_once()
 
 
-@patch.object(SourceTagCache, "lookup_by_guid")
-@patch.object(SourceTagCache, "lookup_by_name")
-@patch.object(
-    SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-)
-def test_get_by_name(mock_get_cache, mock_lookup_by_name, mock_lookup_by_guid):
-    test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
-    test_guid = "test-guid-123"
-    test_qn = "test-qualified-name"
-    conn = Connection()
-    conn.guid = test_guid
-    conn.qualified_name = test_qn
-    test_asset = conn
+# @patch.object(SourceTagCache, "lookup_by_guid")
+# @patch.object(SourceTagCache, "lookup_by_qualified_name")
+# @patch.object(
+#     SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
+# )
+# def test_get_by_qualified_name(mock_get_cache, mock_lookup_by_qn, mock_lookup_by_guid):
+#     test_guid = "test-guid-123"
+#     test_qn = "test-qualified-name"
+#     conn = Connection()
+#     conn.guid = test_guid
+#     conn.qualified_name = test_qn
+#     test_asset = conn
 
-    mock_guid_to_asset = Mock()
-    mock_name_to_guid = Mock()
-    mock_qualified_name_to_guid = Mock()
+#     mock_guid_to_asset = Mock()
+#     mock_name_to_guid = Mock()
+#     mock_qualified_name_to_guid = Mock()
 
-    # 1 - Not found in the cache, triggers a lookup call
-    # 2, 3, 4 - Uses the cached entry from the map
-    mock_name_to_guid.get.side_effect = [
-        None,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
+#     # 1 - Not found in the cache, triggers a lookup call
+#     # 2, 3, 4 - Uses the cached entry from the map
+#     mock_qualified_name_to_guid.get.side_effect = [
+#         None,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
 
-    # Other caches will be populated once
-    # the lookup call for get_by_qualified_name is made
-    mock_guid_to_asset.get.side_effect = [
-        test_asset,
-        test_asset,
-        test_asset,
-        test_asset,
-    ]
-    mock_qualified_name_to_guid.get.side_effect = [
-        test_guid,
-        test_guid,
-        test_guid,
-        test_guid,
-    ]
+#     # Other caches will be populated once
+#     # the lookup call for get_by_qualified_name is made
+#     mock_guid_to_asset.get.side_effect = [
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#     ]
+#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
 
-    mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-    mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-    mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
+#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
+#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
 
-    connection = SourceTagCache.get_by_name(test_name)
+#     connection = SourceTagCache.get_by_qualified_name(test_qn)
 
-    # Multiple calls with the same
-    # qualified name result in no additional API lookups
-    # as the object is already cached
-    connection = SourceTagCache.get_by_name(test_name)
-    connection = SourceTagCache.get_by_name(test_name)
+#     # Multiple calls with the same
+#     # qualified name result in no additional API lookups
+#     # as the object is already cached
+#     connection = SourceTagCache.get_by_qualified_name(test_qn)
+#     connection = SourceTagCache.get_by_qualified_name(test_qn)
 
-    assert test_guid == connection.guid
-    assert test_qn == connection.qualified_name
+#     assert test_guid == connection.guid
+#     assert test_qn == connection.qualified_name
 
-    # The method is called three times
-    # but the lookup is triggered only once
-    assert mock_get_cache.call_count == 3
-    mock_lookup_by_name.assert_called_once()
+#     # The method is called three times
+#     # but the lookup is triggered only once
+#     assert mock_get_cache.call_count == 3
+#     mock_lookup_by_qn.assert_called_once()
 
-    # No call to guid lookup since the object is already in the cache
-    assert mock_lookup_by_guid.call_count == 0
+#     # No call to guid lookup since the object is already in the cache
+#     assert mock_lookup_by_guid.call_count == 0
+
+
+# @patch.object(SourceTagCache, "lookup_by_guid")
+# @patch.object(SourceTagCache, "lookup_by_name")
+# @patch.object(
+#     SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
+# )
+# def test_get_by_name(mock_get_cache, mock_lookup_by_name, mock_lookup_by_guid):
+#     test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
+#     test_guid = "test-guid-123"
+#     test_qn = "test-qualified-name"
+#     conn = Connection()
+#     conn.guid = test_guid
+#     conn.qualified_name = test_qn
+#     test_asset = conn
+
+#     mock_guid_to_asset = Mock()
+#     mock_name_to_guid = Mock()
+#     mock_qualified_name_to_guid = Mock()
+
+#     # 1 - Not found in the cache, triggers a lookup call
+#     # 2, 3, 4 - Uses the cached entry from the map
+#     mock_name_to_guid.get.side_effect = [
+#         None,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
+
+#     # Other caches will be populated once
+#     # the lookup call for get_by_qualified_name is made
+#     mock_guid_to_asset.get.side_effect = [
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#         test_asset,
+#     ]
+#     mock_qualified_name_to_guid.get.side_effect = [
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#         test_guid,
+#     ]
+
+#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
+#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
+#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+
+#     connection = SourceTagCache.get_by_name(test_name)
+
+#     # Multiple calls with the same
+#     # qualified name result in no additional API lookups
+#     # as the object is already cached
+#     connection = SourceTagCache.get_by_name(test_name)
+#     connection = SourceTagCache.get_by_name(test_name)
+
+#     assert test_guid == connection.guid
+#     assert test_qn == connection.qualified_name
+
+#     # The method is called three times
+#     # but the lookup is triggered only once
+#     assert mock_get_cache.call_count == 3
+#     mock_lookup_by_name.assert_called_once()
+
+#     # No call to guid lookup since the object is already in the cache
+#     assert mock_lookup_by_guid.call_count == 0

--- a/tests/unit/test_source_cache.py
+++ b/tests/unit/test_source_cache.py
@@ -1,244 +1,267 @@
-# # SPDX-License-Identifier: Apache-2.0
-# # Copyright 2024 Atlan Pte. Ltd.
-# from unittest.mock import Mock, patch
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Atlan Pte. Ltd.
+from unittest.mock import Mock, patch
 
-# import pytest
+import pytest
 
-# from pyatlan.cache.source_tag_cache import SourceTagCache, SourceTagName
-# from pyatlan.client.atlan import AtlanClient
-# from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
-# from pyatlan.model.assets import Connection
-
-
-# @pytest.fixture(autouse=True)
-# def set_env(monkeypatch):
-#     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
-#     monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+from pyatlan.cache.source_tag_cache import SourceTagCache, SourceTagName
+from pyatlan.client.atlan import AtlanClient
+from pyatlan.errors import ErrorCode, InvalidRequestError, NotFoundError
+from pyatlan.model.assets import Connection
 
 
-# def test_get_by_guid_with_not_found_error(monkeypatch):
-#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-#         SourceTagCache.get_by_guid("")
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
 
 
-# @patch.object(SourceTagCache, "lookup_by_guid")
-# def test_get_by_guid_with_no_invalid_request_error( mock_lookup_by_guid):
-#     test_guid = "test-guid-123"
-#     with pytest.raises(
-#         NotFoundError,
-#         match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
-#     ):
-#         SourceTagCache(client=AtlanClient()).get_by_guid(test_guid)
+@pytest.fixture()
+def client():
+    return AtlanClient()
 
 
-# def test_get_by_qualified_name_with_not_found_error(monkeypatch):
-#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
-#         SourceTagCache.get_by_qualified_name("")
+@pytest.fixture()
+def current_client(client, monkeypatch):
+    monkeypatch.setattr(
+        AtlanClient,
+        "get_current_client",
+        lambda: client,
+    )
 
 
-# @patch.object(SourceTagCache, "lookup_by_qualified_name")
-# def test_get_by_qualified_name_with_no_invalid_request_error(
-# mock_lookup_by_qualified_name
-# ):
-#     test_qn = "default/snowflake/123456789"
-#     test_connector = "snowflake"
-#     with pytest.raises(
-#         NotFoundError,
-#         match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
-#             test_qn, test_connector
-#         ),
-#     ):
-#         SourceTagCache(client=AtlanClient()).get_by_qualified_name(test_qn)
+@pytest.fixture()
+def mock_source_tag_cache(current_client, monkeypatch):
+    mock_cache = SourceTagCache(current_client)
+    monkeypatch.setattr(AtlanClient, "source_tag_cache", mock_cache)
+    return mock_cache
 
 
-# def test_get_by_name_with_not_found_error(monkeypatch):
-#     with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
-#         SourceTagCache.get_by_name("")
+def test_get_by_guid_with_not_found_error(mock_source_tag_cache):
+    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+        mock_source_tag_cache.get_by_guid("")
 
 
-# @patch.object(SourceTagCache, "lookup_by_name")
-# def test_get_by_name_with_no_invalid_request_error(mock_lookup_by_name):
-#     test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
-#     with pytest.raises(
-#         NotFoundError,
-#         match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
-#             SourceTagName._TYPE_NAME,
-#             test_name,
-#         ),
-#     ):
-#         SourceTagCache.get_by_name(test_name)
+@patch.object(SourceTagCache, "lookup_by_guid")
+def test_get_by_guid_with_no_invalid_request_error(
+    mock_lookup_by_guid, mock_source_tag_cache
+):
+    test_guid = "test-guid-123"
+    with pytest.raises(
+        NotFoundError,
+        match=ErrorCode.ASSET_NOT_FOUND_BY_GUID.error_message.format(test_guid),
+    ):
+        mock_source_tag_cache.get_by_guid(test_guid)
 
 
-# @patch.object(SourceTagCache, "lookup_by_guid")
-# def test_get_by_guid(mock_lookup_by_guid):
-#     test_guid = "test-guid-123"
-#     test_qn = "test-qualified-name"
-#     conn = Connection()
-#     conn.guid = test_guid
-#     conn.qualified_name = test_qn
-#     test_asset = conn
-
-#     mock_guid_to_asset = Mock()
-#     mock_name_to_guid = Mock()
-#     mock_qualified_name_to_guid = Mock()
-
-#     # 1 - Not found in the cache, triggers a lookup call
-#     # 2, 3, 4 - Uses the cached entry from the map
-#     mock_guid_to_asset.get.side_effect = [
-#         None,
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#     ]
-#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
-#     mock_qualified_name_to_guid.get.side_effect = [
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
-
-#     # Assign mock caches to the return value of get_cache
-#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
-
-#     connection = SourceTagCache.get_by_guid(test_guid)
-
-#     # Multiple calls with the same GUID result in no additional API lookups
-#     # as the object is already cached
-#     connection = SourceTagCache.get_by_guid(test_guid)
-#     connection = SourceTagCache.get_by_guid(test_guid)
-
-#     assert test_guid == connection.guid
-#     assert test_qn == connection.qualified_name
-
-#     # The method is called three times, but the lookup is triggered only once
-#     assert mock_get_cache.call_count == 3
-#     mock_lookup_by_guid.assert_called_once()
+def test_get_by_qualified_name_with_not_found_error(current_client):
+    source_tag_cache = SourceTagCache(current_client)
+    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_ID.error_message):
+        source_tag_cache.get_by_qualified_name("")
 
 
-# @patch.object(SourceTagCache, "lookup_by_guid")
-# @patch.object(SourceTagCache, "lookup_by_qualified_name")
-# @patch.object(
-#     SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-# )
-# def test_get_by_qualified_name(mock_get_cache, mock_lookup_by_qn, mock_lookup_by_guid):
-#     test_guid = "test-guid-123"
-#     test_qn = "test-qualified-name"
-#     conn = Connection()
-#     conn.guid = test_guid
-#     conn.qualified_name = test_qn
-#     test_asset = conn
-
-#     mock_guid_to_asset = Mock()
-#     mock_name_to_guid = Mock()
-#     mock_qualified_name_to_guid = Mock()
-
-#     # 1 - Not found in the cache, triggers a lookup call
-#     # 2, 3, 4 - Uses the cached entry from the map
-#     mock_qualified_name_to_guid.get.side_effect = [
-#         None,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
-
-#     # Other caches will be populated once
-#     # the lookup call for get_by_qualified_name is made
-#     mock_guid_to_asset.get.side_effect = [
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#     ]
-#     mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
-
-#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
-
-#     connection = SourceTagCache.get_by_qualified_name(test_qn)
-
-#     # Multiple calls with the same
-#     # qualified name result in no additional API lookups
-#     # as the object is already cached
-#     connection = SourceTagCache.get_by_qualified_name(test_qn)
-#     connection = SourceTagCache.get_by_qualified_name(test_qn)
-
-#     assert test_guid == connection.guid
-#     assert test_qn == connection.qualified_name
-
-#     # The method is called three times
-#     # but the lookup is triggered only once
-#     assert mock_get_cache.call_count == 3
-#     mock_lookup_by_qn.assert_called_once()
-
-#     # No call to guid lookup since the object is already in the cache
-#     assert mock_lookup_by_guid.call_count == 0
+@patch.object(SourceTagCache, "lookup_by_qualified_name")
+def test_get_by_qualified_name_with_no_invalid_request_error(
+    mock_lookup_by_qualified_name, mock_source_tag_cache
+):
+    test_qn = "default/snowflake/123456789"
+    test_connector = "snowflake"
+    with pytest.raises(
+        NotFoundError,
+        match=ErrorCode.ASSET_NOT_FOUND_BY_QN.error_message.format(
+            test_qn, test_connector
+        ),
+    ):
+        mock_source_tag_cache.get_by_qualified_name(test_qn)
 
 
-# @patch.object(SourceTagCache, "lookup_by_guid")
-# @patch.object(SourceTagCache, "lookup_by_name")
-# @patch.object(
-#     SourceTagCache, "get_cache", return_value=SourceTagCache(client=AtlanClient())
-# )
-# def test_get_by_name(mock_get_cache, mock_lookup_by_name, mock_lookup_by_guid):
-#     test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
-#     test_guid = "test-guid-123"
-#     test_qn = "test-qualified-name"
-#     conn = Connection()
-#     conn.guid = test_guid
-#     conn.qualified_name = test_qn
-#     test_asset = conn
+def test_get_by_name_with_not_found_error(current_client):
+    source_tag_cache = SourceTagCache(current_client)
+    with pytest.raises(InvalidRequestError, match=ErrorCode.MISSING_NAME.error_message):
+        source_tag_cache.get_by_name("")
 
-#     mock_guid_to_asset = Mock()
-#     mock_name_to_guid = Mock()
-#     mock_qualified_name_to_guid = Mock()
 
-#     # 1 - Not found in the cache, triggers a lookup call
-#     # 2, 3, 4 - Uses the cached entry from the map
-#     mock_name_to_guid.get.side_effect = [
-#         None,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
+@patch.object(SourceTagCache, "lookup_by_name")
+def test_get_by_name_with_no_invalid_request_error(
+    mock_lookup_by_name, mock_source_tag_cache
+):
+    test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
+    with pytest.raises(
+        NotFoundError,
+        match=ErrorCode.ASSET_NOT_FOUND_BY_NAME.error_message.format(
+            SourceTagName._TYPE_NAME,
+            test_name,
+        ),
+    ):
+        mock_source_tag_cache.get_by_name(test_name)
 
-#     # Other caches will be populated once
-#     # the lookup call for get_by_qualified_name is made
-#     mock_guid_to_asset.get.side_effect = [
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#         test_asset,
-#     ]
-#     mock_qualified_name_to_guid.get.side_effect = [
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#         test_guid,
-#     ]
 
-#     mock_get_cache.return_value.guid_to_asset = mock_guid_to_asset
-#     mock_get_cache.return_value.name_to_guid = mock_name_to_guid
-#     mock_get_cache.return_value.qualified_name_to_guid = mock_qualified_name_to_guid
+@patch.object(SourceTagCache, "lookup_by_guid")
+def test_get_by_guid(mock_lookup_by_guid, mock_source_tag_cache):
+    test_guid = "test-guid-123"
+    test_qn = "test-qualified-name"
+    conn = Connection()
+    conn.guid = test_guid
+    conn.qualified_name = test_qn
+    test_asset = conn
 
-#     connection = SourceTagCache.get_by_name(test_name)
+    mock_guid_to_asset = Mock()
+    mock_name_to_guid = Mock()
+    mock_qualified_name_to_guid = Mock()
 
-#     # Multiple calls with the same
-#     # qualified name result in no additional API lookups
-#     # as the object is already cached
-#     connection = SourceTagCache.get_by_name(test_name)
-#     connection = SourceTagCache.get_by_name(test_name)
+    # 1 - Not found in the cache, triggers a lookup call
+    # 2, 3, 4 - Uses the cached entry from the map
+    mock_guid_to_asset.get.side_effect = [
+        None,
+        test_asset,
+        test_asset,
+        test_asset,
+    ]
+    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+    mock_qualified_name_to_guid.get.side_effect = [
+        test_guid,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
 
-#     assert test_guid == connection.guid
-#     assert test_qn == connection.qualified_name
+    # Assign mock caches to the return value of get_cache
+    mock_source_tag_cache.guid_to_asset = mock_guid_to_asset
+    mock_source_tag_cache.name_to_guid = mock_name_to_guid
+    mock_source_tag_cache.qualified_name_to_guid = mock_qualified_name_to_guid
 
-#     # The method is called three times
-#     # but the lookup is triggered only once
-#     assert mock_get_cache.call_count == 3
-#     mock_lookup_by_name.assert_called_once()
+    connection = mock_source_tag_cache.get_by_guid(test_guid)
 
-#     # No call to guid lookup since the object is already in the cache
-#     assert mock_lookup_by_guid.call_count == 0
+    # Multiple calls with the same GUID result in no additional API lookups
+    # as the object is already cached
+    connection = mock_source_tag_cache.get_by_guid(test_guid)
+    connection = mock_source_tag_cache.get_by_guid(test_guid)
+
+    assert test_guid == connection.guid
+    assert test_qn == connection.qualified_name
+
+    # The method is called four times, but the lookup is triggered only once
+    assert mock_guid_to_asset.get.call_count == 4
+    mock_lookup_by_guid.assert_called_once()
+
+
+@patch.object(SourceTagCache, "lookup_by_guid")
+@patch.object(SourceTagCache, "lookup_by_qualified_name")
+def test_get_by_qualified_name(
+    mock_lookup_by_qn, mock_lookup_by_guid, mock_source_tag_cache
+):
+    test_guid = "test-guid-123"
+    test_qn = "test-qualified-name"
+    conn = Connection()
+    conn.guid = test_guid
+    conn.qualified_name = test_qn
+    test_asset = conn
+
+    mock_guid_to_asset = Mock()
+    mock_name_to_guid = Mock()
+    mock_qualified_name_to_guid = Mock()
+
+    # 1 - Not found in the cache, triggers a lookup call
+    # 2, 3, 4 - Uses the cached entry from the map
+    mock_qualified_name_to_guid.get.side_effect = [
+        None,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
+
+    # Other caches will be populated once
+    # the lookup call for get_by_qualified_name is made
+    mock_guid_to_asset.get.side_effect = [
+        test_asset,
+        test_asset,
+        test_asset,
+        test_asset,
+    ]
+    mock_name_to_guid.get.side_effect = [test_guid, test_guid, test_guid, test_guid]
+
+    mock_source_tag_cache.guid_to_asset = mock_guid_to_asset
+    mock_source_tag_cache.name_to_guid = mock_name_to_guid
+    mock_source_tag_cache.qualified_name_to_guid = mock_qualified_name_to_guid
+
+    connection = mock_source_tag_cache.get_by_qualified_name(test_qn)
+
+    # Multiple calls with the same
+    # qualified name result in no additional API lookups
+    # as the object is already cached
+    connection = mock_source_tag_cache.get_by_qualified_name(test_qn)
+    connection = mock_source_tag_cache.get_by_qualified_name(test_qn)
+
+    assert test_guid == connection.guid
+    assert test_qn == connection.qualified_name
+
+    # The method is called three times
+    # but the lookup is triggered only once
+    assert mock_qualified_name_to_guid.get.call_count == 4
+    mock_lookup_by_qn.assert_called_once()
+
+    # No call to guid lookup since the object is already in the cache
+    assert mock_lookup_by_guid.get.call_count == 0
+
+
+@patch.object(SourceTagCache, "lookup_by_guid")
+@patch.object(SourceTagCache, "lookup_by_name")
+def test_get_by_name(mock_lookup_by_name, mock_lookup_by_guid, mock_source_tag_cache):
+    test_name = SourceTagName("snowflake/test@@DB/SCHEMA/TEST_TAG")
+    test_guid = "test-guid-123"
+    test_qn = "test-qualified-name"
+    conn = Connection()
+    conn.guid = test_guid
+    conn.qualified_name = test_qn
+    test_asset = conn
+
+    mock_guid_to_asset = Mock()
+    mock_name_to_guid = Mock()
+    mock_qualified_name_to_guid = Mock()
+
+    # 1 - Not found in the cache, triggers a lookup call
+    # 2, 3, 4 - Uses the cached entry from the map
+    mock_name_to_guid.get.side_effect = [
+        None,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
+
+    # Other caches will be populated once
+    # the lookup call for get_by_qualified_name is made
+    mock_guid_to_asset.get.side_effect = [
+        test_asset,
+        test_asset,
+        test_asset,
+        test_asset,
+    ]
+    mock_qualified_name_to_guid.get.side_effect = [
+        test_guid,
+        test_guid,
+        test_guid,
+        test_guid,
+    ]
+
+    mock_source_tag_cache.guid_to_asset = mock_guid_to_asset
+    mock_source_tag_cache.name_to_guid = mock_name_to_guid
+    mock_source_tag_cache.qualified_name_to_guid = mock_qualified_name_to_guid
+
+    connection = mock_source_tag_cache.get_by_name(test_name)
+
+    # Multiple calls with the same
+    # qualified name result in no additional API lookups
+    # as the object is already cached
+    connection = mock_source_tag_cache.get_by_name(test_name)
+    connection = mock_source_tag_cache.get_by_name(test_name)
+
+    assert test_guid == connection.guid
+    assert test_qn == connection.qualified_name
+
+    # The method is called four times
+    # but the lookup is triggered only once
+    assert mock_name_to_guid.get.call_count == 4
+    mock_lookup_by_name.assert_called_once()
+
+    # No call to guid lookup since the object is already in the cache
+    assert mock_lookup_by_guid.call_count == 0


### PR DESCRIPTION
This PR fixes `pyatlan` caching issues in concurrent environments:
https://atlanhq.atlassian.net/browse/APP-5519?focusedCommentId=367914

References for why we opted for `TLS` to solve this:
https://docs.python.org/3/library/threading.html
https://superfastpython.com/thread-local-data
https://stackoverflow.com/a/105025
https://stackoverflow.com/questions/1408171/thread-local-storage-in-python