### PR TITLE
fix: DbtProcess/DbtColumnProcess parents + typing.get_type_hints shim (SHA-887)

### DIFF
--- a/pyatlan/generator/class_generator.py
+++ b/pyatlan/generator/class_generator.py
@@ -99,8 +99,68 @@ TEMPLATES_DIR = PARENT / "templates"
 # applies when the named supertype is actually present in the typedef,
 # so a typedef change that drops it won't silently break.
 _SUPERCLASS_OVERRIDES: Dict[str, str] = {
+    # SHA-887: dbt-semantic types — Atlas typedef lists ``Dbt`` first but the
+    # publish-app ordering graph (and the asset's true type hierarchy) needs
+    # the semantic-family parent.
     "DbtMeasure": "SemanticMeasure",
+    # SHA-887 follow-up: dbt-process types — Atlas lists ``Dbt`` first but the
+    # publish-app's ``issubclass(cls, Process)`` / ``issubclass(cls,
+    # ColumnProcess)`` checks (used to identify "lineage types" that must
+    # publish *after* the entities they reference) need the process-family
+    # parent. Mis-ordering causes ATLAS-404 on dbt and SAP BW connectors.
+    "DbtProcess": "Process",
+    "DbtColumnProcess": "ColumnProcess",
 }
+
+# Per-module runtime injection overrides for typing.get_type_hints()
+# compatibility. Keyed by core asset module name; each value is the list of
+# class names whose imports are gated under ``if TYPE_CHECKING:`` in that
+# module's source (to break circular imports). After all assets load,
+# ``core/__init__.py`` writes these names back into each module's __dict__
+# so downstream tools (e.g. atlan-publish-app's ordering graph) can resolve
+# the field annotations without supplying a custom ``localns``. Keep this in
+# sync with the ``if TYPE_CHECKING:`` blocks in ``templates/module.jinja2``.
+_RUNTIME_INJECTION_OVERRIDES: Dict[str, List[str]] = {
+    "data_product": ["StarburstDataset"],
+    "data_quality_rule": ["Column"],
+    "process": ["Procedure", "BigqueryRoutine", "FabricActivity", "Function"],
+    "s_q_l": ["DbtTest"],
+    "schema": ["SnowflakeDynamicTable", "Table"],
+}
+
+
+def _build_runtime_injection_block(overrides: Dict[str, List[str]]) -> str:
+    """Render the typing.get_type_hints() compatibility shim for ``core/__init__.py``.
+
+    Built in Python (rather than Jinja loops) so newline handling stays
+    predictable. Returns an empty string when ``overrides`` is empty so the
+    template emits no shim section.
+    """
+    if not overrides:
+        return ""
+    lines = [
+        "",
+        "# typing.get_type_hints() compatibility shim",
+        "#",
+        "# Some Attributes classes reference cross-module relationship types whose",
+        "# imports must stay under TYPE_CHECKING to avoid circular imports at module",
+        "# load time. Pydantic v1 resolves these forward refs via update_forward_refs()",
+        "# above, but typing.get_type_hints() does its own resolution against each",
+        "# class's defining module __dict__ — which doesn't see TYPE_CHECKING-only",
+        "# names. Inject the resolved classes back into the affected modules now that",
+        "# all assets have loaded so downstream tooling (e.g. atlan-publish-app's",
+        "# ordering graph) can call typing.get_type_hints() without a custom localns.",
+    ]
+    for module_name in sorted(overrides):
+        lines.append(f"from . import {module_name} as _{module_name}_module")
+    lines.append("")
+    for module_name in sorted(overrides):
+        for class_name in overrides[module_name]:
+            lines.append(
+                f"_{module_name}_module.{class_name} = {class_name}  "
+                "# type: ignore[misc]"
+            )
+    return "\n".join(lines)
 
 
 def get_type(type_: str):
@@ -935,9 +995,19 @@ class Generator:
                 import_line += "  # isort: skip"
             asset_imports.append(import_line)
 
