### PR TITLE
feat(enums): add deprecated Phosphor icon names to AtlanIcon [BLDX-1096]

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           image-ref: pyatlan-trivy:latest
           scanners: 'vuln'
-          version: 'v0.69.0'
+          version: 'v0.70.0'
           ignore-unfixed: true
           format: 'table'
           output: 'trivy-image.txt'
@@ -71,7 +71,7 @@ jobs:
         with:
           image-ref: pyatlan-trivy:latest
           scanners: 'vuln'
-          version: 'v0.69.0'
+          version: 'v0.70.0'
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-image.sarif'
@@ -87,7 +87,7 @@ jobs:
           scan-type: fs
           scan-ref: uv.lock
           scanners: 'vuln'
-          version: 'v0.69.0'
+          version: 'v0.70.0'
           ignore-unfixed: true
           format: 'table'
           output: 'trivy-deps.txt'
@@ -113,7 +113,7 @@ jobs:
           scan-type: fs
           scan-ref: uv.lock
           scanners: 'vuln'
-          version: 'v0.69.0'
+          version: 'v0.70.0'
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-deps.sarif'
@@ -167,7 +167,7 @@ jobs:
         with:
           image-ref: pyatlan-trivy:latest
           scanners: 'vuln'
-          version: 'v0.69.0'
+          version: 'v0.70.0'
           ignore-unfixed: true
           format: 'table'
           severity: 'CRITICAL,HIGH'
@@ -182,7 +182,7 @@ jobs:
           scan-type: fs
           scan-ref: uv.lock
           scanners: 'vuln'
-          version: 'v0.69.0'
+          version: 'v0.70.0'
           ignore-unfixed: true
           format: 'table'
           severity: 'CRITICAL,HIGH'

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -413,6 +413,7 @@ class AtlanDeleteType(str, Enum):
 
 class AtlanIcon(str, Enum):
     ACORN = "PhAcorn"
+    ACTIVITY = "PhActivity"  # Deprecated: use PULSE
     ADDRESS_BOOK = "PhAddressBook"
     ADDRESS_BOOK_TABS = "PhAddressBookTabs"
     AIRPLANE = "PhAirplane"
@@ -791,6 +792,10 @@ class AtlanIcon(str, Enum):
     CIRCLE_HALF = "PhCircleHalf"
     CIRCLE_HALF_TILT = "PhCircleHalfTilt"
     CIRCLE_NOTCH = "PhCircleNotch"
+    CIRCLE_WAVY = "PhCircleWavy"  # Deprecated: use SEAL
+    CIRCLE_WAVY_CHECK = "PhCircleWavyCheck"  # Deprecated: use SEAL_CHECK
+    CIRCLE_WAVY_QUESTION = "PhCircleWavyQuestion"  # Deprecated: use SEAL_QUESTION
+    CIRCLE_WAVY_WARNING = "PhCircleWavyWarning"  # Deprecated: use SEAL_WARNING
     CIRCUITRY = "PhCircuitry"
     CITY = "PhCity"
     CLIPBOARD = "PhClipboard"
@@ -996,6 +1001,7 @@ class AtlanIcon(str, Enum):
     FILE_CSV = "PhFileCsv"
     FILE_C_SHARP = "PhFileCSharp"
     FILE_DASHED = "PhFileDashed"
+    FILE_DOTTED = "PhFileDotted"  # Deprecated: use FILE_DASHED
     FILE_DOC = "PhFileDoc"
     FILE_HTML = "PhFileHtml"
     FILE_IMAGE = "PhFileImage"
@@ -1005,6 +1011,7 @@ class AtlanIcon(str, Enum):
     FILE_JSX = "PhFileJsx"
     FILE_LOCK = "PhFileLock"
     FILE_MAGNIFYING_GLASS = "PhFileMagnifyingGlass"
+    FILE_SEARCH = "PhFileSearch"  # Deprecated: use FILE_MAGNIFYING_GLASS
     FILE_MD = "PhFileMd"
     FILE_MINUS = "PhFileMinus"
     FILE_PDF = "PhFilePdf"
@@ -1059,6 +1066,7 @@ class AtlanIcon(str, Enum):
     FOLDER = "PhFolder"
     FOLDERS = "PhFolders"
     FOLDER_DASHED = "PhFolderDashed"
+    FOLDER_DOTTED = "PhFolderDotted"  # Deprecated: use FOLDER_DASHED
     FOLDER_LOCK = "PhFolderLock"
     FOLDER_MINUS = "PhFolderMinus"
     FOLDER_NOTCH = "PhFolderNotch"
@@ -1069,6 +1077,7 @@ class AtlanIcon(str, Enum):
     FOLDER_PLUS = "PhFolderPlus"
     FOLDER_SIMPLE = "PhFolderSimple"
     FOLDER_SIMPLE_DASHED = "PhFolderSimpleDashed"
+    FOLDER_SIMPLE_DOTTED = "PhFolderSimpleDotted"  # Deprecated: use FOLDER_SIMPLE_DASHED
     FOLDER_SIMPLE_LOCK = "PhFolderSimpleLock"
     FOLDER_SIMPLE_MINUS = "PhFolderSimpleMinus"
     FOLDER_SIMPLE_PLUS = "PhFolderSimplePlus"
@@ -1462,6 +1471,7 @@ class AtlanIcon(str, Enum):
     PEN_NIB_STRAIGHT = "PhPenNibStraight"
     PEPPER = "PhPepper"
     PERCENT = "PhPercent"
+    PEDESTRIAN = "PhPedestrian"  # Deprecated: use PERSON
     PERSON = "PhPerson"
     PERSON_ARMS_SPREAD = "PhPersonArmsSpread"
     PERSON_SIMPLE = "PhPersonSimple"
@@ -1770,6 +1780,7 @@ class AtlanIcon(str, Enum):
     TEXT_ALIGN_RIGHT = "PhTextAlignRight"
     TEXT_A_UNDERLINE = "PhTextAUnderline"
     TEXT_B = "PhTextB"
+    TEXT_BOLDER = "PhTextBolder"  # Deprecated: use TEXT_B
     TEXT_COLUMNS = "PhTextColumns"
     TEXT_H = "PhTextH"
     TEXT_H_FIVE = "PhTextHFive"

--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -1077,7 +1077,9 @@ class AtlanIcon(str, Enum):
     FOLDER_PLUS = "PhFolderPlus"
     FOLDER_SIMPLE = "PhFolderSimple"
     FOLDER_SIMPLE_DASHED = "PhFolderSimpleDashed"
-    FOLDER_SIMPLE_DOTTED = "PhFolderSimpleDotted"  # Deprecated: use FOLDER_SIMPLE_DASHED
+    FOLDER_SIMPLE_DOTTED = (
+        "PhFolderSimpleDotted"  # Deprecated: use FOLDER_SIMPLE_DASHED
+    )
     FOLDER_SIMPLE_LOCK = "PhFolderSimpleLock"
     FOLDER_SIMPLE_MINUS = "PhFolderSimpleMinus"
     FOLDER_SIMPLE_PLUS = "PhFolderSimplePlus"

--- a/tests/unit/model/icon_enum_test.py
+++ b/tests/unit/model/icon_enum_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from pyatlan.model.enums import AtlanIcon
 
