### PR TITLE
refactor: address review comments for GOVFOUN-408 pool timeout fix

### DIFF
--- a/pyatlan/client/atlan.py
+++ b/pyatlan/client/atlan.py
@@ -121,6 +121,17 @@ DEFAULT_RETRY = Retry(
 
 VERSION = read_text("pyatlan", "version.txt").strip()
 
+# Connection pool configuration (GOVFOUN-408).
+# keepalive_expiry=30s < nginx keepalive_timeout=75s → client retires idle
+# connections before nginx sends FIN, preventing CLOSE_WAIT accumulation.
+# pool timeout=30s → threads raise PoolTimeout instead of blocking forever.
+_DEFAULT_POOL_LIMITS = httpx.Limits(
+    max_connections=50,
+    max_keepalive_connections=10,
+    keepalive_expiry=30.0,
+)
+_DEFAULT_POOL_TIMEOUT_SECONDS = 30.0
+
 
 def log_response(response, *args, **kwargs):
     LOGGER.debug("HTTP Status: %s", response.status_code)
@@ -216,11 +227,7 @@ class AtlanClient(BaseSettings):
             transport=PyatlanSyncTransport(
                 retry=self.retry,
                 client=self,
-                limits=httpx.Limits(
-                    max_connections=50,
-                    max_keepalive_connections=10,
-                    keepalive_expiry=30.0,
-                ),
+                limits=_DEFAULT_POOL_LIMITS,
                 **transport_kwargs,
             ),
             headers={
@@ -293,8 +300,8 @@ class AtlanClient(BaseSettings):
         """Close and rebuild the HTTP session to recover from a degraded connection pool."""
         try:
             self._session.close()
-        except Exception:
-            pass
+        except Exception as e:
+            LOGGER.debug("Failed to close old HTTP session: %s", e)
         transport_kwargs = {}
         if self.proxy is not None:
             transport_kwargs["proxy"] = self.proxy
@@ -304,11 +311,7 @@ class AtlanClient(BaseSettings):
             transport=PyatlanSyncTransport(
                 retry=self.retry,
                 client=self,
-                limits=httpx.Limits(
-                    max_connections=50,
-                    max_keepalive_connections=10,
-                    keepalive_expiry=30.0,
-                ),
+                limits=_DEFAULT_POOL_LIMITS,
                 **transport_kwargs,
             ),
             headers={
@@ -322,7 +325,7 @@ class AtlanClient(BaseSettings):
             event_hooks={"response": [log_response]},
         )
         self._401_has_retried.set(False)
-        LOGGER.warning("HTTP session reset: new connection pool created")
+        LOGGER.info("HTTP session reset: new connection pool created")
 
     @property
     def admin(self) -> AdminClient:
@@ -599,7 +602,7 @@ class AtlanClient(BaseSettings):
                 None,
                 connect=self.connect_timeout,
                 read=self.read_timeout,
-                pool=30.0,
+                pool=_DEFAULT_POOL_TIMEOUT_SECONDS,
             )
             if binary_data:
                 response = self._session.request(
@@ -2061,11 +2064,7 @@ class AtlanClient(BaseSettings):
         new_transport = PyatlanSyncTransport(
             retry=max_retries,
             client=self,
-            limits=httpx.Limits(
-                max_connections=50,
-                max_keepalive_connections=10,
-                keepalive_expiry=30.0,
-            ),
+            limits=_DEFAULT_POOL_LIMITS,
             **transport_kwargs,
         )
         self._session._transport = new_transport

--- a/tests/integration/test_connection_pool_config.py
+++ b/tests/integration/test_connection_pool_config.py
@@ -27,7 +27,12 @@ from pyatlan.client.transport import PyatlanSyncTransport
 
 
 def _get_httpcore_pool(client: AtlanClient):
-    return client._session._transport._transport._pool
+    """Access the underlying httpcore pool. Relies on httpx internals;
+    may need updating if httpx changes its internal structure."""
+    try:
+        return client._session._transport._transport._pool
+    except AttributeError:
+        pytest.skip("httpx internal structure changed; update test helper")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_connection_pool_config.py
+++ b/tests/integration/test_connection_pool_config.py
@@ -30,7 +30,7 @@ def _get_httpcore_pool(client: AtlanClient):
     """Access the underlying httpcore pool. Relies on httpx internals;
     may need updating if httpx changes its internal structure."""
     try:
-        return client._session._transport._transport._pool
+        return client._session._transport._transport._pool  # type: ignore[attr-defined]
     except AttributeError:
         pytest.skip("httpx internal structure changed; update test helper")
 

--- a/tests/unit/test_connection_pool_config.py
+++ b/tests/unit/test_connection_pool_config.py
@@ -21,7 +21,11 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from pyatlan.client.atlan import AtlanClient
+from pyatlan.client.atlan import (
+    AtlanClient,
+    _DEFAULT_POOL_LIMITS,
+    _DEFAULT_POOL_TIMEOUT_SECONDS,
+)
 from pyatlan.client.transport import PyatlanSyncTransport
 from pyatlan.model.assets import AtlasGlossary
 
@@ -53,9 +57,14 @@ def _trigger_api_call(client: AtlanClient) -> None:
 
 
 def _get_httpcore_pool(client: AtlanClient):
-    transport = client._session._transport
-    assert isinstance(transport, PyatlanSyncTransport)
-    return transport._transport._pool
+    """Access the underlying httpcore pool. Relies on httpx internals;
+    may need updating if httpx changes its internal structure."""
+    try:
+        transport = client._session._transport
+        assert isinstance(transport, PyatlanSyncTransport)
+        return transport._transport._pool
+    except AttributeError:
+        pytest.skip("httpx internal structure changed; update test helper")
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +79,7 @@ def test_pool_timeout_is_30_seconds(mock_session, client):
     _trigger_api_call(client)
     assert mock_session.request.called, "no HTTP request was made"
     timeout = mock_session.request.call_args.kwargs["timeout"]
-    assert timeout.pool == 30.0
+    assert timeout.pool == _DEFAULT_POOL_TIMEOUT_SECONDS
 
 
 @patch.object(AtlanClient, "_session")
@@ -120,17 +129,17 @@ def test_pool_timeout_propagates_not_hangs(mock_session, client):
 
 def test_transport_max_connections_is_50(client):
     """max_connections=50 reduces blast radius when CLOSE_WAIT sockets accumulate."""
-    assert _get_httpcore_pool(client)._max_connections == 50
+    assert _get_httpcore_pool(client)._max_connections == _DEFAULT_POOL_LIMITS.max_connections
 
 
 def test_transport_keepalive_expiry_is_30_seconds(client):
     """keepalive_expiry=30.0 — client closes idle connections before nginx's 75s FIN."""
-    assert _get_httpcore_pool(client)._keepalive_expiry == 30.0
+    assert _get_httpcore_pool(client)._keepalive_expiry == _DEFAULT_POOL_LIMITS.keepalive_expiry
 
 
 def test_transport_max_keepalive_connections_is_10(client):
     """max_keepalive_connections=10 bounds idle connections held in the pool."""
-    assert _get_httpcore_pool(client)._max_keepalive_connections == 10
+    assert _get_httpcore_pool(client)._max_keepalive_connections == _DEFAULT_POOL_LIMITS.max_keepalive_connections
 
 
 # ---------------------------------------------------------------------------
@@ -201,9 +210,9 @@ class TestResetHttpSession:
     def test_new_session_has_correct_limits(self, client):
         """New session must use the same pool limits as the initial session."""
         client.reset_http_session()
-        assert _get_httpcore_pool(client)._max_connections == 50
-        assert _get_httpcore_pool(client)._keepalive_expiry == 30.0
-        assert _get_httpcore_pool(client)._max_keepalive_connections == 10
+        assert _get_httpcore_pool(client)._max_connections == _DEFAULT_POOL_LIMITS.max_connections
+        assert _get_httpcore_pool(client)._keepalive_expiry == _DEFAULT_POOL_LIMITS.keepalive_expiry
+        assert _get_httpcore_pool(client)._max_keepalive_connections == _DEFAULT_POOL_LIMITS.max_keepalive_connections
 
     def test_closes_old_session(self, client):
         """reset_http_session() calls close() on the old session before replacing it."""

--- a/tests/unit/test_connection_pool_config.py
+++ b/tests/unit/test_connection_pool_config.py
@@ -22,9 +22,9 @@ import httpx
 import pytest
 
 from pyatlan.client.atlan import (
-    AtlanClient,
     _DEFAULT_POOL_LIMITS,
     _DEFAULT_POOL_TIMEOUT_SECONDS,
+    AtlanClient,
 )
 from pyatlan.client.transport import PyatlanSyncTransport
 from pyatlan.model.assets import AtlasGlossary
@@ -129,17 +129,26 @@ def test_pool_timeout_propagates_not_hangs(mock_session, client):
 
 def test_transport_max_connections_is_50(client):
     """max_connections=50 reduces blast radius when CLOSE_WAIT sockets accumulate."""
-    assert _get_httpcore_pool(client)._max_connections == _DEFAULT_POOL_LIMITS.max_connections
+    assert (
+        _get_httpcore_pool(client)._max_connections
+        == _DEFAULT_POOL_LIMITS.max_connections
+    )
 
 
 def test_transport_keepalive_expiry_is_30_seconds(client):
     """keepalive_expiry=30.0 — client closes idle connections before nginx's 75s FIN."""
-    assert _get_httpcore_pool(client)._keepalive_expiry == _DEFAULT_POOL_LIMITS.keepalive_expiry
+    assert (
+        _get_httpcore_pool(client)._keepalive_expiry
+        == _DEFAULT_POOL_LIMITS.keepalive_expiry
+    )
 
 
 def test_transport_max_keepalive_connections_is_10(client):
     """max_keepalive_connections=10 bounds idle connections held in the pool."""
-    assert _get_httpcore_pool(client)._max_keepalive_connections == _DEFAULT_POOL_LIMITS.max_keepalive_connections
+    assert (
+        _get_httpcore_pool(client)._max_keepalive_connections
+        == _DEFAULT_POOL_LIMITS.max_keepalive_connections
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +170,9 @@ def _capture_transport_limits(client: AtlanClient) -> httpx.Limits:
         with client.max_retries():
             pass
 
-    assert "limits" in captured, "max_retries did not pass limits to PyatlanSyncTransport"
+    assert "limits" in captured, (
+        "max_retries did not pass limits to PyatlanSyncTransport"
+    )
     return captured["limits"]
 
 
@@ -210,9 +221,18 @@ class TestResetHttpSession:
     def test_new_session_has_correct_limits(self, client):
         """New session must use the same pool limits as the initial session."""
         client.reset_http_session()
-        assert _get_httpcore_pool(client)._max_connections == _DEFAULT_POOL_LIMITS.max_connections
-        assert _get_httpcore_pool(client)._keepalive_expiry == _DEFAULT_POOL_LIMITS.keepalive_expiry
-        assert _get_httpcore_pool(client)._max_keepalive_connections == _DEFAULT_POOL_LIMITS.max_keepalive_connections
+        assert (
+            _get_httpcore_pool(client)._max_connections
+            == _DEFAULT_POOL_LIMITS.max_connections
+        )
+        assert (
+            _get_httpcore_pool(client)._keepalive_expiry
+            == _DEFAULT_POOL_LIMITS.keepalive_expiry
+        )
+        assert (
+            _get_httpcore_pool(client)._max_keepalive_connections
+            == _DEFAULT_POOL_LIMITS.max_keepalive_connections
+        )
 
     def test_closes_old_session(self, client):
         """reset_http_session() calls close() on the old session before replacing it."""
@@ -223,6 +243,7 @@ class TestResetHttpSession:
 
     def test_resets_401_retry_flag(self, client):
         """_401_has_retried ContextVar must be reset to False after session rebuild."""
+
         def _run():
             client._401_has_retried.set(True)
             client.reset_http_session()
@@ -245,8 +266,9 @@ class TestResetHttpSession:
 
         # Patch httpx.HTTPTransport so it doesn't try to load the fake cert file
         # from disk — we only need to verify the kwargs are forwarded correctly.
-        with patch.object(PyatlanSyncTransport, "__init__", capturing_init), patch(
-            "httpx.HTTPTransport", Mock(return_value=Mock())
+        with (
+            patch.object(PyatlanSyncTransport, "__init__", capturing_init),
+            patch("httpx.HTTPTransport", Mock(return_value=Mock())),
         ):
             client.reset_http_session()
 


### PR DESCRIPTION
## Summary

Follow-up to PR #911 (GOVFOUN-408) which was merged before review fixes could be applied.

### Changes

1. **Extract `_DEFAULT_POOL_LIMITS` and `_DEFAULT_POOL_TIMEOUT_SECONDS`** — same Limits repeated 4x, now defined once at module level
2. **Log old session close at DEBUG** — bare `except: pass` → `except as e: LOGGER.debug(...)`
3. **`LOGGER.warning` → `LOGGER.info`** for `reset_http_session()` (expected recovery, not error)
4. **Resilient `_get_httpcore_pool` test helper** — `pytest.skip()` fallback if httpx internals change
5. **Test assertions use constants** — auto-update if pool values are tuned

### Tests
62/62 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)