+        # Build the typing.get_type_hints() compatibility shim block as a
+        # single string — easier to control whitespace than nested Jinja loops.
+        runtime_injection_block = _build_runtime_injection_block(
+            _RUNTIME_INJECTION_OVERRIDES
+        )
+
         template = self.environment.get_template("core/init.jinja2")
         content = template.render(
-            {"asset_imports": asset_imports, "asset_names": asset_names}
+            {
+                "asset_imports": asset_imports,
+                "asset_names": asset_names,
+                "runtime_injection_block": runtime_injection_block,
+            }
         )
 
         init_path = CORE_ASSETS_DIR / "__init__.py"

--- a/pyatlan/generator/templates/core/init.jinja2
+++ b/pyatlan/generator/templates/core/init.jinja2
@@ -13,3 +13,5 @@ localns = locals()
 {%- for asset_name in asset_names %}
 {{ asset_name }}.Attributes.update_forward_refs(**localns)
 {%- endfor %}
+
+{{ runtime_injection_block }}

--- a/pyatlan/model/assets/core/__init__.py
+++ b/pyatlan/model/assets/core/__init__.py
@@ -400,3 +400,55 @@ BigqueryRoutine.Attributes.update_forward_refs(**localns)
 DatabricksVolume.Attributes.update_forward_refs(**localns)
 DatabricksVolumePath.Attributes.update_forward_refs(**localns)
 GCPDataplexAspectType.Attributes.update_forward_refs(**localns)
+
+# typing.get_type_hints() compatibility shim
+#
+# Some Attributes classes reference cross-module relationship types whose
+# imports must stay under TYPE_CHECKING to avoid circular imports at module
+# load time. Pydantic v1 resolves these forward refs via update_forward_refs()
+# above, but typing.get_type_hints() does its own resolution against each
+# class's defining module __dict__ — which doesn't see TYPE_CHECKING-only
+# names. Inject the resolved classes back into the affected modules now that
+# all assets have loaded so downstream tooling (e.g. atlan-publish-app's
+# ordering graph) can call typing.get_type_hints() without a custom localns.
+from . import data_product as _data_product_module
+from . import data_quality_rule as _data_quality_rule_module
+from . import process as _process_module
+from . import s_q_l as _s_q_l_module
+from . import schema as _schema_module
+
+_data_product_module.StarburstDataset = StarburstDataset  # type: ignore[misc]
+_data_quality_rule_module.Column = Column  # type: ignore[misc]
+_process_module.Procedure = Procedure  # type: ignore[misc]
+_process_module.BigqueryRoutine = BigqueryRoutine  # type: ignore[misc]
+_process_module.FabricActivity = FabricActivity  # type: ignore[misc]
+_process_module.Function = Function  # type: ignore[misc]
+_s_q_l_module.DbtTest = DbtTest  # type: ignore[misc]
+_schema_module.SnowflakeDynamicTable = SnowflakeDynamicTable  # type: ignore[misc]
+_schema_module.Table = Table  # type: ignore[misc]
+
+# typing.get_type_hints() compatibility shim
+#
+# Some Attributes classes reference cross-module relationship types whose
+# imports must stay under TYPE_CHECKING to avoid circular imports at module
+# load time. Pydantic v1 resolves these forward refs via update_forward_refs()
+# above, but typing.get_type_hints() does its own resolution against each
+# class's defining module __dict__ — which doesn't see TYPE_CHECKING-only
+# names. Inject the resolved classes back into the affected modules now that
+# all assets have loaded so downstream tooling (e.g. atlan-publish-app's
+# ordering graph) can call typing.get_type_hints() without a custom localns.
+from . import data_product as _data_product_module
+from . import data_quality_rule as _data_quality_rule_module
+from . import process as _process_module
+from . import s_q_l as _s_q_l_module
+from . import schema as _schema_module
+
+_data_product_module.StarburstDataset = StarburstDataset  # type: ignore[misc]
+_data_quality_rule_module.Column = Column  # type: ignore[misc]
+_process_module.Procedure = Procedure  # type: ignore[misc]
+_process_module.BigqueryRoutine = BigqueryRoutine  # type: ignore[misc]
+_process_module.FabricActivity = FabricActivity  # type: ignore[misc]
+_process_module.Function = Function  # type: ignore[misc]
+_s_q_l_module.DbtTest = DbtTest  # type: ignore[misc]
+_schema_module.SnowflakeDynamicTable = SnowflakeDynamicTable  # type: ignore[misc]
+_schema_module.Table = Table  # type: ignore[misc]

