### PR TITLE
APP-6827 Add utility method to facilitate processing assets while iterating thru results of a fluent search.

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -1876,13 +1876,13 @@ class AssetClient:
 
         This function iteratively searches for assets using the search provider and processes each
         unique asset using the provided callable function. The uniqueness of assets is determined
-        based on their GUIDs. If new assets are found in subsequent iterations that haven't been
+        based on their GUIDs. If new assets are found in later iterations that haven't been
         processed yet, the process continues until no more new assets are available to process.
 
         Arguments:
             search: IndexSearchRequestProvider
                 The search provider that generates search queries and contains the criteria for
-                searching the assets.
+                searching the assets such as a FluentSearch.
             func: Callable[[Asset], None]
                 A callable function that receives each unique asset as its parameter and performs
                 the required operations on it.


### PR DESCRIPTION
# ✨ Description

Since modification of an asset while iterating thru the results of a fluent search make cause the paging to changing and thus assets could be missed provide a method that will ensure that all the assets returned by the search are processed once.

**Jira link:** _[APP-6827](https://atlanhq.atlassian.net/browse/APP-6827)_

---

## 🧩 Type of change

Select all that apply:

- [X] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Integration test added.

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [X] All new and existing tests pass locally


[APP-6827]: https://atlanhq.atlassian.net/browse/APP-6827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