### PR TITLE
APP-9187 : Backporting changes sub-admin role of workflows

### DIFF
--- a/pyatlan/cache/role_cache.py
+++ b/pyatlan/cache/role_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from threading import Lock
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
+from pyatlan.client.constants import GET_KEYCLOAK_USER_ROLE_MAPPING
 from pyatlan.model.role import AtlanRole
 
 if TYPE_CHECKING:
@@ -24,6 +25,7 @@ class RoleCache:
         self.map_id_to_name: Dict[str, str] = {}
         self.map_name_to_id: Dict[str, str] = {}
         self.lock: Lock = Lock()
+        self._is_api_token_user: Optional[bool] = None
 
     def get_id_for_name(self, name: str) -> Optional[str]:
         """
@@ -33,6 +35,36 @@ class RoleCache:
         :returns: unique identifier (GUID) of the role
         """
         return self._get_id_for_name(name=name)
+
+    def is_api_token_user(self) -> bool:
+        """
+        Check if the current user is authenticated via an API token or OAuth client.
+        This method checks for the presence of $api-token-default-access or $admin roles.
+
+        :returns: True if the user is an API token user, False otherwise
+        """
+        if self._is_api_token_user is not None:
+            return self._is_api_token_user
+
+        # Get current user to retrieve their UUID
+        current_user = self.client.user.get_current()
+
+        # Fetch role mappings for the current user
+        raw_json = self.client._call_api(
+            api=GET_KEYCLOAK_USER_ROLE_MAPPING.format_path(
+                {"user_uuid": current_user.id}
+            )
+        )
+
+        # Check if the user has $api-token-default-access or $admin roles
+        for role_mapping in raw_json["realmMappings"]:
+            role_name = role_mapping.get("name")
+            if role_name in ["$api-token-default-access", "$admin"]:
+                self._is_api_token_user = True
+                return self._is_api_token_user
+
+        self._is_api_token_user = False
+        return self._is_api_token_user
 
     def get_name_for_id(self, idstr: str) -> Optional[str]:
         """

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -146,6 +146,12 @@ GET_KEYCLOAK_USER = API(
     HTTPStatus.OK,
     endpoint=EndPoint.IMPERSONATION,
 )
+GET_KEYCLOAK_USER_ROLE_MAPPING = API(
+    "auth/admin/realms/default/users/{user_uuid}/role-mappings",
+    HTTPMethod.GET,
+    HTTPStatus.OK,
+    endpoint=EndPoint.IMPERSONATION,
+)
 
 ENTITY_API = "entity/"
 PREFIX_ATTR = "attr:"
@@ -462,6 +468,35 @@ WORKFLOW_ARCHIVE = API(
     HTTPStatus.OK,
     endpoint=EndPoint.HERACLES,
 )
+
+# Package workflow endpoints (new endpoints only these are supported)
+PACKAGE_WORKFLOW_RERUN_API = "package-workflows/submit"
+PACKAGE_WORKFLOW_RERUN = API(
+    PACKAGE_WORKFLOW_RERUN_API,
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+
+PACKAGE_WORKFLOW_RUN_API = "package-workflows?submit=true"
+PACKAGE_WORKFLOW_RUN = API(
+    PACKAGE_WORKFLOW_RUN_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HERACLES
+)
+
+PACKAGE_WORKFLOW_API = "package-workflows"
+PACKAGE_WORKFLOW_UPDATE = API(
+    PACKAGE_WORKFLOW_API + "/{workflow_name}",
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+PACKAGE_WORKFLOW_ARCHIVE = API(
+    PACKAGE_WORKFLOW_API + "/{workflow_name}/archive",
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+
 WORKFLOW_SCHEDULE_RUN = "runs"
 GET_ALL_SCHEDULE_RUNS = API(
     WORKFLOW_SCHEDULE_RUN + "/cron",

--- a/tests/unit/test_workflow_client.py
+++ b/tests/unit/test_workflow_client.py
@@ -46,7 +46,13 @@ def set_env(monkeypatch):
 
 @pytest.fixture()
 def mock_api_caller():
-    return Mock(spec=ApiCaller)
+    mock = Mock(spec=ApiCaller)
+    # Add role_cache attribute to the mock
+    mock.role_cache = Mock()
+    mock.role_cache.is_api_token_user.return_value = (
+        False  # Default to non-API token user
+    )
+    return mock
 
 
 @pytest.fixture()
@@ -780,4 +786,174 @@ def test_workflow_get_scheduled_run(
 
     assert mock_api_caller._call_api.call_count == 1
     assert response == WorkflowScheduleResponse(**schedule_response.dict())
+    mock_api_caller.reset_mock()
+
+
+# Tests for role_cache functionality
+def test_rerun_with_role_cache_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+    search_result: WorkflowSearchResult,
+    rerun_response: WorkflowRunResponse,
+):
+    """Test that rerun uses package endpoint when user is API token user."""
+    # Mock role_cache to return True for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = True
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = rerun_response.dict()
+
+    response = client.rerun(search_result)
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    assert response == rerun_response
+    mock_api_caller.reset_mock()
+
+
+def test_rerun_with_role_cache_non_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+    search_result: WorkflowSearchResult,
+    rerun_response: WorkflowRunResponse,
+):
+    """Test that rerun uses non-package endpoint when user is not API token user."""
+    # Mock role_cache to return False for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = False
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = rerun_response.dict()
+
+    response = client.rerun(search_result)
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    assert response == rerun_response
+    mock_api_caller.reset_mock()
+
+
+def test_run_with_role_cache_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+    workflow_response: WorkflowResponse,
+):
+    """Test that run uses package endpoint when user is API token user."""
+    # Mock role_cache to return True for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = True
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = workflow_response.dict()
+
+    workflow = Workflow(
+        metadata=WorkflowMetadata(name="name", namespace="namespace"),
+        spec=WorkflowSpec(),
+        payload=[PackageParameter(parameter="test-param", type="test-type", body={})],
+    )
+
+    response = client.run(workflow)
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    assert response == workflow_response
+    mock_api_caller.reset_mock()
+
+
+def test_update_with_role_cache_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+    workflow_response: WorkflowResponse,
+):
+    """Test that update uses package endpoint when user is API token user."""
+    # Mock role_cache to return True for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = True
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = workflow_response.dict()
+
+    workflow = Workflow(
+        metadata=WorkflowMetadata(name="name", namespace="namespace"),
+        spec=WorkflowSpec(),
+        payload=[PackageParameter(parameter="test-param", type="test-type", body={})],
+    )
+
+    response = client.update(workflow)
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    assert response == workflow_response
+    mock_api_caller.reset_mock()
+
+
+def test_delete_with_role_cache_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+):
+    """Test that delete uses package endpoint when user is API token user."""
+    # Mock role_cache to return True for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = True
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = None
+
+    client.delete("test-workflow-name")
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    mock_api_caller.reset_mock()
+
+
+def test_add_schedule_with_role_cache_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+    search_result: WorkflowSearchResult,
+    schedule: WorkflowSchedule,
+    workflow_response: WorkflowResponse,
+):
+    """Test that add_schedule uses package endpoint when user is API token user."""
+    # Mock role_cache to return True for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = True
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = workflow_response.dict()
+
+    response = client.add_schedule(search_result, schedule)
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    assert response == workflow_response
+    mock_api_caller.reset_mock()
+
+
+def test_remove_schedule_with_role_cache_api_token_user(
+    client: WorkflowClient,
+    mock_api_caller,
+    mock_role_cache,
+    search_result: WorkflowSearchResult,
+    workflow_response: WorkflowResponse,
+):
+    """Test that remove_schedule uses package endpoint when user is API token user."""
+    # Mock role_cache to return True for is_api_token_user
+    mock_role_cache.is_api_token_user.return_value = True
+    mock_api_caller.role_cache = mock_role_cache
+    mock_api_caller._call_api.return_value = workflow_response.dict()
+
+    response = client.remove_schedule(search_result)
+
+    # Verify that role_cache.is_api_token_user was called
+    mock_role_cache.is_api_token_user.assert_called_once()
+    # Verify that _call_api was called (endpoint selection happens in prepare_request)
+    mock_api_caller._call_api.assert_called_once()
+    assert response == workflow_response
     mock_api_caller.reset_mock()


### PR DESCRIPTION
# ✨ Description

Briefly explain the purpose of this PR and what it covers. Mention any related issues or Jira tickets.

**Jira link:** _https://atlanhq.atlassian.net/browse/APP-9187_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> WorkflowClient now switches between standard and package workflow endpoints using a new RoleCache.is_api_token_user() check, adds supporting constants, makes Meaning fields optional, and updates tests and version.
> 
> - **Workflow routing (major)**:
>   - `WorkflowClient` (`rerun`, `run`, `update`, `delete`, `add_schedule`, `remove_schedule`) dynamically selects between `WORKFLOW_*` and `PACKAGE_WORKFLOW_*` endpoints based on `role_cache.is_api_token_user()`.
> - **Auth/role detection**:
>   - `RoleCache.is_api_token_user()` added; fetches Keycloak user role mappings via `GET_KEYCLOAK_USER_ROLE_MAPPING` and caches result.
> - **API constants**:
>   - Add `GET_KEYCLOAK_USER_ROLE_MAPPING`.
>   - Add package workflow endpoints: `PACKAGE_WORKFLOW_RERUN`, `PACKAGE_WORKFLOW_RUN`, `PACKAGE_WORKFLOW_UPDATE`, `PACKAGE_WORKFLOW_ARCHIVE`.
> - **Model change**:
>   - `Meaning` fields (`term_guid`, `relation_guid`, `display_text`, `confidence`) are now `Optional`.
> - **Tests**:
>   - Extend `tests/unit/test_workflow_client.py` to mock `role_cache` and verify endpoint selection for the above methods.
> - **Version/Docs**:
>   - Bump version to `7.1.8` and update `HISTORY.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c6360305f9a9ee1266ea11c5d00301c11200206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->