### PR TITLE
APP-8059 : Add DQ rules schedule support

### DIFF
--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -84,6 +84,7 @@ from pyatlan.model.enums import (
     EntityStatus,
     SaveSemantic,
     SortOrder,
+    alpha_DQScheduleType,
 )
 from pyatlan.model.fields.atlan_fields import AtlanField
 from pyatlan.model.lineage import LineageDirection, LineageListRequest
@@ -2028,6 +2029,21 @@ class AssetClient:
                     has_assets_to_process = True
                     func(asset)
         return len(guids_processed)
+
+    def add_dq_rules_schedule(
+        self, guid: str, schedule_cron_string: str, schedule_time_zone: str
+    ) -> AssetMutationResponse:
+        asset_retrieved = self.get_by_guid(guid=guid)  # type: ignore
+        asset_type = Asset._convert_to_real_type_(asset_retrieved)
+        updated_asset = asset_type.updater(
+            qualified_name=asset_retrieved.qualified_name, name=asset_retrieved.name
+        )
+        updated_asset.guid = guid
+        updated_asset.alpha_asset_d_q_schedule_time_zone = schedule_time_zone
+        updated_asset.alpha_asset_d_q_schedule_crontab = schedule_cron_string
+        updated_asset.alpha_asset_d_q_schedule_type = alpha_DQScheduleType.CRON
+        response = self.save(updated_asset)
+        return response
 
 
 class SearchResults(ABC, Iterable):

--- a/pyatlan/model/utils.py
+++ b/pyatlan/model/utils.py
@@ -25,7 +25,7 @@ def encoders():
     }
 
 
-def convert_with_fixed_prefix(input_str, fixed_prefix="alpha_dq"):
+def convert_with_fixed_prefix(input_str, fixed_prefix):
     prefix = fixed_prefix
     remaining = input_str[len(prefix) + 1 :]
     parts = remaining.split("_")
@@ -39,7 +39,9 @@ def to_camel_case(value: str) -> str:
     if value == "__root__":
         return value
     if value.startswith("alpha_dq"):
-        return convert_with_fixed_prefix(value)
+        return convert_with_fixed_prefix(input_str=value, fixed_prefix="alpha_dq")
+    if value.startswith("alpha_asset"):
+        return convert_with_fixed_prefix(input_str=value, fixed_prefix="alpha_asset")
     if value in CAMEL_CASE_OVERRIDES:
         return CAMEL_CASE_OVERRIDES[value]
     value = "".join(word.capitalize() for word in value.split("_"))


### PR DESCRIPTION
# ✨ Description

- Added support for DQ rules scheduling

This is how the payload that frontend sends looks like:
```
{
    "entities": [
        {
            "guid": "94df4da8-9e44-47dc-be95-b7d387e7e0fe",
            "typeName": "Table",
            "attributes": {
                "name": "customer",
                "qualifiedName": "default/databricks/1750768309/dq_poc/tpch/customer",
                "alpha_assetDQScheduleType": "CRON",
                "alpha_assetDQScheduleCrontab": "30 22 * * 0,2-5",
                "alpha_assetDQScheduleTimeZone": "US/Samoa"
            }
        }
    ]
}
```

**Jira link:** _https://atlanhq.atlassian.net/browse/APP-8059_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally
