### PR TITLE
APP-5774 : Extend tagged with value search with option for specific source tag 

### DIFF
--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -163,9 +163,9 @@ class CompoundQuery:
         :param atlan_tag_name: human-readable name of the Atlan tag
         :param value: tag should have to match the query
         :param directly: when `True`, the asset must have the tag and
-        :param source_tag_qualified_name: qualifiedName of the source tag to match (when there are multiple)
         value directly assigned (otherwise even propagated tags with the value will suffice)
-
+        :param source_tag_qualified_name: (optional) qualified name of
+        the source tag to match (when there are multiple)
         :raises: AtlanError on any error communicating
         with the API to refresh the Atlan tag cache
         :returns: a query that will only match assets that have
@@ -189,10 +189,8 @@ class CompoundQuery:
         if len(synced_tags) > 1 and source_tag_qualified_name is None:
             synced_tag_qn = synced_tags[0].qualified_name or ""
             LOGGER.warning(
-                (
-                    "Multiple mapped source-synced tags found for tag %s -- using only the first: %s",
-                    "You can specify the source tag qualified name so we can match to the specific one",
-                ),
+                "Multiple mapped source-synced tags found for tag %s -- using only the first: %s. "
+                "You can specify the `source_tag_qualified_name` so we can match to the specific one.",
                 atlan_tag_name,
                 synced_tag_qn,
             )

--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -151,7 +151,10 @@ class CompoundQuery:
 
     @staticmethod
     def tagged_with_value(
-        atlan_tag_name: str, value: str, directly: bool = False
+        atlan_tag_name: str,
+        value: str,
+        directly: bool = False,
+        source_tag_qualified_name: Optional[str] = None,
     ) -> Query:
         """
         Returns a query that will match assets that have a
@@ -160,6 +163,7 @@ class CompoundQuery:
         :param atlan_tag_name: human-readable name of the Atlan tag
         :param value: tag should have to match the query
         :param directly: when `True`, the asset must have the tag and
+        :param source_tag_qualified_name: qualifiedName of the source tag to match (when there are multiple)
         value directly assigned (otherwise even propagated tags with the value will suffice)
 
         :raises: AtlanError on any error communicating
@@ -182,17 +186,20 @@ class CompoundQuery:
                 .execute(client=client)
             )
         ]
-        if len(synced_tags) > 1:
+        if len(synced_tags) > 1 and source_tag_qualified_name is None:
             synced_tag_qn = synced_tags[0].qualified_name or ""
             LOGGER.warning(
                 (
                     "Multiple mapped source-synced tags found for tag %s -- using only the first: %s",
+                    "You can specify the source tag qualified name so we can match to the specific one",
                 ),
                 atlan_tag_name,
                 synced_tag_qn,
             )
         elif synced_tags:
-            synced_tag_qn = synced_tags[0].qualified_name or ""
+            synced_tag_qn = (
+                source_tag_qualified_name or synced_tags[0].qualified_name or ""
+            )
         else:
             synced_tag_qn = "NON_EXISTENT"
 


### PR DESCRIPTION
Tested on `field-sandbox`:

```py
import logging

from pyatlan.client.atlan import AtlanClient
from pyatlan.model.fluent_search import CompoundQuery, FluentSearch

logging.basicConfig(level=logging.WARN)
client = AtlanClient()  #

request = (
    FluentSearch()
    .select()  #
    .where(
        CompoundQuery.tagged_with_value(  #
            "Confidential",  #
            "Highly Restricted",  #
            True,  #
            source_tag_qualified_name="default/snowflake/1711669993/ANALYTICS/PRODUCTION/CONFIDENTIAL"
        )
    )
).to_request()  #

response = client.asset.search(request)
print(response.count)
```