### PR TITLE
feat: add AMAZON_MSK to AtlanConnectorType enum

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -332,6 +332,7 @@ class AtlanConnectorType(str, Enum, metaclass=utils.ExtendableEnumMeta):
     SODA = ("soda", AtlanConnectionCategory.DATA_QUALITY)
     MATILLION = ("matillion", AtlanConnectionCategory.ELT)
     AIVEN_KAFKA = ("aiven-kafka", AtlanConnectionCategory.EVENT_BUS)
+    AMAZON_MSK = ("amazon-msk", AtlanConnectionCategory.EVENT_BUS)
     APACHE_KAFKA = ("apache-kafka", AtlanConnectionCategory.EVENT_BUS)
     AZURE_EVENT_HUB = ("azure-event-hub", AtlanConnectionCategory.EVENT_BUS)
     CONFLUENT_KAFKA = ("confluent-kafka", AtlanConnectionCategory.EVENT_BUS)


### PR DESCRIPTION
## Summary

- Adds `AMAZON_MSK = ("amazon-msk", AtlanConnectionCategory.EVENT_BUS)` to the `AtlanConnectorType` enum, matching the Java SDK definition
- Inserted alphabetically alongside the other Kafka/event-bus variants

## Linear

Closes [BLDX-938](https://linear.app/atlan-epd/issue/BLDX-938/pyatlan-add-amazon-msk-to-atlanconnectortype-enum)

## Test plan

- [ ] Verify `AtlanConnectorType.AMAZON_MSK` resolves to `("amazon-msk", AtlanConnectionCategory.EVENT_BUS)`
- [ ] Confirm the `extend_enum` workaround used during the Plusgrade POV is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)