### PR TITLE
APP-9188: Added support for adding proxy settings to `AtlanClient`

### DIFF
--- a/pyatlan/client/transport.py
+++ b/pyatlan/client/transport.py
@@ -1,0 +1,222 @@
+# type: ignore
+"""
+Custom HTTP transport with retry support for Atlan Python SDK.
+
+This module provides transport classes that properly integrate retry logic
+with httpx's HTTPTransport while respecting proxy and SSL configurations.
+"""
+
+import logging
+from functools import partial
+from typing import Any, Optional, Union
+
+import httpx
+from httpx_retries import Retry
+
+logger = logging.getLogger(__name__)
+
+
+class PyatlanSyncTransport(httpx.BaseTransport):
+    """
+    A synchronous transport that wraps httpx.HTTPTransport with retry logic.
+
+    This transport properly handles proxy and SSL configurations by passing
+    them directly to the underlying HTTPTransport, unlike the default
+    RetryTransport which creates its own transport instances.
+
+    Example:
+        ```python
+        transport = PyatlanSyncTransport(
+            retry=Retry(total=5),
+            proxy="http://proxy.example.com:8080",
+            verify="/path/to/cert.pem"
+        )
+        client = httpx.Client(transport=transport)
+        ```
+
+    Args:
+        retry: The retry configuration. Defaults to Retry() if not provided.
+        **kwargs: All other arguments are passed to httpx.HTTPTransport,
+                 including proxy, verify, cert, trust_env, http1, http2, limits, etc.
+    """
+
+    def __init__(
+        self,
+        retry: Optional[Retry] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.retry = retry or Retry()
+        # Ensure trust_env is True by default to respect environment variables
+        # unless explicitly overridden
+        if "trust_env" not in kwargs:
+            kwargs["trust_env"] = True
+        # Create the underlying HTTPTransport with all proxy/SSL config
+        self._transport = httpx.HTTPTransport(**kwargs)
+
+    def __enter__(self):
+        self._transport.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._transport.__exit__(*args)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        """
+        Sends an HTTP request, possibly with retries.
+
+        Args:
+            request: The request to send.
+
+        Returns:
+            The final response.
+        """
+        logger.debug("handle_request started request=%s", request)
+
+        if self.retry.is_retryable_method(request.method):
+            send_method = partial(self._transport.handle_request)
+            response = self._retry_operation(request, send_method)
+        else:
+            response = self._transport.handle_request(request)
+
+        logger.debug(
+            "handle_request finished request=%s response=%s", request, response
+        )
+        return response
+
+    def _retry_operation(
+        self,
+        request: httpx.Request,
+        send_method: partial,
+    ) -> httpx.Response:
+        """Execute a request with retry logic."""
+        retry = self.retry
+        response: Union[httpx.Response, httpx.HTTPError, None] = None
+
+        while True:
+            if response is not None:
+                logger.debug(
+                    "_retry_operation retrying response=%s retry=%s", response, retry
+                )
+                retry = retry.increment()
+                retry.sleep(response)
+
+            try:
+                response = send_method(request)
+            except httpx.HTTPError as e:
+                if retry.is_exhausted() or not retry.is_retryable_exception(e):
+                    raise
+                response = e
+                continue
+
+            if retry.is_exhausted() or not retry.is_retryable_status_code(
+                response.status_code
+            ):
+                return response
+
+    def close(self) -> None:
+        """Close the underlying transport."""
+        self._transport.close()
+
+
+class PyatlanAsyncTransport(httpx.AsyncBaseTransport):
+    """
+    An asynchronous transport that wraps httpx.AsyncHTTPTransport with retry logic.
+
+    This transport properly handles proxy and SSL configurations by passing
+    them directly to the underlying AsyncHTTPTransport.
+
+    Example:
+        ```python
+        transport = PyatlanAsyncTransport(
+            retry=Retry(total=5),
+            proxy="http://proxy.example.com:8080",
+            verify="/path/to/cert.pem"
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://example.com")
+        ```
+
+    Args:
+        retry: The retry configuration. Defaults to Retry() if not provided.
+        **kwargs: All other arguments are passed to httpx.AsyncHTTPTransport,
+                 including proxy, verify, cert, trust_env, http1, http2, limits, etc.
+    """
+
+    def __init__(
+        self,
+        retry: Optional[Retry] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.retry = retry or Retry()
+        # Ensure trust_env is True by default to respect environment variables
+        # unless explicitly overridden
+        if "trust_env" not in kwargs:
+            kwargs["trust_env"] = True
+        # Create the underlying AsyncHTTPTransport with all proxy/SSL config
+        self._transport = httpx.AsyncHTTPTransport(**kwargs)
+
+    async def __aenter__(self):
+        await self._transport.__aenter__()
+        return self
+
+    async def __aexit__(self, *args):
+        return await self._transport.__aexit__(*args)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """
+        Sends an HTTP request asynchronously, possibly with retries.
+
+        Args:
+            request: The request to perform.
+
+        Returns:
+            The final response.
+        """
+        logger.debug("handle_async_request started request=%s", request)
+
+        if self.retry.is_retryable_method(request.method):
+            send_method = partial(self._transport.handle_async_request)
+            response = await self._retry_operation_async(request, send_method)
+        else:
+            response = await self._transport.handle_async_request(request)
+
+        logger.debug(
+            "handle_async_request finished request=%s response=%s", request, response
+        )
+        return response
+
+    async def _retry_operation_async(
+        self,
+        request: httpx.Request,
+        send_method: partial,
+    ) -> httpx.Response:
+        """Execute an async request with retry logic."""
+        retry = self.retry
+        response: Union[httpx.Response, httpx.HTTPError, None] = None
+
+        while True:
+            if response is not None:
+                logger.debug(
+                    "_retry_operation_async retrying response=%s retry=%s",
+                    response,
+                    retry,
+                )
+                retry = retry.increment()
+                await retry.asleep(response)
+
+            try:
+                response = await send_method(request)
+            except httpx.HTTPError as e:
+                if retry.is_exhausted() or not retry.is_retryable_exception(e):
+                    raise
+                response = e
+                continue
+
+            if retry.is_exhausted() or not retry.is_retryable_status_code(
+                response.status_code
+            ):
+                return response
+
+    async def aclose(self) -> None:
+        """Close the underlying transport."""
+        await self._transport.aclose()

--- a/tests/unit/aio/test_client_proxy.py
+++ b/tests/unit/aio/test_client_proxy.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Atlan Pte. Ltd.
+"""
+Tests for AsyncAtlanClient proxy and SSL configuration.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from pyatlan.client.aio.client import AsyncAtlanClient
+
+
+@pytest.mark.parametrize(
+    "proxy_config",
+    [
+        # No proxy configuration (default)
+        {},
+        # Simple proxy
+        {"proxy": "http://127.0.0.1:8080"},
+        # Proxy with SSL verification disabled
+        {"proxy": "http://127.0.0.1:8080", "verify": False},
+    ],
+)
+def test_async_atlan_client_proxy_configurations(monkeypatch, proxy_config):
+    """Test various proxy and SSL configurations are properly initialized for async client."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+    # Clear any system proxy/SSL env vars that might interfere with tests
+    for var in [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    # Create async client with proxy settings
+    client = AsyncAtlanClient(**proxy_config)
+
+    # Verify the async session was created
+    assert client._async_session is not None
+    assert isinstance(client._async_session, httpx.AsyncClient)
+
+    # Verify proxy is set correctly if provided
+    if "proxy" in proxy_config:
+        assert client.proxy == proxy_config["proxy"]
+    else:
+        assert client.proxy is None
+
+    # Verify verify is set correctly if provided
+    if "verify" in proxy_config:
+        assert client.verify == proxy_config["verify"]
+    else:
+        assert client.verify is True  # Default value
+
+
+def test_async_atlan_client_proxy_passed_to_transport(monkeypatch):
+    """Test that proxy and verify settings are correctly configured on the async client."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+    # Clear any proxy env vars that might interfere
+    for var in [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    # Test with proxy and verify=False (to disable SSL verification for testing)
+    proxy_url = "http://127.0.0.1:8080"
+
+    client = AsyncAtlanClient(proxy=proxy_url, verify=False)
+
+    # Verify the client has the correct settings
+    assert client.proxy == proxy_url
+    assert client.verify is False
+
+    # Verify the transport was created
+    assert client._async_session is not None
+    assert hasattr(client._async_session, "_transport")
+
+
+@pytest.mark.parametrize(
+    "env_vars, expected_proxy",
+    [
+        # HTTP_PROXY environment variable
+        (
+            {"HTTP_PROXY": "http://proxy.example.com:8080"},
+            "http://proxy.example.com:8080",
+        ),
+        # http_proxy (lowercase) environment variable
+        (
+            {"http_proxy": "http://proxy.example.com:8080"},
+            "http://proxy.example.com:8080",
+        ),
+        # HTTPS_PROXY takes precedence
+        (
+            {
+                "HTTP_PROXY": "http://proxy.example.com:8080",
+                "HTTPS_PROXY": "https://proxy.example.com:8443",
+            },
+            "https://proxy.example.com:8443",
+        ),
+    ],
+)
+@patch("httpx.AsyncClient")
+def test_async_atlan_client_proxy_from_environment_variables(
+    mock_async_httpx_client,
+    monkeypatch,
+    env_vars,
+    expected_proxy,
+):
+    """Test that proxy settings are picked up from environment variables when not explicitly provided."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+    # Clear any system proxy/SSL env vars that might interfere with tests
+    for var in [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    # Set environment variables
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    # Create async client without explicit proxy settings
+    client = AsyncAtlanClient()
+
+    # Verify proxy configuration
+    assert client.proxy == expected_proxy
+
+
+@patch("httpx_retries.transport.httpx.AsyncHTTPTransport")
+@patch("httpx_retries.transport.httpx.HTTPTransport")
+@patch("httpx.AsyncClient")
+def test_async_atlan_client_proxy_with_ssl_cert_file_from_env(
+    mock_async_httpx_client, mock_http_transport, mock_async_http_transport, monkeypatch
+):
+    """Test that SSL_CERT_FILE environment variable is picked up for async client."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+    # Use the fake certificate file
+    fake_cert_path = str(
+        Path(__file__).parent.parent / "data" / "fake_certificates" / "fake-cert.pem"
+    )
+    monkeypatch.setenv("SSL_CERT_FILE", fake_cert_path)
+
+    client = AsyncAtlanClient()
+
+    # Verify SSL cert path was picked up
+    assert client.verify == fake_cert_path
+
+
+@patch("httpx_retries.transport.httpx.AsyncHTTPTransport")
+@patch("httpx_retries.transport.httpx.HTTPTransport")
+@patch("httpx.AsyncClient")
+def test_async_atlan_client_explicit_args_override_env_vars(
+    mock_async_httpx_client, mock_http_transport, mock_async_http_transport, monkeypatch
+):
+    """Test that explicitly provided arguments take precedence over environment variables for async client."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+    # Use the fake certificate file
+    fake_cert_path = str(
+        Path(__file__).parent.parent / "data" / "fake_certificates" / "fake-cert.pem"
+    )
+
+    # Set environment variables
+    monkeypatch.setenv("HTTP_PROXY", "http://env-proxy:8080")
+    monkeypatch.setenv("SSL_CERT_FILE", fake_cert_path)
+
+    # Explicitly provide different values
+    explicit_proxy = "http://explicit-proxy:9090"
+    explicit_verify = False
+
+    client = AsyncAtlanClient(proxy=explicit_proxy, verify=explicit_verify)
+
+    # Verify explicit values take precedence
+    assert client.proxy == explicit_proxy
+    assert client.verify == explicit_verify
+
+
+def test_async_atlan_client_no_proxy_when_no_env_vars(monkeypatch):
+    """Test that no proxy is configured when neither args nor env vars are provided for async client."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.atlan.com")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-api-key")
+
+    # Ensure proxy env vars are not set
+    for env_var in [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    ]:
+        monkeypatch.delenv(env_var, raising=False)
+
+    client = AsyncAtlanClient()
+
+    assert client.proxy is None
+    assert client.verify is True  # Default value


### PR DESCRIPTION
# ✨ Description

**Jira link:** https://atlanhq.atlassian.net/browse/APP-9188

```py
import logging
import os
import httpx
from pyatlan.client.atlan import AtlanClient

logging.basicConfig(level=logging.DEBUG)

proxy_settings = {
    "verify": os.getenv("SSL_CERT_FILE"),
    "proxy": os.getenv("HTTP_PROXY"),
}
client = AtlanClient(**proxy_settings)

response = client.workflow.find_by_id("atlan-databricks-1760456955-qw4n8")
print(response)
```

---

## 🧩 Type of change

Select all that apply:

- [x] 🚀 New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add proxy/SSL verification support to sync/async clients via custom httpx transports with retry, including env var handling and tests.
> 
> - **HTTP transport and configuration**:
>   - **Custom transports**: Introduce `PyatlanSyncTransport` and `PyatlanAsyncTransport` to integrate `Retry` with `httpx` while honoring proxy/SSL settings.
>   - **Proxy/SSL support**: Add `proxy` and `verify` to `AtlanClient` and pass through to transports; default `trust_env=True` and support `HTTP(S)_PROXY`, `ALL_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`.
>   - **Config builder**: Implement `_build_transport_proxy_config(...)` to derive transport kwargs from args/env.
> - **Client initialization and retries**:
>   - Replace `RetryTransport` with custom transports in sync/async clients; initialize sessions with new transport and headers.
>   - Update `max_retries` context managers to swap in new transports while preserving current `proxy`/`verify`.
> - **Tests**:
>   - Add async proxy/SSL tests in `tests/unit/aio/test_client_proxy.py`.
>   - Expand sync tests in `tests/unit/test_client.py` for headers, proxy/SSL args vs env vars, and transport setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18cda078d30e02b9bb3fb3b4b145dffe464696a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->