### PR TITLE
APP-7697 : custom metadata object created via Python

### DIFF
--- a/pyatlan/model/typedef.py
+++ b/pyatlan/model/typedef.py
@@ -504,7 +504,7 @@ class AttributeDef(AtlanObject):
 
         def __setattr__(self, name, value):
             super().__setattr__(name, value)
-            if self._attr_def and name == "multi_value_select":
+            if self._attr_def and name == "multi_value_select" and value is True:
                 self._attr_def.cardinality = Cardinality.SET
                 if self._attr_def.type_name and "array<" not in str(
                     self._attr_def.type_name


### PR DESCRIPTION
# ✨ Description

The intended flow involves first creating an enum using PyAtlan, followed by defining a custom metadata type and linking the created enum to one of its AttributeDef fields during the metadata creation process.

However, during this setup, the customer was explicitly setting:

`attr_def.options.multi_value_select = False
`

Even though this was meant to enforce a single-select behavior, setting this property manually led to unintended consequences. The SDK logic did not validate the value of the attribute before applying it, which resulted in:

type_name = "array[]" with cardinality = SET

This configuration contradicts how single-select enums are expected to behave.

As a result, when the customer attempted to assign this custom metadata to an asset, the following error was triggered:

`ATLAS-404-00-007 – "invalid value for type array[Data Classification Options]"
`

**Jira link:** _https://atlanhq.atlassian.net/browse/APP-7697_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

This is the approach we've recommended in the developer documentation for this use case:

```
from pyatlan.client.atlan import AtlanClient
from pyatlan.model.enums import AtlanCustomAttributePrimitiveType
from pyatlan.model.typedef import AttributeDef, CustomMetadataDef, EnumDef

client = AtlanClient()
print(client.base_url)
enum_def = EnumDef.create(
    name="Test Options", #
    values=["Test1", "Test2", "Test3", "Public"] #
)


response = client.typedef.create(enum_def) #
print(response)


cm_def = CustomMetadataDef.create(display_name="Data Class")  #
attr_def = AttributeDef.create(
    client=client,  #
    display_name="Data",  #
    attribute_type=AtlanCustomAttributePrimitiveType.OPTIONS,  #
    options_name="Test Options",  #
    multi_valued=False,  #
)

cm_def.attribute_defs = [attr_def]

response = client.typedef.create(cm_def) 

```
This works as expected—it's aligned with the UI behavior, minimal in complexity, and satisfies the intended use case.

However, in this case, the customer was additionally setting the following properties manually before creating the custom metadata:

`attr_def.options.multi_value_select = False
`

This resulting in raising an edge case where if multi_value_select attribute is set regardless of its value then automatically below is set which is against the expected behaviour of single-select enum:
type_name = "array[]" with cardinality = SET

---

## 📋 Checklist

- [x] My code follows the project’s style guidelines
- [x] I’ve performed a self-review of my code
- [x] I’ve added comments in tricky or complex areas
- [x] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [x] I’ve added tests to cover my changes
- [x] All new and existing tests pass locally
