### PR TITLE
APP-9140 | Testing chainguard image - fixed dockerfile

### DIFF
--- a/Dockerfile.chainguard
+++ b/Dockerfile.chainguard
@@ -8,19 +8,6 @@ ARG INSTALL_FROM_GIT=false
 
 WORKDIR /app
 
-# Install Python and git (needed for git-based installations)
-# Update package index and use --no-cache to avoid download corruption issues
-# Add retry logic to handle transient network issues
-# Clean up package cache in same layer to avoid increasing image size
-RUN for i in 1 2 3; do \
-        apk update && \
-        apk add --no-cache python-${PYTHON_VERSION} git && \
-        break || \
-        (echo "Attempt $i failed, retrying..." && sleep 5); \
-    done && \
-    rm -rf /var/cache/apk/* && \
-    chown -R nonroot:nonroot /app/
-
 # Install pyatlan - either from PyPI or git branch
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$INSTALL_FROM_GIT" = "true" ]; then \
@@ -43,12 +30,6 @@ RUN if [ "$INSTALL_FROM_GIT" = "true" ]; then \
         echo "LABEL pyatlan.version=$PYATLAN_VERSION" >> /tmp/labels; \
     fi && \
     echo "LABEL python.version=$PYTHON_VERSION" >> /tmp/labels
-
-USER nonroot
-
-# Set environment variables
-ENV PYTHONPATH=/app
-ENV PATH="/home/nonroot/.local/bin:${PATH}"
 
 # Default working directory for applications
 WORKDIR /app


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restores dependency installation with retries, sets nonroot user and environment variables, and keeps pyatlan installation logic in the Chainguard Dockerfile.
> 
> - **Dockerfile (`Dockerfile.chainguard`)**:
>   - Add install step for `python-${PYTHON_VERSION}` and `git` with retry logic and cache cleanup.
>   - Set `USER nonroot` and define `PYTHONPATH` and updated `PATH`.
>   - Retain `uv pip`-based `pyatlan` install (from PyPI or git branch) and build labels.
>   - Keep default `WORKDIR /app` and `CMD ["python"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19be19104ab7a0bb564ab7e0252bfa5012033272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->