--- a/pyatlan/model/assets/dbt_column_process.py
+++ b/pyatlan/model/assets/dbt_column_process.py
@@ -20,10 +20,10 @@ from pyatlan.model.fields.atlan_fields import (
 )
 from pyatlan.model.structs import DbtJobRun
 
-from .core.dbt import Dbt
+from .core.column_process import ColumnProcess
 
 
-class DbtColumnProcess(Dbt):
+class DbtColumnProcess(ColumnProcess):
     """Description"""
 
     type_name: str = Field(default="DbtColumnProcess", allow_mutation=False)
@@ -771,7 +771,7 @@ class DbtColumnProcess(Dbt):
             self.attributes = self.Attributes()
         self.attributes.column_processes = column_processes
 
-    class Attributes(Dbt.Attributes):
+    class Attributes(ColumnProcess.Attributes):
         dbt_column_process_job_status: Optional[str] = Field(
             default=None, description=""
         )

--- a/pyatlan/model/assets/dbt_process.py
+++ b/pyatlan/model/assets/dbt_process.py
@@ -20,10 +20,10 @@ from pyatlan.model.fields.atlan_fields import (
 )
 from pyatlan.model.structs import DbtInputContext, DbtJobRun
 
-from .core.dbt import Dbt
+from .core.process import Process
 
 
-class DbtProcess(Dbt):
+class DbtProcess(Process):
     """Description"""
 
     type_name: str = Field(default="DbtProcess", allow_mutation=False)
@@ -773,7 +773,7 @@ class DbtProcess(Dbt):
             self.attributes = self.Attributes()
         self.attributes.column_processes = column_processes
 
