### PR TITLE
fix the indentation issue in documentDB jinja template

### DIFF
--- a/pyatlan/generator/templates/methods/asset/document_d_b_collection.jinja2
+++ b/pyatlan/generator/templates/methods/asset/document_d_b_collection.jinja2
@@ -1,3 +1,4 @@
+
     @classmethod
     @init_guid
     def creator(cls, *,

--- a/pyatlan/generator/templates/methods/asset/document_d_b_database.jinja2
+++ b/pyatlan/generator/templates/methods/asset/document_d_b_database.jinja2
@@ -1,3 +1,4 @@
+
     @classmethod
     @init_guid
     def creator(cls, *, name: str, connection_qualified_name: str) -> DocumentDBDatabase:

--- a/pyatlan/generator/templates/methods/attribute/document_d_b_collection.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/document_d_b_collection.jinja2
@@ -1,3 +1,4 @@
+
         @classmethod
         @init_guid
         def creator(cls,

--- a/pyatlan/generator/templates/methods/attribute/document_d_b_database.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/document_d_b_database.jinja2
@@ -1,3 +1,4 @@
+
         @classmethod
         @init_guid
         def creator(cls, *, name: str, connection_qualified_name: str) -> DocumentDBDatabase.Attributes:


### PR DESCRIPTION
Fixed the new line issue in template because of which the generator python script was giving indentation error