### PR TITLE
GOV-778 fix(typedef) | add show_as_featured to AttributeDef.Options to prevent silent data loss on update

### DIFF
--- a/pyatlan/model/typedef.py
+++ b/pyatlan/model/typedef.py
@@ -551,6 +551,10 @@ class AttributeDef(AtlanObject):
             default=False,
             description="Whether this attribute supports rich text formatting (True) or not (False). ",
         )
+        show_as_featured: Optional[bool] = Field(
+            default=None,
+            description="Whether this attribute is shown as featured in the asset profile (True) or not (False).",
+        )
 
         def __setattr__(self, name, value):
             super().__setattr__(name, value)

--- a/pyatlan_v9/model/typedef.py
+++ b/pyatlan_v9/model/typedef.py
@@ -553,6 +553,9 @@ class AttributeDef(msgspec.Struct, kw_only=True, rename="camel", omit_defaults=T
         is_rich_text: Union[bool, None, msgspec.UnsetType] = msgspec.UNSET
         """Whether this attribute supports rich text formatting."""
 
+        show_as_featured: Union[bool, None, msgspec.UnsetType] = msgspec.UNSET
+        """Whether this attribute is shown as featured in the asset profile."""
+
         def __post_init__(self) -> None:
             if self.custom_metadata_version is msgspec.UNSET:
                 self.custom_metadata_version = "v2"

--- a/tests/integration/custom_metadata_test.py
+++ b/tests/integration/custom_metadata_test.py
@@ -340,6 +340,30 @@ def test_cm_raci(
     assert not one.options.multi_value_select
 
 
+@pytest.mark.order(after="test_cm_raci")
+def test_show_as_featured_survives_update(
+    client: AtlanClient, cm_raci: CustomMetadataDef
+):
+    existing = client.custom_metadata_cache.get_custom_metadata_def(name=CM_RACI)
+    assert existing.attribute_defs
+    attr = existing.attribute_defs[0]
+    assert attr.options
+    attr.options.show_as_featured = True
+    assert existing.options
+    existing.options.is_locked = True
+    response = client.typedef.update(existing)
+    assert response
+    assert len(response.custom_metadata_defs) == 1
+    updated = response.custom_metadata_defs[0]
+    assert updated.attribute_defs
+    updated_attr = updated.attribute_defs[0]
+    assert updated_attr.options
+    assert updated_attr.options.show_as_featured is True
+    assert updated.options
+    updated.options.is_locked = False
+    client.typedef.update(updated)
+
+
 @pytest.fixture(scope="module")
 def cm_enum(
     client: AtlanClient,

--- a/tests_v9/integration/custom_metadata_test.py
+++ b/tests_v9/integration/custom_metadata_test.py
@@ -340,6 +340,30 @@ def test_cm_raci(
     assert not one.options.multi_value_select
 
 
+@pytest.mark.order(after="test_cm_raci")
+def test_show_as_featured_survives_update(
+    client: AtlanClient, cm_raci: CustomMetadataDef
+):
+    existing = client.custom_metadata_cache.get_custom_metadata_def(name=CM_RACI)
+    assert existing.attribute_defs
+    attr = existing.attribute_defs[0]
+    assert attr.options
+    attr.options.show_as_featured = True
+    assert existing.options
+    existing.options.is_locked = True
+    response = client.typedef.updater(existing)
+    assert response
+    assert len(response.custom_metadata_defs) == 1
+    updated = response.custom_metadata_defs[0]
+    assert updated.attribute_defs
+    updated_attr = updated.attribute_defs[0]
+    assert updated_attr.options
+    assert updated_attr.options.show_as_featured is True
+    assert updated.options
+    updated.options.is_locked = False
+    client.typedef.updater(updated)
+
+
 @pytest.fixture(scope="module")
 def cm_enum(
     client: AtlanClient,


### PR DESCRIPTION
# ✨ Description
                                                                                                        
  ## Problem                                                                                                            
                                                                                                                        
  When updating a Custom Metadata typedef via the SDK (e.g. setting `cm.options.is_locked = True`                       
  then calling `typedef.update(cm)`), the `showAsFeatured` setting on attribute definitions was                         
  silently cleared in the backend.                                                             
                                                                                                                        
  ## Root Cause                                                                          
                                                                                                                        
  `AttributeDef.Options` did not model the `showAsFeatured` field. Because `AtlanObject` uses
  `Config.extra = Extra.ignore`, Pydantic silently discards unknown fields on parse. This meant:                        
                                                                                                
  1. API response returns `attributeDefs[*].options.showAsFeatured: true`                                               
  2. Pydantic parses into `AttributeDef.Options` → field unknown → **dropped**                                          
  3. `typedef.update()` serializes the full CM (including attributeDefs) → `showAsFeatured` absent in payload           
  4. Backend **replaces** attribute options (not merges) → field gone → UI toggle turns off                             
                                                                                                                        
  ## Fix                                                                                                                
                                                                                                                        
  Add `show_as_featured: Optional[bool]` to `AttributeDef.Options`. The `alias_generator = to_camel_case`               
  on `AtlanObject` automatically maps this to `showAsFeatured` in API JSON, so the field now                            
  round-trips correctly through fetch → modify → update.                                    
                                                                                                                        
  ## Impact                                                                                                             
                                                                                                                        
  Any SDK operation that fetched and re-submitted a CM typedef with `showAsFeatured` set on any                         
  attribute was silently clearing that setting. No other attribute option fields are affected.                          
                                                                                              
**Jira link:** _[[IGOV-778](https://linear.app/atlan-epd/issue/GOV-778/locking-custom-metadata-via-python-sdk-disables-showasfeatured)]_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Added integration tests
<img width="1145" height="576" alt="Screenshot 2026-04-21 at 12 20 18" src="https://github.com/user-attachments/assets/cf2705f1-d9f3-47b4-b94e-7fd1cceb24b0" />
<img width="1140" height="556" alt="Screenshot 2026-04-21 at 12 22 21" src="https://github.com/user-attachments/assets/f7227edc-f31e-4861-87fb-225b4ffbfb4c" />

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally
