### PR TITLE
APP-7103 : Add Long as a Primitive Type in AtlanCustomAttributePrimitiveType

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -394,6 +394,7 @@ class AtlanCustomAttributePrimitiveType(str, Enum):
     GROUPS = "groups"
     URL = "url"
     SQL = "SQL"
+    LONG = "long"
 
 
 class AtlanDeleteType(str, Enum):


### PR DESCRIPTION
# ✨ Description

Adding a missing Primitive Type in AtlanCustomAttributePrimitiveType class of Pyatlan
**Jira link:** _https://atlanhq.atlassian.net/browse/APP-7103_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally
