### PR TITLE
feat: add skillArtifactContent to SkillArtifact model

### DIFF
--- a/pyatlan/model/assets/core/skill_artifact.py
+++ b/pyatlan/model/assets/core/skill_artifact.py
@@ -69,9 +69,7 @@ class SkillArtifact(Artifact):
     @property
     def skill_artifact_content(self) -> Optional[str]:
         return (
-            None
-            if self.attributes is None
-            else self.attributes.skill_artifact_content
+            None if self.attributes is None else self.attributes.skill_artifact_content
         )
 
     @skill_artifact_content.setter
@@ -91,9 +89,7 @@ class SkillArtifact(Artifact):
         self.attributes.skill_source = skill_source
 
     class Attributes(Artifact.Attributes):
-        skill_artifact_content: Optional[str] = Field(
-            default=None, description=""
-        )
+        skill_artifact_content: Optional[str] = Field(default=None, description="")
         skill_source: Optional[Skill] = Field(
             default=None, description=""
         )  # relationship

--- a/pyatlan/model/assets/core/skill_artifact.py
+++ b/pyatlan/model/assets/core/skill_artifact.py
@@ -10,7 +10,7 @@ from nanoid import generate as generate_nanoid  # type: ignore
 from pydantic.v1 import Field, validator
 
 from pyatlan.model.enums import FileType
-from pyatlan.model.fields.atlan_fields import RelationField
+from pyatlan.model.fields.atlan_fields import KeywordField, RelationField
 from pyatlan.utils import init_guid, validate_required_fields
 
 from .artifact import Artifact
@@ -49,14 +49,36 @@ class SkillArtifact(Artifact):
             return object.__setattr__(self, name, value)
         super().__setattr__(name, value)
 
+    SKILL_ARTIFACT_CONTENT: ClassVar[KeywordField] = KeywordField(
+        "skillArtifactContent", "skillArtifactContent"
+    )
+    """
+    Content of the skill artifact (e.g. the body of a skill .md file).
+    """
+
     SKILL_SOURCE: ClassVar[RelationField] = RelationField("skillSource")
     """
     TBC
     """
 
     _convenience_properties: ClassVar[List[str]] = [
+        "skill_artifact_content",
         "skill_source",
     ]
+
+    @property
+    def skill_artifact_content(self) -> Optional[str]:
+        return (
+            None
+            if self.attributes is None
+            else self.attributes.skill_artifact_content
+        )
+
+    @skill_artifact_content.setter
+    def skill_artifact_content(self, skill_artifact_content: Optional[str]):
+        if self.attributes is None:
+            self.attributes = self.Attributes()
+        self.attributes.skill_artifact_content = skill_artifact_content
 
     @property
     def skill_source(self) -> Optional[Skill]:
@@ -69,6 +91,9 @@ class SkillArtifact(Artifact):
         self.attributes.skill_source = skill_source
 
     class Attributes(Artifact.Attributes):
+        skill_artifact_content: Optional[str] = Field(
+            default=None, description=""
+        )
         skill_source: Optional[Skill] = Field(
             default=None, description=""
         )  # relationship

--- a/pyatlan_v9/model/assets/skill_artifact.py
+++ b/pyatlan_v9/model/assets/skill_artifact.py
@@ -102,6 +102,7 @@ class SkillArtifact(Asset):
     LINKS: ClassVar[Any] = None
     README: ClassVar[Any] = None
     SCHEMA_REGISTRY_SUBJECTS: ClassVar[Any] = None
+    SKILL_ARTIFACT_CONTENT: ClassVar[Any] = None
     SKILL_SOURCE: ClassVar[Any] = None
     SODA_CHECKS: ClassVar[Any] = None
     INPUT_TO_SPARK_JOBS: ClassVar[Any] = None
@@ -133,6 +134,9 @@ class SkillArtifact(Asset):
 
     resource_metadata: Union[Dict[str, str], None, UnsetType] = UNSET
     """Metadata of the resource."""
+
+    skill_artifact_content: Union[str, None, UnsetType] = UNSET
+    """Content of the skill artifact (e.g. the body of a skill .md file)."""
 
     input_to_airflow_tasks: Union[List[RelatedAirflowTask], None, UnsetType] = UNSET
     """Tasks to which this asset provides input."""
@@ -388,6 +392,9 @@ class SkillArtifactAttributes(AssetAttributes):
     resource_metadata: Union[Dict[str, str], None, UnsetType] = UNSET
     """Metadata of the resource."""
 
+    skill_artifact_content: Union[str, None, UnsetType] = UNSET
+    """Content of the skill artifact (e.g. the body of a skill .md file)."""
+
 
 class SkillArtifactRelationshipAttributes(AssetRelationshipAttributes):
     """SkillArtifact-specific relationship attributes for nested API format."""
@@ -569,6 +576,7 @@ def _populate_skill_artifact_attrs(
     attrs.is_global = obj.is_global
     attrs.reference = obj.reference
     attrs.resource_metadata = obj.resource_metadata
+    attrs.skill_artifact_content = obj.skill_artifact_content
 
 
 def _extract_skill_artifact_attrs(attrs: SkillArtifactAttributes) -> dict:
@@ -583,6 +591,7 @@ def _extract_skill_artifact_attrs(attrs: SkillArtifactAttributes) -> dict:
     result["is_global"] = attrs.is_global
     result["reference"] = attrs.reference
     result["resource_metadata"] = attrs.resource_metadata
+    result["skill_artifact_content"] = attrs.skill_artifact_content
     return result
 
 
@@ -738,6 +747,9 @@ SkillArtifact.FILES = RelationField("files")
 SkillArtifact.LINKS = RelationField("links")
 SkillArtifact.README = RelationField("readme")
 SkillArtifact.SCHEMA_REGISTRY_SUBJECTS = RelationField("schemaRegistrySubjects")
+SkillArtifact.SKILL_ARTIFACT_CONTENT = KeywordField(
+    "skillArtifactContent", "skillArtifactContent"
+)
 SkillArtifact.SKILL_SOURCE = RelationField("skillSource")
 SkillArtifact.SODA_CHECKS = RelationField("sodaChecks")
 SkillArtifact.INPUT_TO_SPARK_JOBS = RelationField("inputToSparkJobs")

--- a/tests/unit/model/skill_artifact_test.py
+++ b/tests/unit/model/skill_artifact_test.py
@@ -96,3 +96,23 @@ def test_type_name_is_immutable():
     )
     with pytest.raises(TypeError):
         sut.type_name = "NotSkillArtifact"
+
+
+def test_skill_artifact_content_defaults_to_none():
+    sut = SkillArtifact.creator(
+        name=SKILL_ARTIFACT_NAME,
+        skill_qualified_name=SKILL_QUALIFIED_NAME,
+        file_type=FileType.TXT,
+    )
+    assert sut.skill_artifact_content is None
+
+
+def test_skill_artifact_content_roundtrip():
+    sut = SkillArtifact.creator(
+        name=SKILL_ARTIFACT_NAME,
+        skill_qualified_name=SKILL_QUALIFIED_NAME,
+        file_type=FileType.TXT,
+    )
+    content = "# My Skill\nThis skill does X when Y."
+    sut.skill_artifact_content = content
+    assert sut.skill_artifact_content == content


### PR DESCRIPTION
## Summary
- Adds `skill_artifact_content` (`skillArtifactContent`) attribute to `SkillArtifact` in both `pyatlan` (pydantic v1) and `pyatlan_v9` (msgspec)
- The Atlas API returns this attribute on SkillArtifact entities but PyAtlan currently drops it silently (`Config.extra = ignore`)
- This unblocks the Atlan MCP server from surfacing skill `.md` body content via `get_asset` / `search_assets` without needing a raw HTTP fallback

## Context
- Context Studio teams (P&G, ColPal/Workiva demos) currently work around this by calling the REST API directly (`GET /api/meta/entity/guid/{guid}`) to fetch `skillArtifactContent`
- With this change, `client.asset.get_by_guid(guid)` will preserve the content field, and FluentSearch can include it via `include_on_results`

## Changes
- `pyatlan/model/assets/core/skill_artifact.py` — added `SKILL_ARTIFACT_CONTENT` KeywordField, property, setter, and Attributes field
- `pyatlan_v9/model/assets/skill_artifact.py` — added field to flat class, `SkillArtifactAttributes`, populate/extract helpers, and deferred field descriptor
- `tests/unit/model/skill_artifact_test.py` — added 2 tests (default None, roundtrip set/get)

## Test plan
- [x] `pytest tests/unit/model/skill_artifact_test.py` — 11/11 passing
- [x] `pytest tests/unit/model/agentic_test.py` — 4/4 passing
- [ ] Integration test: verify `get_by_guid` on a real SkillArtifact returns `skill_artifact_content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)