### PR TITLE
APP-9140 | Testing chainguard docker image

### DIFF
--- a/.github/workflows/pyatlan-chainguard.yaml
+++ b/.github/workflows/pyatlan-chainguard.yaml
@@ -1,0 +1,221 @@
+name: Build Pyatlan Chainguard Base Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'Build type (dev uses amd64 only, release uses amd64+arm64)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - 'dev'
+          - 'release'
+      python_version:
+        description: 'Python version (leave empty for 3.13)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+      pyatlan_version:
+        description: 'Pyatlan version (leave empty to use version.txt ie: latest)'
+        required: false
+        type: string
+      pyatlan_branch:
+        description: 'Pyatlan git branch (overrides version - installs from git://github.com/atlanhq/atlan-python.git@branch)'
+        required: false
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for commit hash
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Chainguard Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CHAINGUARD_USERNAME }}
+          password: ${{ secrets.CHAINGUARD_PASSWORD }}
+
+      - name: Set build parameters
+        id: set-params
+        run: |
+          # Check if triggered by release or manual dispatch
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Release trigger: use latest Python and SDK version, release build type
+            BUILD_TYPE="release"
+            PYTHON_VERSION="3.13"
+            PYATLAN_VERSION=$(cat pyatlan/version.txt)
+            PYATLAN_BRANCH=""
+            INSTALL_FROM_GIT="false"
+            echo "Release trigger detected - using latest versions"
+          else
+            # Manual dispatch: use provided inputs with defaults
+            BUILD_TYPE="${{ github.event.inputs.build_type }}"
+            
+            # Set Python version (default to 3.13 if empty)
+            if [ -z "${{ github.event.inputs.python_version }}" ]; then
+              PYTHON_VERSION="3.13"
+            else
+              PYTHON_VERSION="${{ github.event.inputs.python_version }}"
+            fi
+            
+            # Check if branch is provided (overrides version)
+            if [ -n "${{ github.event.inputs.pyatlan_branch }}" ]; then
+              PYATLAN_BRANCH="${{ github.event.inputs.pyatlan_branch }}"
+              PYATLAN_VERSION="branch-${PYATLAN_BRANCH}"
+              INSTALL_FROM_GIT="true"
+              echo "Using pyatlan branch: $PYATLAN_BRANCH"
+            else
+              # Set Pyatlan version (default to version.txt if empty)
+              if [ -z "${{ github.event.inputs.pyatlan_version }}" ]; then
+                PYATLAN_VERSION=$(cat pyatlan/version.txt)
+                echo "Using pyatlan version from version.txt: $PYATLAN_VERSION"
+              else
+                PYATLAN_VERSION="${{ github.event.inputs.pyatlan_version }}"
+                echo "Using specified pyatlan version: $PYATLAN_VERSION"
+              fi
+              PYATLAN_BRANCH=""
+              INSTALL_FROM_GIT="false"
+            fi
+          fi
+          
+          echo "BUILD_TYPE=$BUILD_TYPE" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
+          echo "PYATLAN_VERSION=$PYATLAN_VERSION" >> $GITHUB_ENV
+          echo "PYATLAN_BRANCH=$PYATLAN_BRANCH" >> $GITHUB_ENV
+          echo "INSTALL_FROM_GIT=$INSTALL_FROM_GIT" >> $GITHUB_ENV
+          
+          # Set platforms based on build type
+          if [ "$BUILD_TYPE" = "dev" ]; then
+            PLATFORMS="linux/amd64"
+          else
+            PLATFORMS="linux/amd64,linux/arm64"
+          fi
+          echo "PLATFORMS=$PLATFORMS" >> $GITHUB_ENV
+          
+          # Generate commit hash for dev builds
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
+          
+          echo "Build parameters:"
+          echo "  - Trigger: ${{ github.event_name }}"
+          echo "  - Build Type: $BUILD_TYPE"
+          echo "  - Python Version: $PYTHON_VERSION"
+          echo "  - Pyatlan Version: $PYATLAN_VERSION"
+          if [ "$INSTALL_FROM_GIT" = "true" ]; then
+            echo "  - Pyatlan Branch: $PYATLAN_BRANCH"
+            echo "  - Install Method: Git (development build)"
+          else
+            echo "  - Install Method: PyPI (stable release)"
+          fi
+          echo "  - Platforms: $PLATFORMS"
+          echo "  - Commit Hash: $COMMIT_HASH"
+
+      - name: Generate image tags
+        id: generate-tags
+        run: |
+          BUILD_TYPE="${{ env.BUILD_TYPE }}"
+          PYTHON_VERSION="${{ env.PYTHON_VERSION }}"
+          PYATLAN_VERSION="${{ env.PYATLAN_VERSION }}"
+          COMMIT_HASH="${{ env.COMMIT_HASH }}"
+          
+          if [ "$BUILD_TYPE" = "dev" ]; then
+            # Dev: 8.0.0-3.11-commithash
+            IMAGE_TAG="${PYATLAN_VERSION}-${PYTHON_VERSION}-${COMMIT_HASH}"
+          else
+            # Release: 8.0.0-3.11
+            IMAGE_TAG="${PYATLAN_VERSION}-${PYTHON_VERSION}"
+          fi
+          
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          
+          echo "Generated image tag: ghcr.io/atlanhq/pyatlan-chainguard-base:$IMAGE_TAG"
+
+      - name: Wait for PyPI availability
+        if: env.INSTALL_FROM_GIT == 'false' && (github.event.inputs.pyatlan_version != '' || github.event_name == 'release')
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 3
+          command: |
+            echo "Checking if pyatlan==${{ env.PYATLAN_VERSION }} is available on PyPI..."
+            if pip index versions pyatlan | grep -q "${{ env.PYATLAN_VERSION }}"; then
+              echo "Package is available on PyPI!"
+              exit 0
+            else
+              echo "Package not available yet. Retrying..."
+              exit 1
+            fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.chainguard
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ghcr.io/atlanhq/pyatlan-chainguard-base:${{ env.IMAGE_TAG }}
+          build-args: |
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            PYATLAN_VERSION=${{ env.PYATLAN_VERSION }}
+            PYATLAN_BRANCH=${{ env.PYATLAN_BRANCH }}
+            INSTALL_FROM_GIT=${{ env.INSTALL_FROM_GIT }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output image information
+        run: |
+          echo "## 🐳 Chainguard Docker Image Built Successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Image Details:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Base Image:** Chainguard" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Type:** ${{ env.BUILD_TYPE }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Python Version:** ${{ env.PYTHON_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Pyatlan Version:** ${{ env.PYATLAN_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ env.INSTALL_FROM_GIT }}" = "true" ]; then
+            echo "- **Pyatlan Branch:** ${{ env.PYATLAN_BRANCH }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Install Method:** Git (development build)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Install Method:** PyPI (stable release)" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "- **Platforms:** ${{ env.PLATFORMS }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ env.BUILD_TYPE }}" = "dev" ]; then
+            echo "- **Commit Hash:** ${{ env.COMMIT_HASH }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Available Tag:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`ghcr.io/atlanhq/pyatlan-chainguard-base:${{ env.IMAGE_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Usage in your Dockerfile:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`dockerfile" >> $GITHUB_STEP_SUMMARY
+          echo "FROM ghcr.io/atlanhq/pyatlan-chainguard-base:${{ env.IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Your application code here" >> $GITHUB_STEP_SUMMARY
+          echo "COPY your-package/ /app/" >> $GITHUB_STEP_SUMMARY
+          echo "RUN uv pip install --system -r requirements.txt" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "CMD [\"python\", \"your-app.py\"]" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile.chainguard
+++ b/Dockerfile.chainguard
@@ -1,0 +1,57 @@
+FROM cgr.dev/atlan.com/python:3.11
+
+# Build arguments for configurable versions
+ARG PYTHON_VERSION=3.11
+ARG PYATLAN_VERSION=latest
+ARG PYATLAN_BRANCH=""
+ARG INSTALL_FROM_GIT=false
+
+WORKDIR /app
+
+# Install Python and git (needed for git-based installations)
+# Update package index and use --no-cache to avoid download corruption issues
+# Add retry logic to handle transient network issues
+# Clean up package cache in same layer to avoid increasing image size
+RUN for i in 1 2 3; do \
+        apk update && \
+        apk add --no-cache python-${PYTHON_VERSION} git && \
+        break || \
+        (echo "Attempt $i failed, retrying..." && sleep 5); \
+    done && \
+    rm -rf /var/cache/apk/* && \
+    chown -R nonroot:nonroot /app/
+
+# Install pyatlan - either from PyPI or git branch
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$INSTALL_FROM_GIT" = "true" ]; then \
+        echo "Installing pyatlan from git branch: $PYATLAN_BRANCH"; \
+        uv pip install --system "git+https://github.com/atlanhq/atlan-python.git@$PYATLAN_BRANCH"; \
+    elif [ "$PYATLAN_VERSION" = "latest" ]; then \
+        echo "Installing latest pyatlan from PyPI"; \
+        uv pip install --system pyatlan; \
+    else \
+        echo "Installing pyatlan==$PYATLAN_VERSION from PyPI"; \
+        uv pip install --system pyatlan==$PYATLAN_VERSION; \
+    fi
+
+# Add build information as labels
+RUN if [ "$INSTALL_FROM_GIT" = "true" ]; then \
+        echo "LABEL pyatlan.source=git" >> /tmp/labels && \
+        echo "LABEL pyatlan.branch=$PYATLAN_BRANCH" >> /tmp/labels; \
+    else \
+        echo "LABEL pyatlan.source=pypi" >> /tmp/labels && \
+        echo "LABEL pyatlan.version=$PYATLAN_VERSION" >> /tmp/labels; \
+    fi && \
+    echo "LABEL python.version=$PYTHON_VERSION" >> /tmp/labels
+
+USER nonroot
+
+# Set environment variables
+ENV PYTHONPATH=/app
+ENV PATH="/home/nonroot/.local/bin:${PATH}"
+
+# Default working directory for applications
+WORKDIR /app
+
+# Default command (can be overridden by extending images)
+CMD ["python"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GitHub Actions workflow and Dockerfile to build and push a Chainguard-based Pyatlan base image with configurable Python/Pyatlan versions, branch installs, and multi-arch support.
> 
> - **CI/CD**:
>   - **New workflow** `.github/workflows/pyatlan-chainguard.yaml` to build/push `ghcr.io/atlanhq/pyatlan-chainguard-base`.
>     - Supports manual and release triggers; `dev` (amd64) and `release` (amd64+arm64) builds.
>     - Inputs for `python_version`, `pyatlan_version`, and `pyatlan_branch` (git install override).
>     - Generates image tag from `pyatlan` and Python versions (plus commit hash for dev).
>     - Optional PyPI availability check before build; uses Buildx with registry auth and cache.
>     - Publishes build info in GitHub step summary.
> - **Docker**:
>   - **New `Dockerfile.chainguard`** based on `cgr.dev/atlan.com/python:3.11`.
>     - Args: `PYTHON_VERSION`, `PYATLAN_VERSION`, `PYATLAN_BRANCH`, `INSTALL_FROM_GIT`.
>     - Installs Python and git via `apk` with retries; installs `pyatlan` from PyPI or git branch via `uv`.
>     - Adds labels for source/version and Python version; runs as `nonroot`; default CMD `python`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6258bf17ac8507ff85d931e8df1c12ad0fde6491. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->