### PR TITLE
APP-9303 : Fixed source tag search with value

### DIFF
--- a/pyatlan/model/fluent_search.py
+++ b/pyatlan/model/fluent_search.py
@@ -206,9 +206,6 @@ class CompoundQuery:
             little_spans.append(
                 SpanTerm(field="__classificationsText.text", value=token)
             )
-        little_spans.append(
-            SpanTerm(field="__classificationsText.text", value="tagAttachmentKey")
-        )
 
         # Contruct big spans
         big_spans.append(SpanTerm(field="__classificationsText.text", value=tag_id))
@@ -299,9 +296,6 @@ class CompoundQuery:
             little_spans.append(
                 SpanTerm(field="__classificationsText.text", value=token)
             )
-        little_spans.append(
-            SpanTerm(field="__classificationsText.text", value="tagAttachmentKey")
-        )
 
         # Contruct big spans
         big_spans.append(SpanTerm(field="__classificationsText.text", value=tag_id))


### PR DESCRIPTION
# ✨ Description

- Search for source-synced tags with specific values was failing due to an outdated tagAttachmentKey still being included in SDK queries.
- We’re removing this key to align with the updated Tag V2 flow from Metastore and restore search functionality.
- The frontend and Java SDK have also implemented similar items.

**Jira link:** _https://atlanhq.atlassian.net/browse/APP-9303_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `tagAttachmentKey` from span queries in tag-with-value searches to align with Tag V2 and fix source-synced tag value search.
> 
> - **Search (Python SDK)**
>   - In `pyatlan/model/fluent_search.py`:
>     - `CompoundQuery.tagged_with_value` and `CompoundQuery.tagged_with_value_async` no longer add `"tagAttachmentKey"` to `little_spans` when building `SpanNear` queries for tag value searches.
>     - Span construction otherwise unchanged (tokens of value retained; `tagAttachmentValue` and big spans with tag ID and synced tag QN remain).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64998db398b99b614d26953d014883ddeb73f77d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->