### PR TITLE
APP-8799 : Force-lowercase all connector names

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -192,7 +192,7 @@ class AtlanConnectorType(str, Enum, metaclass=utils.ExtendableEnumMeta):
     def CREATE_CUSTOM(
         cls, name: str, value: str, category=AtlanConnectionCategory.CUSTOM
     ) -> "AtlanConnectorType":
-        # Force-lowercase the value to avoid frotend case-related issues
+        # Force-lowercase the value to avoid frontend case-related issues
         return cls.add_value(name, value.lower(), category)
 
     def to_qualified_name(self):

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -192,7 +192,7 @@ class AtlanConnectorType(str, Enum, metaclass=utils.ExtendableEnumMeta):
     def CREATE_CUSTOM(
         cls, name: str, value: str, category=AtlanConnectionCategory.CUSTOM
     ) -> "AtlanConnectorType":
-        # Force-lowercase the value to avoid case-related issues
+        # Force-lowercase the value to avoid frotend case-related issues
         return cls.add_value(name, value.lower(), category)
 
     def to_qualified_name(self):

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -192,7 +192,8 @@ class AtlanConnectorType(str, Enum, metaclass=utils.ExtendableEnumMeta):
     def CREATE_CUSTOM(
         cls, name: str, value: str, category=AtlanConnectionCategory.CUSTOM
     ) -> "AtlanConnectorType":
-        return cls.add_value(name, value, category)
+        # Force-lowercase the value to avoid case-related issues
+        return cls.add_value(name, value.lower(), category)
 
     def to_qualified_name(self):
         return f"default/{self.value}/{int(utils.get_epoch_timestamp())}"

--- a/tests/integration/connection_test.py
+++ b/tests/integration/connection_test.py
@@ -46,10 +46,12 @@ def custom_connection(client: AtlanClient) -> Generator[Connection, None, None]:
 
 def test_custom_connection(custom_connection: Connection):
     assert custom_connection.name == MODULE_NAME
-    assert custom_connection.connector_name == f"{MODULE_NAME}_type"
+    assert custom_connection.connector_name == f"{MODULE_NAME.lower()}_type"
     assert custom_connection.qualified_name
-    assert f"default/{MODULE_NAME}_type" in custom_connection.qualified_name
-    assert AtlanConnectorType[f"{MODULE_NAME}_NAME"].value == f"{MODULE_NAME}_type"
+    assert f"default/{MODULE_NAME.lower()}_type" in custom_connection.qualified_name
+    assert (
+        AtlanConnectorType[f"{MODULE_NAME}_NAME"].value == f"{MODULE_NAME.lower()}_type"
+    )
 
 
 def test_invalid_connection(client: AtlanClient):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -325,27 +325,26 @@ def test_atlan_connector_type_create_custom(custom_connectors):
 
 def test_atlan_connector_type_create_custom_force_lowercase():
     """Test that CREATE_CUSTOM method force-lowercases the value parameter to avoid case-related issues."""
-    # Test CREATE_CUSTOM with mixed case - value should be lowercased
+
     custom_connector = AtlanConnectorType.CREATE_CUSTOM(
         name="MIXED_CASE", value="MiXeD_CaSe", category=AtlanConnectionCategory.CUSTOM
     )
     assert custom_connector.value == "mixed_case"
-    
-    # Test CREATE_CUSTOM with uppercase - value should be lowercased
+
     custom_connector_upper = AtlanConnectorType.CREATE_CUSTOM(
         name="UPPER_CASE", value="UPPERCASE", category=AtlanConnectionCategory.CUSTOM
     )
     assert custom_connector_upper.value == "uppercase"
-    
-    # Test CREATE_CUSTOM with already lowercase - should remain unchanged
+
     custom_connector_lower = AtlanConnectorType.CREATE_CUSTOM(
         name="LOWER_CASE", value="lowercase", category=AtlanConnectionCategory.CUSTOM
     )
     assert custom_connector_lower.value == "lowercase"
-    
-    # Test CREATE_CUSTOM with special characters - should be lowercased
+
     custom_connector_special = AtlanConnectorType.CREATE_CUSTOM(
-        name="SPECIAL_CHARS", value="My-Connector_Type", category=AtlanConnectionCategory.CUSTOM
+        name="SPECIAL_CHARS",
+        value="My-Connector_Type",
+        category=AtlanConnectionCategory.CUSTOM,
     )
     assert custom_connector_special.value == "my-connector_type"
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -323,6 +323,33 @@ def test_atlan_connector_type_create_custom(custom_connectors):
         ) in AtlanConnectorType.get_items()
 
 
+def test_atlan_connector_type_create_custom_force_lowercase():
+    """Test that CREATE_CUSTOM method force-lowercases the value parameter to avoid case-related issues."""
+    # Test CREATE_CUSTOM with mixed case - value should be lowercased
+    custom_connector = AtlanConnectorType.CREATE_CUSTOM(
+        name="MIXED_CASE", value="MiXeD_CaSe", category=AtlanConnectionCategory.CUSTOM
+    )
+    assert custom_connector.value == "mixed_case"
+    
+    # Test CREATE_CUSTOM with uppercase - value should be lowercased
+    custom_connector_upper = AtlanConnectorType.CREATE_CUSTOM(
+        name="UPPER_CASE", value="UPPERCASE", category=AtlanConnectionCategory.CUSTOM
+    )
+    assert custom_connector_upper.value == "uppercase"
+    
+    # Test CREATE_CUSTOM with already lowercase - should remain unchanged
+    custom_connector_lower = AtlanConnectorType.CREATE_CUSTOM(
+        name="LOWER_CASE", value="lowercase", category=AtlanConnectionCategory.CUSTOM
+    )
+    assert custom_connector_lower.value == "lowercase"
+    
+    # Test CREATE_CUSTOM with special characters - should be lowercased
+    custom_connector_special = AtlanConnectorType.CREATE_CUSTOM(
+        name="SPECIAL_CHARS", value="My-Connector_Type", category=AtlanConnectionCategory.CUSTOM
+    )
+    assert custom_connector_special.value == "my-connector_type"
+
+
 @pytest.mark.parametrize(
     "custom_asset_qns",
     [


### PR DESCRIPTION
# ✨ Description

- Force lowering case the value when creating custom connector names
- Added unit tests. 
- Tested below code  :

```
from pyatlan.client.atlan import AtlanClient
from pyatlan.model.assets import Connection
from pyatlan.model.enums import AtlanConnectionCategory, AtlanConnectorType
import logging

# logging.basicConfig(level=logging.DEBUG)
a = AtlanConnectorType.CREATE_CUSTOM(
    name="CUSTOM123", value="My_lower_customa", category=AtlanConnectionCategory.CUSTOM
)
print(a)

client = AtlanClient()
admin_role_guid = client.role_cache.get_id_for_name("$admin")

connection = Connection.creator(
    client=client,
    name="test-final",
    connector_type=AtlanConnectorType.CUSTOM123,  #
    admin_roles=[admin_role_guid],
)
response = client.asset.save(connection)
connection = Connection.creator(
    client=client,
    name="test-final2",
    connector_type=AtlanConnectorType.CUSTOM123,  #
    admin_roles=[admin_role_guid],
)
response = client.asset.save(connection)

```
**Jira link:** _https://atlanhq.atlassian.net/browse/APP-8799_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally
