### PR TITLE
APP-6379: Add public method `init_for_thread()` to prepare `AtlanClient` for use in multithreaded envs

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -191,6 +191,17 @@ class AtlanClient(BaseSettings):
         env_prefix = "atlan_"
 
     @classmethod
+    def init_for_thread(cls, client: AtlanClient):
+        """
+        Prepares the given client for use in the current thread.
+
+        Sets the thread-local context and
+        resets internal retry flags for multi-threaded environments.
+        """
+        AtlanClient.set_current_client(client)
+        client._401_tls.has_retried = False
+
+    @classmethod
     def set_current_client(cls, client: AtlanClient):
         """
         Sets the current client to thread-local storage (TLS)
@@ -222,8 +233,7 @@ class AtlanClient(BaseSettings):
         adapter = HTTPAdapter(max_retries=self.retry)
         session.mount(HTTPS_PREFIX, adapter)
         session.mount(HTTP_PREFIX, adapter)
-        AtlanClient.set_current_client(self)
-        self._401_tls.has_retried = False
+        AtlanClient.init_for_thread(self)
 
     @property
     def admin(self) -> AdminClient:


### PR DESCRIPTION
```
ghcr.io/atlanhq/marketplace-csa-scripts-main:latest,ghcr.io/atlanhq/marketplace-csa-scripts-main:a51530e
```

Done with testing - both workflows succeeded using the new `AtlanClient.init_for_thread(client)` method. I’ll release the changes tomorrow! ✅ 

https://fieldtec42.atlan.com/workflows/profile/csa-metadata-completeness-1743083803/runs?name=csa-metadata-completeness-1743083803-62tkd

<img width="1201" alt="Screenshot 2025-04-25 at 12 17 26 AM" src="https://github.com/user-attachments/assets/36c5e1a9-414b-4682-a880-6d6b8de14202" />