### PR TITLE
APP-6218: Improve 401 token refresh handling

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -15,7 +15,7 @@ from pyatlan.client.search_log import (
     SearchLogResults,
     SearchLogViewResults,
 )
-from pyatlan.errors import AuthenticationError, NotFoundError
+from pyatlan.errors import AuthenticationError, InvalidRequestError, NotFoundError
 from pyatlan.model.api_tokens import ApiToken
 from pyatlan.model.assets import (
     Asset,
@@ -1506,8 +1506,8 @@ def test_client_401_token_refresh(
     # Test that providing an invalid user ID results in the same authentication error
     client._user_id = "invalid-user-id"
     with pytest.raises(
-        AuthenticationError,
-        match="Server responded with an authentication error 401",
+        InvalidRequestError,
+        match="Missing privileged credentials to impersonate users",
     ):
         FluentSearch().where(CompoundQuery.active_assets()).where(
             CompoundQuery.asset_type(AtlasGlossary)


### PR DESCRIPTION
- Add delay after token refresh to avoid empty typedef responses.
- Reset `has_retried` if last retry wasn't a `401` to allow future retries.