### PR TITLE
APP-6565: Added support for dynamic extension of `AtlanConnectorType` for custom connectors

### DIFF
--- a/pyatlan/utils.py
+++ b/pyatlan/utils.py
@@ -10,7 +10,7 @@ import re
 import time
 from contextvars import ContextVar
 from datetime import datetime
-from enum import Enum
+from enum import Enum, EnumMeta
 from functools import reduce, wraps
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -471,3 +471,21 @@ def validate_single_required_field(field_names: List[str], values: List[Any]):
         raise ValueError(
             f"Only one of the following parameters are allowed: {', '.join(names)}"
         )
+
+
+class ExtendableEnumMeta(EnumMeta):
+    def __init__(cls, name, bases, namespace):
+        super().__init__(name, bases, namespace)
+        cls._additional_members = {}
+
+    def add_value(cls, name, value, category=None):
+        member = str.__new__(cls, value)
+        member._name_ = name
+        member._value_ = value
+        member.category = category
+
+        cls._member_map_[name] = member
+        cls._value2member_map_[value] = member
+        cls._member_names_.append(name)
+        cls._additional_members[name] = member
+        return member

--- a/tests/unit/model/a_d_l_s_object_test.py
+++ b/tests/unit/model/a_d_l_s_object_test.py
@@ -134,7 +134,7 @@ def test_create():
         ),
         (
             ADLS_OBJECT_NAME,
-            "default/adls-invalid/production",
+            "default/adls/invalid/production",
             "abc",
             ADLS_CONTAINER_NAME,
             ADLS_CONTAINER_QUALIFIED_NAME,


### PR DESCRIPTION
# ✨ Description

Added support for dynamic extension of `AtlanConnectorType` for custom connectors
    
- Enabled adding custom connector types at runtime
- Ensured compatibility with string behavior and existing enum usage
- Added helper methods to list names and values

```py
import logging

from pyatlan.client.atlan import AtlanClient
from pyatlan.model.assets import Connection
from pyatlan.model.enums import AtlanConnectionCategory, AtlanConnectorType

client = AtlanClient()
logging.basicConfig(level=logging.DEBUG)

AtlanConnectorType.CREATE_CUSTOM(
    name="FOO", value="bar", category=AtlanConnectionCategory.API
)
admin_role_guid = client.role_cache.get_id_for_name("$admin")

connection = Connection.creator(
    name="test-custom",
    connector_type=AtlanConnectorType.FOO,
    admin_roles=[admin_role_guid],
)

response = client.asset.save(connection)
print(response)

```

**Jira link:** _[APP-6565](https://atlanhq.atlassian.net/browse/APP-6565)_

---

## 🧩 Type of change

Select all that apply:

- [x] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [x] My code follows the project’s style guidelines
- [x] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [x] There are no new warnings from my changes
- [x] I’ve added tests to cover my changes
- [x] All new and existing tests pass locally


[APP-6565]: https://atlanhq.atlassian.net/browse/APP-6565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