### PR TITLE
feat: expose user publish preflight endpoint via workflow client (HYP-829)

### DIFF
--- a/pyatlan/client/common/__init__.py
+++ b/pyatlan/client/common/__init__.py
@@ -192,6 +192,7 @@ from .workflow import (
     WorkflowStop,
     WorkflowUpdate,
     WorkflowUpdateOwner,
+    WorkflowUserPublishPreflight,
 )
 
 __all__ = [
@@ -337,4 +338,5 @@ __all__ = [
     "WorkflowStop",
     "WorkflowUpdate",
     "WorkflowUpdateOwner",
+    "WorkflowUserPublishPreflight",
 ]

--- a/pyatlan/client/common/workflow.py
+++ b/pyatlan/client/common/workflow.py
@@ -17,6 +17,7 @@ from pyatlan.client.constants import (
     SCHEDULE_QUERY_WORKFLOWS_MISSED,
     SCHEDULE_QUERY_WORKFLOWS_SEARCH,
     STOP_WORKFLOW_RUN,
+    USER_PUBLISH_PREFLIGHT,
     WORKFLOW_ARCHIVE,
     WORKFLOW_CHANGE_OWNER,
     WORKFLOW_INDEX_RUN_SEARCH,
@@ -374,6 +375,45 @@ class WorkflowStop:
         :returns: WorkflowRunResponse object
         """
         return WorkflowParseResponse.parse_response(raw_json, WorkflowRunResponse)
+
+
+class WorkflowUserPublishPreflight:
+    """Shared logic for the user publish preflight check (HYP-829).
+
+    Verifies the workflow creator's account is enabled and that they may
+    publish (ENTITY_CREATE/UPDATE/DELETE) to the target connection. Heracles
+    runs both checks server-side (including the Keycloak impersonation), so
+    callers only need their own service-account token — the endpoint is
+    restricted to service-account callers.
+    """
+
+    @staticmethod
+    def prepare_request(user_id: str, connection_qualified_name: str = "") -> tuple:
+        """
+        Prepare the request for the user publish preflight check.
+
+        :param user_id: Keycloak user GUID of the workflow creator
+        :param connection_qualified_name: qualifiedName of the target
+            connection (e.g. ``default/snowflake/1234567890``); may be empty,
+            in which case only the user-enabled check runs
+        :returns: tuple of (endpoint, request_obj)
+        """
+        request = {
+            "user_id": user_id,
+            "connection_qualified_name": connection_qualified_name,
+        }
+        return USER_PUBLISH_PREFLIGHT, request
+
+    @staticmethod
+    def process_response(raw_json: Dict) -> Dict:
+        """
+        Process the preflight response.
+
+        :param raw_json: raw response from the API
+        :returns: dict with ``passed`` (bool), ``failed_checks``
+            (list of str or None) and ``message`` (str)
+        """
+        return raw_json or {}
 
 
 class WorkflowDelete:

--- a/pyatlan/client/constants.py
+++ b/pyatlan/client/constants.py
@@ -482,6 +482,17 @@ WORKFLOW_OWNER_RERUN = API(
     WORKFLOW_OWNER_RERUN_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HERACLES
 )
 
+# user publish preflight (HYP-829) — verifies the workflow creator's account is
+# enabled and that they may publish (ENTITY_CREATE/UPDATE/DELETE) to the target
+# connection; restricted to service-account callers on the Heracles side
+USER_PUBLISH_PREFLIGHT_API = "workflows/preflight/user-publish-check"
+USER_PUBLISH_PREFLIGHT = API(
+    USER_PUBLISH_PREFLIGHT_API,
+    HTTPMethod.POST,
+    HTTPStatus.OK,
+    endpoint=EndPoint.HERACLES,
+)
+
 WORKFLOW_RUN_API = "workflows?submit=true"
 WORKFLOW_RUN = API(
     WORKFLOW_RUN_API, HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HERACLES

--- a/pyatlan_v9/client/aio/workflow.py
+++ b/pyatlan_v9/client/aio/workflow.py
@@ -18,6 +18,7 @@ from pyatlan.client.common import (
     WorkflowGetScheduledRun,
     WorkflowStop,
     WorkflowUpdateOwner,
+    WorkflowUserPublishPreflight,
 )
 from pyatlan.client.constants import (
     PACKAGE_WORKFLOW_RERUN,
@@ -595,6 +596,34 @@ class V9AsyncWorkflowClient:
         endpoint, _ = WorkflowStop.prepare_request(workflow_run_id)
         raw_json = await self._client._call_api(endpoint, request_obj=None)
         return msgspec.convert(raw_json, WorkflowRunResponse, strict=False)
+
+    async def user_publish_preflight(
+        self,
+        user_id: str,
+        connection_qualified_name: str = "",
+    ) -> dict:
+        """
+        Run the user publish preflight check (HYP-829) for a workflow creator.
+
+        Verifies the user's account is enabled and that they may publish
+        (ENTITY_CREATE/UPDATE/DELETE) to the target connection. All checks run
+        server-side in Heracles (including the Keycloak impersonation), so the
+        caller only needs its own service-account token — the endpoint is
+        restricted to service-account callers.
+
+        :param user_id: Keycloak user GUID of the workflow creator
+        :param connection_qualified_name: qualifiedName of the target
+            connection (e.g. ``default/snowflake/1234567890``); may be empty,
+            in which case only the user-enabled check runs
+        :returns: dict with ``passed`` (bool), ``failed_checks``
+            (list of str or None) and ``message`` (str)
+        :raises AtlanError: on any API communication issue
+        """
+        endpoint, request = WorkflowUserPublishPreflight.prepare_request(
+            user_id, connection_qualified_name
+        )
+        raw_json = await self._client._call_api(endpoint, request_obj=request)
+        return WorkflowUserPublishPreflight.process_response(raw_json)
 
     @validate_arguments
     async def delete(

--- a/pyatlan_v9/client/workflow.py
+++ b/pyatlan_v9/client/workflow.py
@@ -18,6 +18,7 @@ from pyatlan.client.common import (
     WorkflowGetScheduledRun,
     WorkflowStop,
     WorkflowUpdateOwner,
+    WorkflowUserPublishPreflight,
 )
 from pyatlan.client.constants import (
     PACKAGE_WORKFLOW_RERUN,
@@ -584,6 +585,34 @@ class V9WorkflowClient:
         endpoint, _ = WorkflowStop.prepare_request(workflow_run_id)
         raw_json = self._client._call_api(endpoint, request_obj=None)
         return msgspec.convert(raw_json, WorkflowRunResponse, strict=False)
+
+    def user_publish_preflight(
+        self,
+        user_id: str,
+        connection_qualified_name: str = "",
+    ) -> dict:
+        """
+        Run the user publish preflight check (HYP-829) for a workflow creator.
+
+        Verifies the user's account is enabled and that they may publish
+        (ENTITY_CREATE/UPDATE/DELETE) to the target connection. All checks run
+        server-side in Heracles (including the Keycloak impersonation), so the
+        caller only needs its own service-account token — the endpoint is
+        restricted to service-account callers.
+
+        :param user_id: Keycloak user GUID of the workflow creator
+        :param connection_qualified_name: qualifiedName of the target
+            connection (e.g. ``default/snowflake/1234567890``); may be empty,
+            in which case only the user-enabled check runs
+        :returns: dict with ``passed`` (bool), ``failed_checks``
+            (list of str or None) and ``message`` (str)
+        :raises AtlanError: on any API communication issue
+        """
+        endpoint, request = WorkflowUserPublishPreflight.prepare_request(
+            user_id, connection_qualified_name
+        )
+        raw_json = self._client._call_api(endpoint, request_obj=request)
+        return WorkflowUserPublishPreflight.process_response(raw_json)
 
     @validate_arguments
     def delete(

--- a/tests/unit/test_workflow_client.py
+++ b/tests/unit/test_workflow_client.py
@@ -972,3 +972,36 @@ def test_remove_schedule_with_role_cache_api_token_user(
     mock_api_caller._call_api.assert_called_once()
     assert response == workflow_response
     mock_api_caller.reset_mock()
+
+
+def test_user_publish_preflight_prepare_request():
+    from pyatlan.client.common import WorkflowUserPublishPreflight
+    from pyatlan.client.constants import USER_PUBLISH_PREFLIGHT
+
+    endpoint, request = WorkflowUserPublishPreflight.prepare_request(
+        "8c1e2d8a-1564-4e95-8b14-ea14522fcf61", "default/snowflake/1234567890"
+    )
+    assert endpoint is USER_PUBLISH_PREFLIGHT
+    assert request == {
+        "user_id": "8c1e2d8a-1564-4e95-8b14-ea14522fcf61",
+        "connection_qualified_name": "default/snowflake/1234567890",
+    }
+
+
+def test_user_publish_preflight_prepare_request_without_connection():
+    from pyatlan.client.common import WorkflowUserPublishPreflight
+
+    _, request = WorkflowUserPublishPreflight.prepare_request("user-123")
+    assert request == {"user_id": "user-123", "connection_qualified_name": ""}
+
+
+def test_user_publish_preflight_process_response():
+    from pyatlan.client.common import WorkflowUserPublishPreflight
+
+    verdict = {
+        "passed": False,
+        "failed_checks": ["UserEnabled"],
+        "message": "User user-123 failed publish preflight checks: UserEnabled",
+    }
+    assert WorkflowUserPublishPreflight.process_response(verdict) == verdict
+    assert WorkflowUserPublishPreflight.process_response(None) == {}


### PR DESCRIPTION
## Summary

Adds `client.workflow.user_publish_preflight(user_id, connection_qualified_name)` to the **v9 sync and async** workflow clients, wrapping Heracles' `POST /workflows/preflight/user-publish-check`.

The endpoint verifies the workflow creator's account is **enabled** and that they may **publish (ENTITY_CREATE/UPDATE/DELETE)** to the target connection. All checks — including the Keycloak impersonation/token-exchange — run **server-side in Heracles**, so callers only need their own service-account token; the endpoint is restricted to `service-account-*` callers on the Heracles side (`x-endpoint-type: service-account`).

## Why

Per @cmgrote's review on atlanhq/application-sdk#1966 ("New Heracles endpoints should be exposed via pyatlan, and then the existing pyatlan bits used for the actual interactions"): the application-sdk's `run_publish_preflight` Temporal activity — the first activity of every extract workflow (HYP-829) — currently calls this endpoint with raw httpx. With this wrapper the SDK switches to the pyatlan client and inherits its auth handling, observability headers, retries, and pooling.

Deliberately **not** done client-side via `client.impersonate.user` + `/evaluates`: that would require distributing impersonate-any-user credentials (`CLIENT_ID`/`CLIENT_SECRET`) to every connector app, including customer-deployed SDR runtimes. Keeping impersonation server-side in Heracles is the security boundary this design preserves (discussion: HYP-829).

## Changes (house pattern, +111/-0)

| File | Change |
|---|---|
| `pyatlan/client/constants.py` | `USER_PUBLISH_PREFLIGHT` API constant (`EndPoint.HERACLES`) |
| `pyatlan/client/common/workflow.py` | `WorkflowUserPublishPreflight` shared prepare/process |
| `pyatlan/client/common/__init__.py` | re-export |
| `pyatlan_v9/client/workflow.py` | sync `user_publish_preflight()` |
| `pyatlan_v9/client/aio/workflow.py` | async `user_publish_preflight()` |
| `tests/unit/test_workflow_client.py` | 3 unit tests for the shared logic |

## Related

- Heracles endpoint: atlanhq/heracles#5928
- SDK consumer: atlanhq/application-sdk#1966
- Linear: [HYP-829](https://linear.app/atlan-epd/issue/HYP-829)

## Notes for reviewers

- Files compile; unit tests are pure (no client mock needed) — but I could not execute the suite locally (local Python 3.14 can't import pyatlan's pydantic-v1 models), so relying on CI.
- v9-only by design (the SDK consumes `pyatlan_v9`); happy to mirror onto the legacy v1 `WorkflowClient` if wanted.
- Method returns the raw verdict `dict` (`{passed, failed_checks, message}`); can switch to a typed response model if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)