### PR TITLE
APP-9140 | Testing chainguard image - added ghcr login

### DIFF
--- a/.github/workflows/pyatlan-chainguard.yaml
+++ b/.github/workflows/pyatlan-chainguard.yaml
@@ -50,6 +50,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Log in to Chainguard Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GHCR login step to authenticate pushes to ghcr.io in the pyatlan Chainguard image workflow.
> 
> - **CI/CD**:
>   - **GitHub Actions** (`.github/workflows/pyatlan-chainguard.yaml`):
>     - Add `Log in to GitHub Container Registry` step using `docker/login-action@v3` with `ghcr.io` via `GITHUB_TOKEN`, placed before Chainguard registry login.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c655392d78d52b0289dd86d78445f84f23d94ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->