### PR TITLE
fix(batch): count partial updates and fix PARTIAL_UPDATE alias collision

### DIFF
--- a/pyatlan/client/aio/batch.py
+++ b/pyatlan/client/aio/batch.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Atlan Pte. Ltd.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, cast
 
 from pydantic.v1 import validate_arguments
 
@@ -83,6 +83,7 @@ class AsyncBatch:
         self._creation_handling: AssetCreationHandling = creation_handling
         self._num_created = 0
         self._num_updated = 0
+        self._num_partial_updated = 0
         self._num_restored = 0
         self._num_skipped = 0
         self._resolved_guids: Dict[str, str] = {}
@@ -90,6 +91,7 @@ class AsyncBatch:
         self._failures: List[FailedBatch] = []
         self._created: List[Asset] = []
         self._updated: List[Asset] = []
+        self._partial_updated: List[Asset] = []
         self._restored: List[Asset] = []
         self._skipped: List[Asset] = []
         self._resolved_qualified_names: Dict[str, str] = {}
@@ -118,6 +120,17 @@ class AsyncBatch:
         :returns: a list of all the Assets that were updated
         """
         return self._updated
+
+    @property
+    def partial_updated(self) -> List[Asset]:
+        """Get a list of all the Assets that were partially updated.
+        Atlan reports an update as partial when only primitive attributes
+        change, or when a relationship (such as a glossary term's anchor)
+        is touched. These are successful updates, distinct from `restored`.
+
+        :returns: a list of all the Assets that were partially updated
+        """
+        return self._partial_updated
 
     @property
     def restored(self) -> List[Asset]:
@@ -151,6 +164,13 @@ class AsyncBatch:
         Number of assets that were updated (count only)
         """
         return self._num_updated
+
+    @property
+    def num_partial_updated(self) -> int:
+        """
+        Number of assets that were partially updated (count only)
+        """
+        return self._num_partial_updated
 
     @property
     def num_restored(self) -> int:
@@ -352,6 +372,14 @@ class AsyncBatch:
 
     def _track_response(self, response: AssetMutationResponse, sent: list[Asset]):
         if response:
+            # Atlan reports partial updates (primitive-only attribute changes, or
+            # changes that touch a relationship such as a glossary term's anchor)
+            # under mutated_entities.PARTIAL_UPDATE and/or the top-level
+            # partial_updated_entities list. Reconcile both and de-duplicate by GUID
+            # so a successful partial update is counted as updated rather than falling
+            # through to the "restored" bucket below.
+            partial_assets = self._collect_partial_updated(response)
+
             if self._track and response.mutated_entities:
                 if response.mutated_entities.CREATE:
                     for asset in response.mutated_entities.CREATE:
@@ -359,17 +387,22 @@ class AsyncBatch:
                 if response.mutated_entities.UPDATE:
                     for asset in response.mutated_entities.UPDATE:
                         self.__track(self._updated, asset)
+            if self._track:
+                for asset in partial_assets:
+                    self.__track(self._partial_updated, asset)
 
             # Always track the counts and resolved GUIDs...
             if response.mutated_entities and response.mutated_entities.CREATE:
                 self._num_created += len(response.mutated_entities.CREATE)
             if response.mutated_entities and response.mutated_entities.UPDATE:
                 self._num_updated += len(response.mutated_entities.UPDATE)
+            self._num_partial_updated += len(partial_assets)
 
             if response.guid_assignments:
                 self._resolved_guids.update(response.guid_assignments)
             if sent:
                 created_guids, updated_guids = set(), set()
+                partial_guids = {asset.guid for asset in partial_assets}
                 if response.mutated_entities:
                     if response.mutated_entities.CREATE:
                         created_guids = {
@@ -392,9 +425,11 @@ class AsyncBatch:
                     if (
                         mapped_guid not in created_guids
                         and mapped_guid not in updated_guids
+                        and mapped_guid not in partial_guids
                     ):
-                        # Ensure any assets that do not show as either created or updated are still tracked
-                        # as possibly restored (and inject the mapped GUID in case it had a placeholder)
+                        # Ensure any assets that do not show as created, updated or
+                        # partially updated are still tracked as possibly restored
+                        # (and inject the mapped GUID in case it had a placeholder)
                         one.guid = mapped_guid
                         self.__track(self._restored, one)
                         self._num_restored += 1
@@ -418,6 +453,26 @@ class AsyncBatch:
             asset = candidate.trim_to_required()
         asset.name = candidate.name
         tracker.append(asset)
+
+    @staticmethod
+    def _collect_partial_updated(response: AssetMutationResponse) -> List[Asset]:
+        """Gather partially-updated assets from both places Atlan may report them
+        (mutated_entities.PARTIAL_UPDATE and the top-level partial_updated_entities),
+        de-duplicated by GUID.
+        """
+        partial_assets: List[Asset] = []
+        seen_guids: Set[str] = set()
+        sources: List[List[Asset]] = []
+        if response.mutated_entities and response.mutated_entities.PARTIAL_UPDATE:
+            sources.append(response.mutated_entities.PARTIAL_UPDATE)
+        if response.partial_updated_entities:
+            sources.append(response.partial_updated_entities)
+        for source in sources:
+            for asset in source:
+                if asset.guid not in seen_guids:
+                    seen_guids.add(asset.guid)
+                    partial_assets.append(asset)
+        return partial_assets
 
     def add_fuzzy_matched(
         self,

--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -2241,6 +2241,7 @@ class Batch:
         self._creation_handling: AssetCreationHandling = creation_handling
         self._num_created = 0
         self._num_updated = 0
+        self._num_partial_updated = 0
         self._num_restored = 0
         self._num_skipped = 0
         self._resolved_guids: Dict[str, str] = {}
@@ -2248,6 +2249,7 @@ class Batch:
         self._failures: List[FailedBatch] = []
         self._created: List[Asset] = []
         self._updated: List[Asset] = []
+        self._partial_updated: List[Asset] = []
         self._restored: List[Asset] = []
         self._skipped: List[Asset] = []
         self._resolved_qualified_names: Dict[str, str] = {}
@@ -2276,6 +2278,17 @@ class Batch:
         :returns: a list of all the Assets that were updated
         """
         return self._updated
+
+    @property
+    def partial_updated(self) -> List[Asset]:
+        """Get a list of all the Assets that were partially updated.
+        Atlan reports an update as partial when only primitive attributes
+        change, or when a relationship (such as a glossary term's anchor)
+        is touched. These are successful updates, distinct from `restored`.
+
+        :returns: a list of all the Assets that were partially updated
+        """
+        return self._partial_updated
 
     @property
     def restored(self) -> List[Asset]:
@@ -2309,6 +2322,13 @@ class Batch:
         Number of assets that were updated (count only)
         """
         return self._num_updated
+
+    @property
+    def num_partial_updated(self) -> int:
+        """
+        Number of assets that were partially updated (count only)
+        """
+        return self._num_partial_updated
 
     @property
     def num_restored(self) -> int:
@@ -2512,6 +2532,14 @@ class Batch:
 
     def _track_response(self, response: AssetMutationResponse, sent: list[Asset]):
         if response:
+            # Atlan reports partial updates (primitive-only attribute changes, or
+            # changes that touch a relationship such as a glossary term's anchor)
+            # under mutated_entities.PARTIAL_UPDATE and/or the top-level
+            # partial_updated_entities list. Reconcile both and de-duplicate by GUID
+            # so a successful partial update is counted as updated rather than falling
+            # through to the "restored" bucket below.
+            partial_assets = self._collect_partial_updated(response)
+
             if self._track and response.mutated_entities:
                 if response.mutated_entities.CREATE:
                     for asset in response.mutated_entities.CREATE:
@@ -2519,17 +2547,22 @@ class Batch:
                 if response.mutated_entities.UPDATE:
                     for asset in response.mutated_entities.UPDATE:
                         self.__track(self._updated, asset)
+            if self._track:
+                for asset in partial_assets:
+                    self.__track(self._partial_updated, asset)
 
             # Always track the counts and resolved GUIDs...
             if response.mutated_entities and response.mutated_entities.CREATE:
                 self._num_created += len(response.mutated_entities.CREATE)
             if response.mutated_entities and response.mutated_entities.UPDATE:
                 self._num_updated += len(response.mutated_entities.UPDATE)
+            self._num_partial_updated += len(partial_assets)
 
             if response.guid_assignments:
                 self._resolved_guids.update(response.guid_assignments)
             if sent:
                 created_guids, updated_guids = set(), set()
+                partial_guids = {asset.guid for asset in partial_assets}
                 if response.mutated_entities:
                     if response.mutated_entities.CREATE:
                         created_guids = {
@@ -2552,9 +2585,11 @@ class Batch:
                     if (
                         mapped_guid not in created_guids
                         and mapped_guid not in updated_guids
+                        and mapped_guid not in partial_guids
                     ):
-                        # Ensure any assets that do not show as either created or updated are still tracked
-                        # as possibly restored (and inject the mapped GUID in case it had a placeholder)
+                        # Ensure any assets that do not show as created, updated or
+                        # partially updated are still tracked as possibly restored
+                        # (and inject the mapped GUID in case it had a placeholder)
                         one.guid = mapped_guid
                         self.__track(self._restored, one)
                         self._num_restored += 1
@@ -2578,6 +2613,26 @@ class Batch:
             asset = candidate.trim_to_required()
         asset.name = candidate.name
         tracker.append(asset)
+
+    @staticmethod
+    def _collect_partial_updated(response: AssetMutationResponse) -> List[Asset]:
+        """Gather partially-updated assets from both places Atlan may report them
+        (mutated_entities.PARTIAL_UPDATE and the top-level partial_updated_entities),
+        de-duplicated by GUID.
+        """
+        partial_assets: List[Asset] = []
+        seen_guids: Set[str] = set()
+        sources: List[List[Asset]] = []
+        if response.mutated_entities and response.mutated_entities.PARTIAL_UPDATE:
+            sources.append(response.mutated_entities.PARTIAL_UPDATE)
+        if response.partial_updated_entities:
+            sources.append(response.partial_updated_entities)
+        for source in sources:
+            for asset in source:
+                if asset.guid not in seen_guids:
+                    seen_guids.add(asset.guid)
+                    partial_assets.append(asset)
+        return partial_assets
 
     def add_fuzzy_matched(
         self,

--- a/pyatlan/model/response.py
+++ b/pyatlan/model/response.py
@@ -32,7 +32,7 @@ class MutatedEntities(AtlanObject):
         default=None,
         description="Assets that were partially updated. The detailed properties of the returned asset will "
         "vary based on the type of asset, but listed in the example are the common set of properties across assets.",
-        alias="DELETE",
+        alias="PARTIAL_UPDATE",
     )
 
 

--- a/tests/unit/aio/test_client.py
+++ b/tests/unit/aio/test_client.py
@@ -2364,7 +2364,9 @@ class TestBatch:
         updated = [table_2]
         mutated_entities.CREATE = created
         mutated_entities.UPDATE = updated
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
 
         # Set up async mocks - need to mock the FluentSearch.execute_async behavior
@@ -2518,7 +2520,9 @@ class TestBatch:
         created = [term_1, term_2]
         mutated_entities.UPDATE = []
         mutated_entities.CREATE = created
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
         # Set up async mocks - need to mock the FluentSearch.execute_async behavior
         mock_search_results = AsyncMock()
@@ -2550,6 +2554,49 @@ class TestBatch:
             assert len(created) == batch.num_created
             mock_ref_by_guid.assert_has_calls([call(term_1.guid), call(term_2.guid)])
             mock_trim_to_required.assert_not_called()
+
+    def test_partial_updates_counted_and_not_restored(self, mock_async_atlan_client):
+        # Async mirror: partial updates reported under
+        # mutated_entities.PARTIAL_UPDATE and/or the top-level
+        # partial_updated_entities must be counted (de-duplicated by GUID) and
+        # must NOT be mislabeled as restored.
+        response = AssetMutationResponse(
+            **{
+                "mutatedEntities": {
+                    "PARTIAL_UPDATE": [
+                        {
+                            "typeName": "Table",
+                            "attributes": {
+                                "qualifiedName": "default/p/1",
+                                "name": "p1",
+                            },
+                            "guid": "pu-1",
+                        }
+                    ]
+                },
+                "partialUpdatedEntities": [
+                    {
+                        "typeName": "AtlasGlossaryTerm",
+                        "attributes": {"qualifiedName": "term/1", "name": "term1"},
+                        "guid": "term-1",
+                    },
+                    {
+                        "typeName": "Table",
+                        "attributes": {"qualifiedName": "default/p/1", "name": "p1"},
+                        "guid": "pu-1",
+                    },
+                ],
+            }
+        )
+        batch = AsyncBatch(client=mock_async_atlan_client, max_size=10, track=True)
+        sent = [Table.ref_by_guid("pu-1"), AtlasGlossaryTerm.ref_by_guid("term-1")]
+        batch._track_response(response, sent=sent)
+
+        assert batch.num_partial_updated == 2
+        assert len(batch.partial_updated) == 2
+        assert "term-1" in {a.guid for a in batch.partial_updated}
+        assert batch.num_restored == 0
+        assert batch.num_updated == 0
 
 
 class TestBulkRequest:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2190,7 +2190,9 @@ class TestBatch:
         updated = [table_2]
         mutated_entities.CREATE = created
         mutated_entities.UPDATE = updated
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
 
         if custom_metadata_handling == CustomMetadataHandling.IGNORE:
@@ -2304,7 +2306,9 @@ class TestBatch:
         created = [term_1, term_2]
         mutated_entities.UPDATE = []
         mutated_entities.CREATE = created
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
         mock_atlan_client.asset.search.return_value = [term_1]
         mock_atlan_client.asset.save.return_value = mock_response
@@ -2321,6 +2325,88 @@ class TestBatch:
         assert len(created) == batch.num_created
         mock_ref_by_guid.assert_has_calls([call(term_1.guid), call(term_2.guid)])
         mock_trim_to_required.assert_not_called()
+
+    def test_partial_update_alias_does_not_collide_with_delete(self):
+        # Regression: MutatedEntities.PARTIAL_UPDATE previously carried
+        # alias="DELETE", so a wire "PARTIAL_UPDATE" payload was dropped and
+        # deleted assets leaked into partial-updates. They must stay distinct.
+        response = AssetMutationResponse(
+            **{
+                "mutatedEntities": {
+                    "DELETE": [
+                        {
+                            "typeName": "Table",
+                            "attributes": {
+                                "qualifiedName": "default/d/1",
+                                "name": "d1",
+                            },
+                            "guid": "del-1",
+                        }
+                    ],
+                    "PARTIAL_UPDATE": [
+                        {
+                            "typeName": "Table",
+                            "attributes": {
+                                "qualifiedName": "default/p/1",
+                                "name": "p1",
+                            },
+                            "guid": "pu-1",
+                        }
+                    ],
+                }
+            }
+        )
+        assert [a.guid for a in response.mutated_entities.DELETE] == ["del-1"]
+        assert [a.guid for a in response.mutated_entities.PARTIAL_UPDATE] == ["pu-1"]
+        assert [a.guid for a in response.assets_deleted(Table)] == ["del-1"]
+        assert [a.guid for a in response.assets_partially_updated(Table)] == ["pu-1"]
+
+    def test_partial_updates_counted_and_not_restored(self, mock_atlan_client):
+        # A successful partial update (a primitive-only change, or a glossary
+        # term whose anchor relationship makes every change partial) is reported
+        # by Atlan under mutated_entities.PARTIAL_UPDATE and/or the top-level
+        # partial_updated_entities list. Both must be counted as partial updates,
+        # de-duplicated by GUID, and must NOT fall through to "restored".
+        response = AssetMutationResponse(
+            **{
+                "mutatedEntities": {
+                    "PARTIAL_UPDATE": [
+                        {
+                            "typeName": "Table",
+                            "attributes": {
+                                "qualifiedName": "default/p/1",
+                                "name": "p1",
+                            },
+                            "guid": "pu-1",
+                        }
+                    ]
+                },
+                "partialUpdatedEntities": [
+                    {
+                        "typeName": "AtlasGlossaryTerm",
+                        "attributes": {"qualifiedName": "term/1", "name": "term1"},
+                        "guid": "term-1",
+                    },
+                    # Duplicate of the mutated_entities.PARTIAL_UPDATE entry above;
+                    # must be de-duplicated rather than double-counted.
+                    {
+                        "typeName": "Table",
+                        "attributes": {"qualifiedName": "default/p/1", "name": "p1"},
+                        "guid": "pu-1",
+                    },
+                ],
+            }
+        )
+        batch = Batch(client=mock_atlan_client, max_size=10, track=True)
+        sent = [Table.ref_by_guid("pu-1"), AtlasGlossaryTerm.ref_by_guid("term-1")]
+        batch._track_response(response, sent=sent)
+
+        assert batch.num_partial_updated == 2
+        assert len(batch.partial_updated) == 2
+        assert "term-1" in {a.guid for a in batch.partial_updated}
+        # The key regression guard: partial updates are not mislabeled as restored.
+        assert batch.num_restored == 0
+        assert batch.num_updated == 0
 
 
 class TestBulkRequest:

--- a/tests_v9/unit/aio/test_client.py
+++ b/tests_v9/unit/aio/test_client.py
@@ -2455,7 +2455,9 @@ class TestBatch:
         updated = [table_2]
         mutated_entities.CREATE = created
         mutated_entities.UPDATE = updated
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
 
         # Set up async mocks - need to mock the FluentSearch.execute_async behavior
@@ -2609,7 +2611,9 @@ class TestBatch:
         created = [term_1, term_2]
         mutated_entities.UPDATE = []
         mutated_entities.CREATE = created
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
         # Set up async mocks - need to mock the FluentSearch.execute_async behavior
         mock_search_results = AsyncMock()

--- a/tests_v9/unit/test_client.py
+++ b/tests_v9/unit/test_client.py
@@ -2469,7 +2469,9 @@ class TestBatch:
         updated = [table_2]
         mutated_entities.CREATE = created
         mutated_entities.UPDATE = updated
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
 
         if custom_metadata_handling == CustomMetadataHandling.IGNORE:
@@ -2593,7 +2595,9 @@ class TestBatch:
         created = [term_1, term_2]
         mutated_entities.UPDATE = []
         mutated_entities.CREATE = created
+        mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
         mock_response.attach_mock(mutated_entities, "mutated_entities")
         mock_atlan_client.asset.search.return_value = [term_1]
         mock_atlan_client.asset.save.return_value = mock_response


### PR DESCRIPTION
## Problem

`Batch`/`AsyncBatch._track_response` only inspect `mutated_entities.CREATE` and `.UPDATE`. But Atlan reports many **successful** updates as *partial*:

- primitive-only attribute changes (e.g. `user_description` alone) arrive under the top-level `partial_updated_entities` list
- any change touching a relationship (e.g. a glossary term's `anchor`) arrives under `mutated_entities.PARTIAL_UPDATE`

These were never counted. Worse, the sent-loop fallback bucketed them as `restored` with `num_updated = 0`. Any caller that gates on the update count therefore treats a successful update as a no-op — which, for consumers that retry on "nothing updated", causes a retry storm on the common glossary-term path.

There is also a latent model bug: `MutatedEntities.PARTIAL_UPDATE` was declared with `alias="DELETE"` (a copy-paste error). It collided with the real `DELETE` field, so a wire `"PARTIAL_UPDATE"` payload was dropped and deleted assets leaked into `assets_partially_updated()`. Only the top-level `partial_updated_entities` was usable before this fix.

## Changes

- **`model/response.py`**: fix `MutatedEntities.PARTIAL_UPDATE` alias (`"DELETE"` → `"PARTIAL_UPDATE"`).
- **`client/asset.py` (`Batch`) and `client/aio/batch.py` (`AsyncBatch`)**:
  - Reconcile partial updates from **both** `mutated_entities.PARTIAL_UPDATE` and the top-level `partial_updated_entities`, de-duplicated by GUID, into new `partial_updated` / `num_partial_updated` trackers.
  - Exclude partially-updated GUIDs from the `restored` fallback so they are no longer mislabeled.

## Behaviour

Same partial-update response, before vs after:

| | before | after |
|---|---|---|
| `num_updated` | 0 | 0 |
| `num_partial_updated` | n/a | 2 |
| `num_restored` | 2 (wrong) | 0 |

## Tests

- `test_partial_update_alias_does_not_collide_with_delete` — model deserialization keeps `DELETE` and `PARTIAL_UPDATE` distinct.
- `test_partial_updates_counted_and_not_restored` — sync + async: partial updates from both sources counted, de-duplicated, and not mislabeled as restored.

All existing `Batch`/`AsyncBatch` tests pass (391 in the client suites). `ruff check` / `ruff format` clean; `mypy` introduces no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)