### PR TITLE
fix: DbtProcess/DbtColumnProcess extend correct process parent (SHA-887)

### DIFF
--- a/pyatlan/generator/class_generator.py
+++ b/pyatlan/generator/class_generator.py
@@ -99,7 +99,17 @@ TEMPLATES_DIR = PARENT / "templates"
 # applies when the named supertype is actually present in the typedef,
 # so a typedef change that drops it won't silently break.
 _SUPERCLASS_OVERRIDES: Dict[str, str] = {
+    # SHA-887: dbt-semantic types — Atlas typedef lists ``Dbt`` first but
+    # the publish-app ordering graph (and the asset's true type hierarchy)
+    # needs the semantic-family parent.
     "DbtMeasure": "SemanticMeasure",
+    # SHA-887 follow-up: dbt-process types — Atlas lists ``Dbt`` first but
+    # publish-app's ``issubclass(cls, Process)`` / ``issubclass(cls,
+    # ColumnProcess)`` checks (used to identify "lineage types" that must
+    # publish *after* the entities they reference) need the process-family
+    # parent. Mis-ordering causes ATLAS-404 on dbt and SAP BW connectors.
+    "DbtProcess": "Process",
+    "DbtColumnProcess": "ColumnProcess",
 }
 
 

--- a/pyatlan/model/assets/dbt_column_process.py
+++ b/pyatlan/model/assets/dbt_column_process.py
@@ -20,10 +20,10 @@ from pyatlan.model.fields.atlan_fields import (
 )
 from pyatlan.model.structs import DbtJobRun
 
-from .core.dbt import Dbt
+from .core.column_process import ColumnProcess
 
 
-class DbtColumnProcess(Dbt):
+class DbtColumnProcess(ColumnProcess):
     """Description"""
 
     type_name: str = Field(default="DbtColumnProcess", allow_mutation=False)
@@ -771,7 +771,7 @@ class DbtColumnProcess(Dbt):
             self.attributes = self.Attributes()
         self.attributes.column_processes = column_processes
 
-    class Attributes(Dbt.Attributes):
+    class Attributes(ColumnProcess.Attributes):
         dbt_column_process_job_status: Optional[str] = Field(
             default=None, description=""
         )

--- a/pyatlan/model/assets/dbt_process.py
+++ b/pyatlan/model/assets/dbt_process.py
@@ -20,10 +20,10 @@ from pyatlan.model.fields.atlan_fields import (
 )
 from pyatlan.model.structs import DbtInputContext, DbtJobRun
 
-from .core.dbt import Dbt
+from .core.process import Process
 
 
-class DbtProcess(Dbt):
+class DbtProcess(Process):
     """Description"""
 
     type_name: str = Field(default="DbtProcess", allow_mutation=False)
@@ -773,7 +773,7 @@ class DbtProcess(Dbt):
             self.attributes = self.Attributes()
         self.attributes.column_processes = column_processes
 
