### PR TITLE
APP-7318: Make FS usage in `get_by_*()` methods consistent with GET API (return active and archive assets)

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -440,7 +440,6 @@ class AssetClient:
         ):
             search = (
                 FluentSearch()
-                .select()
                 .where(Asset.QUALIFIED_NAME.eq(qualified_name))
                 .where(Asset.TYPE_NAME.eq(asset_type.__name__))
             )
@@ -514,7 +513,6 @@ class AssetClient:
         ):
             search = (
                 FluentSearch()
-                .select()
                 .where(Asset.GUID.eq(guid))
                 .where(Asset.TYPE_NAME.eq(asset_type.__name__))
             )

--- a/tests/integration/api_asset_test.py
+++ b/tests/integration/api_asset_test.py
@@ -401,8 +401,10 @@ def test_delete_api_object(
 def test_read_deleted_api_object(
     client: AtlanClient, connection: Connection, api_object_overload: APIObject
 ):
-    deleted = client.asset.get_by_guid(
-        api_object_overload.guid, asset_type=APIObject, ignore_relationships=False
+    # Running get_by_qualified_name with attributes to use FluentSearch behind the scenes
+    assert api_object_overload.qualified_name
+    deleted = client.asset.get_by_qualified_name(
+        api_object_overload.qualified_name, asset_type=APIObject, attributes=["name"]
     )
     assert deleted
     assert deleted.guid == api_object_overload.guid
@@ -639,8 +641,9 @@ def test_delete_api_query(
 def test_read_deleted_api_query(
     client: AtlanClient, connection: Connection, api_query_overload_3: APIQuery
 ):
+    # Running get_by_guid with attributes to use FluentSearch behind the scenes
     deleted = client.asset.get_by_guid(
-        api_query_overload_3.guid, asset_type=APIQuery, ignore_relationships=False
+        api_query_overload_3.guid, asset_type=APIQuery, attributes=["name"]
     )
     assert deleted
     assert deleted.guid == api_query_overload_3.guid


### PR DESCRIPTION
# ✨ Description

https://atlanhq.atlassian.net/browse/APP-7318

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [x] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [x] My code follows the project’s style guidelines
- [x] I’ve performed a self-review of my code
- [x] I’ve added comments in tricky or complex areas
- [x] I’ve updated the documentation as needed
- [x] There are no new warnings from my changes
- [x] I’ve added tests to cover my changes
- [x] All new and existing tests pass locally