-
 # Mapping of deprecated enum names to their string values
 DEPRECATED_ICONS = {
     "ACTIVITY": "PhActivity",
@@ -54,15 +53,11 @@ class TestDeprecatedIconsExist:
 class TestReplacementIconsExist:
     """Each deprecated icon has a valid replacement in the enum."""
 
-    @pytest.mark.parametrize(
-        "deprecated,replacement", REPLACEMENT_MAP.items()
-    )
+    @pytest.mark.parametrize("deprecated,replacement", REPLACEMENT_MAP.items())
     def test_replacement_exists(self, deprecated, replacement):
         assert replacement in AtlanIcon.__members__
 
-    @pytest.mark.parametrize(
-        "deprecated,replacement", REPLACEMENT_MAP.items()
-    )
+    @pytest.mark.parametrize("deprecated,replacement", REPLACEMENT_MAP.items())
     def test_deprecated_and_replacement_are_different_values(
         self, deprecated, replacement
     ):

--- a/tests/unit/model/icon_enum_test.py
+++ b/tests/unit/model/icon_enum_test.py
@@ -1,0 +1,84 @@
+"""Tests for AtlanIcon enum — deprecated Phosphor icon backward compat (BLDX-1096)."""
+
+import pytest
+
+from pyatlan.model.enums import AtlanIcon
+
+
+# Mapping of deprecated enum names to their string values
+DEPRECATED_ICONS = {
+    "ACTIVITY": "PhActivity",
+    "CIRCLE_WAVY": "PhCircleWavy",
+    "CIRCLE_WAVY_CHECK": "PhCircleWavyCheck",
+    "CIRCLE_WAVY_QUESTION": "PhCircleWavyQuestion",
+    "CIRCLE_WAVY_WARNING": "PhCircleWavyWarning",
+    "FILE_DOTTED": "PhFileDotted",
+    "FILE_SEARCH": "PhFileSearch",
+    "FOLDER_DOTTED": "PhFolderDotted",
+    "FOLDER_SIMPLE_DOTTED": "PhFolderSimpleDotted",
+    "PEDESTRIAN": "PhPedestrian",
+    "TEXT_BOLDER": "PhTextBolder",
+}
+
+# Mapping of deprecated → replacement enum names
+REPLACEMENT_MAP = {
+    "ACTIVITY": "PULSE",
+    "CIRCLE_WAVY": "SEAL",
+    "CIRCLE_WAVY_CHECK": "SEAL_CHECK",
+    "CIRCLE_WAVY_QUESTION": "SEAL_QUESTION",
+    "CIRCLE_WAVY_WARNING": "SEAL_WARNING",
+    "FILE_DOTTED": "FILE_DASHED",
+    "FILE_SEARCH": "FILE_MAGNIFYING_GLASS",
+    "FOLDER_DOTTED": "FOLDER_DASHED",
+    "FOLDER_SIMPLE_DOTTED": "FOLDER_SIMPLE_DASHED",
+    "PEDESTRIAN": "PERSON",
+    "TEXT_BOLDER": "TEXT_B",
+}
+
+
+class TestDeprecatedIconsExist:
+    """All deprecated Phosphor icon names must be valid AtlanIcon enum members."""
+
+    @pytest.mark.parametrize("name,value", DEPRECATED_ICONS.items())
+    def test_deprecated_icon_exists_in_enum(self, name, value):
+        icon = AtlanIcon[name]
+        assert icon.value == value
+
+    @pytest.mark.parametrize("name,value", DEPRECATED_ICONS.items())
+    def test_deprecated_icon_deserializes_from_value(self, name, value):
+        """Simulates deserialization — looking up by string value."""
+        icon = AtlanIcon(value)
+        assert icon.name == name
+
+
+class TestReplacementIconsExist:
+    """Each deprecated icon has a valid replacement in the enum."""
+
+    @pytest.mark.parametrize(
+        "deprecated,replacement", REPLACEMENT_MAP.items()
+    )
+    def test_replacement_exists(self, deprecated, replacement):
+        assert replacement in AtlanIcon.__members__
+
+    @pytest.mark.parametrize(
+        "deprecated,replacement", REPLACEMENT_MAP.items()
+    )
+    def test_deprecated_and_replacement_are_different_values(
+        self, deprecated, replacement
+    ):
+        """Deprecated and replacement icons have different string values."""
+        assert AtlanIcon[deprecated].value != AtlanIcon[replacement].value
+
+
+class TestIconEnumIntegrity:
+    """General enum health checks."""
+
+    def test_no_duplicate_values(self):
+        """All enum values must be unique."""
+        values = [icon.value for icon in AtlanIcon]
+        assert len(values) == len(set(values)), "Duplicate values found in AtlanIcon"
+
+    def test_all_values_are_non_empty(self):
+        """All AtlanIcon values must be non-empty strings."""
+        for icon in AtlanIcon:
+            assert icon.value, f"{icon.name} has empty value"


### PR DESCRIPTION
## Summary
Add 11 deprecated Phosphor icon values to AtlanIcon enum for backward compatibility. Customers with tag/CM definitions using old icon names (e.g. PhCircleWavyWarning) cause SDK deserialization failure — one unrecognized icon breaks all tag resolution for the entire export.

## Changes
Added 11 deprecated entries to pyatlan/model/enums.py AtlanIcon enum, each with # Deprecated: use <replacement> comment. 46 new unit tests.

## Linear
https://linear.app/atlan-epd/issue/BLDX-1096