-    class Attributes(Dbt.Attributes):
+    class Attributes(Process.Attributes):
         dbt_process_job_status: Optional[str] = Field(default=None, description="")
         dbt_upstream_contexts: Optional[List[DbtInputContext]] = Field(
             default=None, description=""

--- a/tests/unit/model/dbt_column_process_test.py
+++ b/tests/unit/model/dbt_column_process_test.py
@@ -1,0 +1,64 @@
+"""Regression tests for SHA-887 follow-up — DbtColumnProcess must extend
+ColumnProcess, not Dbt.
+
+The Atlas typedef for DbtColumnProcess declares
+``superTypes=["Dbt", "ColumnProcess"]``. Without an override the class
+generator picks ``Dbt`` (``super_types[0]``) and publish-app's
+``issubclass(cls, ColumnProcess)`` check — used to identify column-level
+lineage types — returns False. DbtColumnProcess then lands in the wrong
+publish batch and ATLAS-404s on the columns it references.
+
+The override lives in ``pyatlan/generator/class_generator.py``
+(``_SUPERCLASS_OVERRIDES``). These tests guard the generated output so a
+future regeneration that drops the override fails CI rather than silently
+regressing publish ordering.
+"""
+
+import pytest
+
+from pyatlan.model.assets import ColumnProcess, Dbt, DbtColumnProcess
+
+
+def test_dbt_column_process_extends_column_process():
+    """DbtColumnProcess must inherit from ColumnProcess so publish-app
+    treats it as a column-level lineage type."""
+    assert issubclass(DbtColumnProcess, ColumnProcess)
+
+
+def test_dbt_column_process_does_not_extend_dbt():
+    """Negative guard: extending Dbt re-introduces the wrong-batch ordering bug."""
+    assert not issubclass(DbtColumnProcess, Dbt)
+
+
+def test_dbt_column_process_direct_parent_is_column_process():
+    """The Python parent (not just an ancestor) must be ColumnProcess."""
+    assert DbtColumnProcess.__bases__[0] is ColumnProcess
+
+
+def test_dbt_column_process_type_name():
+    """Ensure the wire ``type_name`` is preserved despite the parent change."""
+    sut = DbtColumnProcess()
+    assert sut.type_name == "DbtColumnProcess"
+
+
+def test_dbt_column_process_type_name_is_immutable():
+    sut = DbtColumnProcess()
+    with pytest.raises(TypeError):
+        sut.type_name = "NotDbtColumnProcess"
+
+
+def test_dbt_attributes_round_trip():
+    """Dbt-specific fields are still declared inline on
+    DbtColumnProcess.Attributes."""
+    sut = DbtColumnProcess()
+    sut.attributes = DbtColumnProcess.Attributes(dbt_alias="x", dbt_unique_id="y")
+    assert sut.attributes.dbt_alias == "x"
+    assert sut.attributes.dbt_unique_id == "y"
+
+
+def test_column_process_attributes_round_trip():
+    """ColumnProcess-specific fields inherited via ColumnProcess.Attributes
+    are accessible."""
+    sut = DbtColumnProcess()
+    sut.attributes = DbtColumnProcess.Attributes(code="cast(foo as int)")
+    assert sut.attributes.code == "cast(foo as int)"

--- a/tests/unit/model/dbt_process_test.py
+++ b/tests/unit/model/dbt_process_test.py
@@ -1,0 +1,61 @@
+"""Regression tests for SHA-887 follow-up — DbtProcess must extend Process, not Dbt.
+
+The Atlas typedef for DbtProcess declares ``superTypes=["Dbt", "Process"]``.
+Without an override the class generator picks ``Dbt`` (``super_types[0]``)
+and publish-app's ``issubclass(cls, Process)`` check — which decides whether
+a type is a "lineage type" that must publish after the entities it references
+— returns False. DbtProcess then lands in Batch 1 and ATLAS-404s when
+referencing later-batch entities (DbtModel, Column, etc.).
+
+The override lives in ``pyatlan/generator/class_generator.py``
+(``_SUPERCLASS_OVERRIDES``). These tests guard the generated output so a
+future regeneration that drops the override fails CI rather than silently
+regressing publish ordering.
+"""
+
+import pytest
+
+from pyatlan.model.assets import Dbt, DbtProcess, Process
+
+
+def test_dbt_process_extends_process():
+    """DbtProcess must inherit from Process so publish-app treats it as a
+    lineage type (publish-after-references)."""
+    assert issubclass(DbtProcess, Process)
+
+
+def test_dbt_process_does_not_extend_dbt():
+    """Negative guard: extending Dbt re-introduces the Batch-1 ordering bug."""
+    assert not issubclass(DbtProcess, Dbt)
+
+
+def test_dbt_process_direct_parent_is_process():
+    """The Python parent (not just an ancestor) must be Process."""
+    assert DbtProcess.__bases__[0] is Process
+
+
+def test_dbt_process_type_name():
+    """Ensure the wire ``type_name`` is preserved despite the parent change."""
+    sut = DbtProcess()
+    assert sut.type_name == "DbtProcess"
+
+
+def test_dbt_process_type_name_is_immutable():
+    sut = DbtProcess()
+    with pytest.raises(TypeError):
+        sut.type_name = "NotDbtProcess"
+
+
+def test_dbt_attributes_round_trip():
+    """Dbt-specific fields are still declared inline on DbtProcess.Attributes."""
+    sut = DbtProcess()
+    sut.attributes = DbtProcess.Attributes(dbt_alias="x", dbt_unique_id="y")
+    assert sut.attributes.dbt_alias == "x"
+    assert sut.attributes.dbt_unique_id == "y"
+
+
+def test_process_attributes_round_trip():
+    """Process-specific fields inherited via Process.Attributes are accessible."""
+    sut = DbtProcess()
+    sut.attributes = DbtProcess.Attributes(code="select * from foo")
+    assert sut.attributes.code == "select * from foo"


### PR DESCRIPTION
Same root cause as the ``DbtMeasure`` fix in 9.7.0 (#919) — Atlas typedefs list ``Dbt`` first in ``superTypes``, the class generator picks ``super_types[0]``, and ``atlan-publish-app``'s ``issubclass(cls, Process)`` / ``issubclass(cls, ColumnProcess)`` checks (used to identify lineage types that must publish *after* the entities they reference) silently return ``False``. The dbt-process classes then land in Batch 1 alongside their upstream entities and ATLAS-404 on every ``inputs`` / ``outputs`` lookup. ~35 publish failures observed in a live dbt run, plus the same pattern hits SAP BW connectors.

## Atlas typedefs

| Class | ``superTypes`` (Atlas) | Picked by generator | Should pick |
|---|---|---|---|
| ``DbtProcess`` | ``[\"Dbt\", \"Process\"]`` | ``Dbt`` | ``Process`` |
| ``DbtColumnProcess`` | ``[\"Dbt\", \"ColumnProcess\"]`` | ``Dbt`` | ``ColumnProcess`` |

Sibling type ``DbtMeasure`` was fixed via the same mechanism in 9.7.0 — this PR uses the same ``_SUPERCLASS_OVERRIDES`` map.

## Changes

- ``pyatlan/generator/class_generator.py`` — extend ``_SUPERCLASS_OVERRIDES`` with ``\"DbtProcess\": \"Process\"`` and ``\"DbtColumnProcess\": \"ColumnProcess\"``. The override only applies when the named supertype is actually declared on the entity, so a future typedef change that drops it cleanly errors rather than silently reverting.
- ``pyatlan/model/assets/dbt_process.py`` — ``class DbtProcess(Process)`` and ``class Attributes(Process.Attributes)``.
- ``pyatlan/model/assets/dbt_column_process.py`` — same shape against ``ColumnProcess``.

## Blast radius

Same as the DbtMeasure fix:
- ``isinstance(x, Dbt)`` on a ``DbtProcess`` / ``DbtColumnProcess`` was ``True``, is now ``False``. That check was incorrect — Atlas does not model ``DbtProcess`` as a ``Dbt`` subtype in a way that's meaningful for ordering. A grep across pyatlan and its tests finds no such ``isinstance`` usage.
- Serialised JSON (``type_name``, attribute keys) is unchanged — every ``dbt_*`` and ``Process`` / ``ColumnProcess`` field is declared inline on the respective ``Attributes`` classes, so no fields are lost; only the MRO is corrected.

## Tests

- ``tests/unit/model/dbt_process_test.py`` — 7 cases (``issubclass`` guards both directions, ``__bases__[0]``, ``type_name`` immutability, ``dbt_*`` and ``Process`` attribute round-trip on the same instance).
- ``tests/unit/model/dbt_column_process_test.py`` — same 7 cases for the ``ColumnProcess`` parent.

## Verified

- [x] ``./qa-checks`` — ruff format / ruff check / mypy all pass
- [x] ``pytest tests/unit/model/dbt_process_test.py tests/unit/model/dbt_column_process_test.py -q`` — 14/14 pass
- [x] Full unit suite clean (no new failures)
- [ ] Downstream verification in atlan-publish-app once this ships: ``DbtProcess`` / ``DbtColumnProcess`` move to a strictly later batch than the entities they reference

## Notes

Release notes will land in the next version bump (HISTORY.md is left alone here so 9.7.0's already-shipped section isn't retroactively edited). The ``typing.get_type_hints`` shim that was bundled into the closed PR #922 has been dropped — the better fix is on the publish-app side (switching to pydantic v1's ``ModelField.type_`` / ``.shape``, which are already fully resolved at SDK import time via ``update_forward_refs``). A separate publish-app PR will land that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)