-    class Attributes(Dbt.Attributes):
+    class Attributes(Process.Attributes):
         dbt_process_job_status: Optional[str] = Field(default=None, description="")
         dbt_upstream_contexts: Optional[List[DbtInputContext]] = Field(
             default=None, description=""

--- a/tests/unit/model/dbt_column_process_test.py
+++ b/tests/unit/model/dbt_column_process_test.py
@@ -1,0 +1,64 @@
+"""Regression tests for SHA-887 follow-up — DbtColumnProcess must extend
+ColumnProcess, not Dbt.
+
+The Atlas typedef for DbtColumnProcess declares
+``superTypes=["Dbt", "ColumnProcess"]``. Without an override the class
+generator picks ``Dbt`` (``super_types[0]``) and publish-app's
+``issubclass(cls, ColumnProcess)`` check — used to identify column-level
+lineage types — returns False. DbtColumnProcess then lands in the wrong
+publish batch and ATLAS-404s on the columns it references.
+
+The override lives in ``pyatlan/generator/class_generator.py``
+(``_SUPERCLASS_OVERRIDES``). These tests guard the generated output so a
+future regeneration that drops the override fails CI rather than silently
+regressing publish ordering.
+"""
+
+import pytest
+
+from pyatlan.model.assets import ColumnProcess, Dbt, DbtColumnProcess
+
+
+def test_dbt_column_process_extends_column_process():
+    """DbtColumnProcess must inherit from ColumnProcess so publish-app
+    treats it as a column-level lineage type."""
+    assert issubclass(DbtColumnProcess, ColumnProcess)
+
+
+def test_dbt_column_process_does_not_extend_dbt():
+    """Negative guard: extending Dbt re-introduces the wrong-batch ordering bug."""
+    assert not issubclass(DbtColumnProcess, Dbt)
+
+
+def test_dbt_column_process_direct_parent_is_column_process():
+    """The Python parent (not just an ancestor) must be ColumnProcess."""
+    assert DbtColumnProcess.__bases__[0] is ColumnProcess
+
+
+def test_dbt_column_process_type_name():
+    """Ensure the wire ``type_name`` is preserved despite the parent change."""
+    sut = DbtColumnProcess()
+    assert sut.type_name == "DbtColumnProcess"
+
+
+def test_dbt_column_process_type_name_is_immutable():
+    sut = DbtColumnProcess()
+    with pytest.raises(TypeError):
+        sut.type_name = "NotDbtColumnProcess"
+
+
+def test_dbt_attributes_round_trip():
+    """Dbt-specific fields are still declared inline on
+    DbtColumnProcess.Attributes."""
+    sut = DbtColumnProcess()
+    sut.attributes = DbtColumnProcess.Attributes(dbt_alias="x", dbt_unique_id="y")
+    assert sut.attributes.dbt_alias == "x"
+    assert sut.attributes.dbt_unique_id == "y"
+
+
+def test_column_process_attributes_round_trip():
+    """ColumnProcess-specific fields inherited via ColumnProcess.Attributes
+    are accessible."""
+    sut = DbtColumnProcess()
+    sut.attributes = DbtColumnProcess.Attributes(code="cast(foo as int)")
+    assert sut.attributes.code == "cast(foo as int)"

--- a/tests/unit/model/dbt_process_test.py
+++ b/tests/unit/model/dbt_process_test.py
@@ -1,0 +1,61 @@
+"""Regression tests for SHA-887 follow-up — DbtProcess must extend Process, not Dbt.
+
+The Atlas typedef for DbtProcess declares ``superTypes=["Dbt", "Process"]``.
+Without an override the class generator picks ``Dbt`` (``super_types[0]``)
+and publish-app's ``issubclass(cls, Process)`` check — which decides whether
+a type is a "lineage type" that must publish after the entities it references
+— returns False. DbtProcess then lands in Batch 1 and ATLAS-404s when
+referencing later-batch entities (DbtModel, Column, etc.).
+
+The override lives in ``pyatlan/generator/class_generator.py``
+(``_SUPERCLASS_OVERRIDES``). These tests guard the generated output so a
+future regeneration that drops the override fails CI rather than silently
+regressing publish ordering.
+"""
+
+import pytest
+
+from pyatlan.model.assets import Dbt, DbtProcess, Process
+
+
+def test_dbt_process_extends_process():
+    """DbtProcess must inherit from Process so publish-app treats it as a
+    lineage type (publish-after-references)."""
+    assert issubclass(DbtProcess, Process)
+
+
+def test_dbt_process_does_not_extend_dbt():
+    """Negative guard: extending Dbt re-introduces the Batch-1 ordering bug."""
+    assert not issubclass(DbtProcess, Dbt)
+
+
+def test_dbt_process_direct_parent_is_process():
+    """The Python parent (not just an ancestor) must be Process."""
+    assert DbtProcess.__bases__[0] is Process
+
+
+def test_dbt_process_type_name():
+    """Ensure the wire ``type_name`` is preserved despite the parent change."""
+    sut = DbtProcess()
+    assert sut.type_name == "DbtProcess"
+
+
+def test_dbt_process_type_name_is_immutable():
+    sut = DbtProcess()
+    with pytest.raises(TypeError):
+        sut.type_name = "NotDbtProcess"
+
+
+def test_dbt_attributes_round_trip():
+    """Dbt-specific fields are still declared inline on DbtProcess.Attributes."""
+    sut = DbtProcess()
+    sut.attributes = DbtProcess.Attributes(dbt_alias="x", dbt_unique_id="y")
+    assert sut.attributes.dbt_alias == "x"
+    assert sut.attributes.dbt_unique_id == "y"
+
+
+def test_process_attributes_round_trip():
+    """Process-specific fields inherited via Process.Attributes are accessible."""
+    sut = DbtProcess()
+    sut.attributes = DbtProcess.Attributes(code="select * from foo")
+    assert sut.attributes.code == "select * from foo"

--- a/tests/unit/model/get_type_hints_compat_test.py
+++ b/tests/unit/model/get_type_hints_compat_test.py
@@ -1,0 +1,76 @@
+"""Regression tests for SHA-887 follow-up — ``typing.get_type_hints()`` must
+work for every core asset's ``Attributes`` inner class.
+
+Five core asset modules gate cross-module relationship-type imports under
+``if TYPE_CHECKING:`` to avoid circular imports at module load time. With
+``from __future__ import annotations`` (PEP 563), all field annotations are
+stored as strings, and ``typing.get_type_hints`` evaluates them against the
+defining class's module ``__dict__``. That namespace doesn't see
+TYPE_CHECKING-only names, so calls fail with ``NameError`` (e.g.
+``name 'DbtTest' is not defined`` for ``Table.Attributes``).
+
+Pydantic v1 already resolves these forward refs internally via
+``update_forward_refs(**localns)`` in ``core/__init__.py``, but
+``typing.get_type_hints`` is a separate code path used by reflection-based
+tools (notably ``atlan-publish-app``'s publish-ordering graph). To make
+``get_type_hints`` work without a caller-supplied ``localns``,
+``core/__init__.py`` injects each TYPE_CHECKING-only target back into the
+defining module's ``__dict__`` after every asset has loaded.
+
+The injection list is generated from
+``class_generator._RUNTIME_INJECTION_OVERRIDES``. These tests guard every
+entry — if a future regeneration drops the shim, or if pyatlan adds a new
+TYPE_CHECKING-only relationship import without updating the override map,
+CI fails here rather than silently regressing every downstream consumer.
+"""
+
+from typing import get_type_hints
+
+import pytest
+
+from pyatlan.model.assets.core.data_product import DataProduct
+from pyatlan.model.assets.core.data_quality_rule import DataQualityRule
+from pyatlan.model.assets.core.process import Process
+from pyatlan.model.assets.core.s_q_l import SQL
+from pyatlan.model.assets.core.schema import Schema
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [SQL, Schema, DataProduct, DataQualityRule, Process],
+    ids=["SQL", "Schema", "DataProduct", "DataQualityRule", "Process"],
+)
+def test_get_type_hints_resolves_for_core_attributes(cls):
+    """``get_type_hints`` on each affected ``Attributes`` class must succeed
+    without a caller-supplied ``localns`` — the runtime injection shim in
+    ``core/__init__.py`` makes the TYPE_CHECKING-only names visible."""
+    hints = get_type_hints(cls.Attributes)
+    assert hints, f"{cls.__name__}.Attributes returned no hints"
+
+
+def test_sql_attributes_dbt_tests_resolves_to_dbt_test():
+    """Concrete spot-check: the field that originally tripped publish-app
+    (``SQL.Attributes.dbt_tests``) must resolve to the real ``DbtTest``
+    class rather than raising ``NameError`` on the forward ref."""
+    import typing
+
+    from pyatlan.model.assets.core.dbt_test import DbtTest
+
+    hints = get_type_hints(SQL.Attributes)
+    dbt_tests_hint = hints.get("dbt_tests")
+    assert dbt_tests_hint is not None, "dbt_tests field missing from SQL hints"
+    # The resolved hint is ``Optional[List[DbtTest]]``. Walk the generic
+    # arg tree to confirm the leaf is the actual class, not a string.
+    leaves = []
+    stack = [dbt_tests_hint]
+    while stack:
+        node = stack.pop()
+        args = typing.get_args(node)
+        if args:
+            stack.extend(args)
+        else:
+            leaves.append(node)
+    assert DbtTest in leaves, (
+        f"DbtTest not present in resolved leaves: {leaves} "
+        f"(full hint: {dbt_tests_hint!r})"
+    )


