### PR TITLE
APP-5915 : Add "Workflow Name" as an optional param in credentials.get_all()

### DIFF
--- a/pyatlan/client/credential.py
+++ b/pyatlan/client/credential.py
@@ -83,6 +83,7 @@ class CredentialClient:
         filter: Optional[Dict[str, Any]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        workflow_name: Optional[str] = None,
     ) -> CredentialListResponse:
         """
         Retrieves all credentials.
@@ -90,6 +91,7 @@ class CredentialClient:
         :param filter: (optional) dictionary specifying the filter criteria.
         :param limit: (optional) maximum number of credentials to retrieve.
         :param offset: (optional) number of credentials to skip before starting retrieval.
+        :param workflow_name: (optional) name of the workflow to retrieve credentials for.
         :returns: CredentialListResponse instance.
         :raises: AtlanError on any error during API invocation.
         """
@@ -100,6 +102,17 @@ class CredentialClient:
             params["limit"] = limit
         if offset is not None:
             params["offset"] = offset
+
+        if workflow_name is not None:
+            if filter is None:
+                filter = {}
+
+            if workflow_name.startswith("atlan-"):
+                workflow_name = "default-" + workflow_name[len("atlan-") :]
+
+            filter["name"] = f"{workflow_name}-0"
+
+            params["filter"] = dumps(filter)
 
         raw_json = self._client._call_api(
             GET_ALL_CREDENTIALS.format_path_with_params(), query_params=params


### PR DESCRIPTION
For all workflows provided by **Atlan**, the naming convention follows this pattern:

- **Workflow Name:**  
  Example:  
  ```
  atlan-bigquery-1735837155
  ```

- **Credential Name Pattern:**  
  ```
  default-<connector-name>-<timestamp>-0
  ```  
  So for the example above, the credential name would be:  
  ```
  default-bigquery-1735837155-0
  ```

---

For **CSA packages** using credentials, the format is slightly different:

- **Credential Name Pattern:**  
  ```
  <workflow-name>-0
  ```
  
  Did local testing as well  ✅  : 

Testing with Atlan connecter:  
![image](https://github.com/user-attachments/assets/478a6fa9-1384-4e99-89e9-62b840f55705)
![image](https://github.com/user-attachments/assets/40f1efe8-fef7-41c9-81f6-611eca0b0a4b)

Cross check the creds here: https://field-sandbox.atlan.com/workflows/profile/atlan-bigquery-1735837155/config

Testing with csa connector:
![image](https://github.com/user-attachments/assets/07c7f030-83ab-42a2-908d-8be2d2524fea)
![image](https://github.com/user-attachments/assets/327e6387-eedf-4ba3-857a-7bc4eb513401)

Cross check the creds here : https://field-sandbox.atlan.com/workflows/profile/csa-s3-1734926030/config
 