### PR TITLE
APP-9234 : Fix the endpoint inside role cache for deciding whether api token is being used or not

### DIFF
--- a/pyatlan/cache/aio/role_cache.py
+++ b/pyatlan/cache/aio/role_cache.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 from pyatlan.cache.common import RoleCacheCommon
-from pyatlan.client.constants import GET_KEYCLOAK_USER_ROLE_MAPPING
+from pyatlan.client.constants import GET_WHOAMI_USER
 from pyatlan.model.role import AtlanRole
 
 if TYPE_CHECKING:
@@ -107,17 +107,11 @@ class AsyncRoleCache:
         if self._is_api_token_user is not None:
             return self._is_api_token_user
 
-        current_user = await self.client.user.get_current()
-
         # Fetch role mappings for the current user
-        raw_json = await self.client._call_api(
-            api=GET_KEYCLOAK_USER_ROLE_MAPPING.format_path(
-                {"user_uuid": current_user.id}
-            )
-        )
+        raw_json = await self.client._call_api(api=GET_WHOAMI_USER)
 
         # Check if the user has $api-token-default-access or $admin roles
-        for role_mapping in raw_json["realmMappings"]:
+        for role_mapping in raw_json["roles"]:
             role_name = role_mapping.get("name")
             if role_name in ["$api-token-default-access", "$admin"]:
                 self._is_api_token_user = True

--- a/pyatlan/cache/role_cache.py
+++ b/pyatlan/cache/role_cache.py
@@ -6,7 +6,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 from pyatlan.cache.common import RoleCacheCommon
-from pyatlan.client.constants import GET_KEYCLOAK_USER_ROLE_MAPPING
+from pyatlan.client.constants import GET_WHOAMI_USER
 from pyatlan.model.role import AtlanRole
 
 if TYPE_CHECKING:
@@ -111,18 +111,11 @@ class RoleCache:
         if self._is_api_token_user is not None:
             return self._is_api_token_user
 
-        # Get current user to retrieve their UUID
-        current_user = self.client.user.get_current()
-
         # Fetch role mappings for the current user
-        raw_json = self.client._call_api(
-            api=GET_KEYCLOAK_USER_ROLE_MAPPING.format_path(
-                {"user_uuid": current_user.id}
-            )
-        )
+        raw_json = self.client._call_api(api=GET_WHOAMI_USER)
 
         # Check if the user has $api-token-default-access or $admin roles
-        for role_mapping in raw_json["realmMappings"]:
+        for role_mapping in raw_json["roles"]:
             role_name = role_mapping.get("name")
             if role_name in ["$api-token-default-access", "$admin"]:
                 self._is_api_token_user = True

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -20,6 +20,7 @@ QUERY_API = "query"
 IMAGE_API = "images"
 LOGS_API = "events"
 TOKENS_API = "apikeys"
+WHOAMI_API = "whoami"
 
 # Role APIs
 GET_ROLES = API(ROLE_API, HTTPMethod.GET, HTTPStatus.OK, endpoint=EndPoint.HERACLES)
@@ -84,7 +85,9 @@ CHANGE_USER_ROLE = API(
 GET_CURRENT_USER = API(
     f"{USER_API}/current", HTTPMethod.GET, HTTPStatus.OK, endpoint=EndPoint.HERACLES
 )
-
+GET_WHOAMI_USER = API(
+    WHOAMI_API, HTTPMethod.GET, HTTPStatus.OK, endpoint=EndPoint.HERACLES
+)
 # SQL parsing APIs
 PARSE_QUERY = API(
     f"{QUERY_API}/parse", HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HEKA
@@ -141,12 +144,6 @@ GET_CLIENT_SECRET = API(
 )
 GET_KEYCLOAK_USER = API(
     "/auth/admin/realms/default/users",
-    HTTPMethod.GET,
-    HTTPStatus.OK,
-    endpoint=EndPoint.IMPERSONATION,
-)
-GET_KEYCLOAK_USER_ROLE_MAPPING = API(
-    "auth/admin/realms/default/users/{user_uuid}/role-mappings",
     HTTPMethod.GET,
     HTTPStatus.OK,
     endpoint=EndPoint.IMPERSONATION,


### PR DESCRIPTION
# ✨ Description

- Removing the old endpoint instead making use of our internal hearcles endpoint: /whoami

**Jira link:** _https://atlanhq.atlassian.net/browse/APP-9234_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Keycloak role-mapping call with `whoami` and parse `roles` instead of `realmMappings`, adding `GET_WHOAMI_USER` and removing the old constant.
> 
> - **Role cache (sync/async)**:
>   - Switch API-token detection from `GET_KEYCLOAK_USER_ROLE_MAPPING` (via current user UUID) to `GET_WHOAMI_USER`.
>   - Parse `raw_json["roles"]` instead of `raw_json["realmMappings"]`.
> - **Constants**:
>   - Add `WHOAMI_API` and `GET_WHOAMI_USER` (Heracles endpoint).
>   - Remove `GET_KEYCLOAK_USER_ROLE_MAPPING` and update imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f40aaed862b16a497191bb94f896535302f0870f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->