### PR DESCRIPTION
Three SHA-887 follow-ups that all independently break atlan-publish-app's ordering graph against pyatlan v9.x. Bundling them because the symptoms overlap (publish-app order regressions reproduce until the full set lands) and they share the same generator-level mechanism.

## 1. ``DbtProcess`` extends ``Process``, not ``Dbt``

- Atlas typedef: ``superTypes=[\"Dbt\", \"Process\"]``
- Generator picks ``super_types[0]`` → ``Dbt`` → publish-app's ``issubclass(cls, Process)`` check (used to identify lineage types that must publish *after* the entities they reference) returned ``False``.
- ``DbtProcess`` then landed in Batch 1 alongside its upstream entities → ATLAS-404 on ``inputs`` / ``outputs`` lookups in live dbt runs.
- Fix: add ``\"DbtProcess\": \"Process\"`` to ``_SUPERCLASS_OVERRIDES`` in ``class_generator.py`` and patch the generated ``pyatlan/model/assets/dbt_process.py`` source.

## 2. ``DbtColumnProcess`` extends ``ColumnProcess``, not ``Dbt``

- Same root cause: ``superTypes=[\"Dbt\", \"ColumnProcess\"]``.
- Same fix applied to ``pyatlan/model/assets/dbt_column_process.py`` and the override map.

## 3. ``typing.get_type_hints()`` shim for core ``Attributes`` classes

- Five core asset modules (``s_q_l``, ``schema``, ``data_product``, ``data_quality_rule``, ``process``) gate cross-module relationship-type imports under ``if TYPE_CHECKING:`` to avoid circular imports at module load. With ``from __future__ import annotations``, those forward-ref strings can't be resolved by ``typing.get_type_hints()`` against the defining module's ``__dict__`` and the call raises ``NameError`` — e.g. ``name 'DbtTest' is not defined`` for ``Table.Attributes``.
- Pydantic v1's ``update_forward_refs(**localns)`` in ``core/__init__.py`` already handles this for the SDK's own use, but reflection-based downstream tooling (notably ``atlan-publish-app``'s ordering graph) falls through to a degraded fallback that collapses all SQL types into one publish batch.
- Fix: after every asset has loaded, ``core/__init__.py`` injects the resolved classes back into each affected module's ``__dict__`` so ``typing.get_type_hints(cls.Attributes)`` succeeds without a caller-supplied ``localns``.
- A new ``_RUNTIME_INJECTION_OVERRIDES`` constant + ``_build_runtime_injection_block`` helper in ``class_generator.py`` plus a corresponding placeholder in ``templates/core/init.jinja2`` ensure the shim survives regeneration.

## Tests

- ``tests/unit/model/dbt_process_test.py`` — 7 cases (``issubclass`` guards, ``__bases__[0]``, ``type_name`` immutability, ``dbt_*`` + ``Process`` attribute round-trip).
- ``tests/unit/model/dbt_column_process_test.py`` — same 7 cases for the ``ColumnProcess`` parent.
- ``tests/unit/model/get_type_hints_compat_test.py`` — parametrised over all 5 affected core classes plus a concrete spot-check that ``SQL.Attributes.dbt_tests`` resolves to the real ``DbtTest`` class.

## Verified

- [x] ``./qa-checks`` — ruff format / ruff check / mypy all pass
- [x] ``pytest tests/unit -q --ignore=tests/unit/aio`` — 6033 passed, 2 skipped
- [x] Manual ``issubclass`` / ``get_type_hints`` checks against installed pyatlan
- [ ] Downstream verification in atlan-publish-app once this ships: ``DbtProcess`` / ``DbtColumnProcess`` move to a strictly later batch than the entities they reference, and ``typing.get_type_hints()`` resolves on every core ``Attributes`` class without a workaround ``localns``

## Notes

Release notes will be added in the next version bump — ``HISTORY.md`` is left alone here so the already-shipped 9.7.0 section isn't retroactively edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)