### PR TITLE
fix(batch): preserve real guid + qualified_name in Batch tracked lists

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- **`Batch`/`AsyncBatch` tracked lists now carry real identity (both `pyatlan` and `pyatlan_v9`)**: the tracked lists (`created` / `updated` / `partial_updated` / `restored`) now carry each asset's real `guid` and `qualified_name`, so callers can match tracked items back to their inputs by either key. Previously non-glossary assets got a placeholder (negative) guid in `pyatlan` (or a missing/`UNSET` guid in `pyatlan_v9`) via `trim_to_required()`, and glossary terms got the guid in place of `qualified_name` in `pyatlan` (or a missing/`UNSET` `qualified_name` in `pyatlan_v9`) via `ref_by_guid()`, making the tracked items impossible to match back by guid or qualified_name.
+- **`Batch`/`AsyncBatch` tracked lists now carry real identity (both `pyatlan` and `pyatlan_v9`)**: the tracked lists (`created` / `updated` / `partial_updated` / `restored`) now carry each asset's real `guid` and `qualified_name`, so callers can match tracked items back to their inputs by either key. Previously non-glossary assets got a placeholder (negative) guid in `pyatlan` (or a missing/`UNSET` guid in `pyatlan_v9`) via `trim_to_required()`, and glossary terms got the guid in place of `qualified_name` in `pyatlan` (or a missing/`UNSET` `qualified_name` in `pyatlan_v9`) via `ref_by_guid()`, making the tracked items impossible to match back by guid or qualified_name. Tracking also now handles `AtlasGlossaryCategory` (and types it correctly as a category): previously a category in the tracked path crashed `__track` with `ValueError("anchor.guid must be available")`, because — like `AtlasGlossaryTerm` — its `trim_to_required()` requires the parent glossary anchor, which is absent in an `AssetMutationResponse`.
 
 ## 9.7.5 (June 16, 2026)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- **`Batch`/`AsyncBatch` tracked lists now carry real identity (both `pyatlan` and `pyatlan_v9`)**: the tracked lists (`created` / `updated` / `partial_updated` / `restored`) now carry each asset's real `guid` and `qualified_name`, so callers can match tracked items back to their inputs by either key. Previously non-glossary assets got a placeholder (negative) guid in `pyatlan` (or a missing/`UNSET` guid in `pyatlan_v9`) via `trim_to_required()`, and glossary terms got the guid in place of `qualified_name` in `pyatlan` (or a missing/`UNSET` `qualified_name` in `pyatlan_v9`) via `ref_by_guid()`, making the tracked items impossible to match back by guid or qualified_name.
+
 ## 9.7.5 (June 16, 2026)
 
 ### Bug Fixes

--- a/pyatlan/client/aio/batch.py
+++ b/pyatlan/client/aio/batch.py
@@ -13,7 +13,14 @@ from pyatlan.client.asset import (
     FailedBatch,
 )
 from pyatlan.errors import AtlanError, ErrorCode
-from pyatlan.model.assets import Asset, AtlasGlossaryTerm, MaterialisedView, Table, View
+from pyatlan.model.assets import (
+    Asset,
+    AtlasGlossaryCategory,
+    AtlasGlossaryTerm,
+    MaterialisedView,
+    Table,
+    View,
+)
 from pyatlan.model.fluent_search import FluentSearch
 from pyatlan.model.response import AssetMutationResponse
 from pyatlan.model.search import DSL
@@ -445,11 +452,13 @@ class AsyncBatch:
 
     @staticmethod
     def __track(tracker: List[Asset], candidate: Asset):
-        if isinstance(candidate, AtlasGlossaryTerm):
-            # trim_to_required for AtlasGlossaryTerm requires the anchor (parent
-            # glossary), which is not present in an AssetMutationResponse, so we
-            # fall back to a guid reference and restore the real identity below.
-            asset = cast(Asset, AtlasGlossaryTerm.ref_by_guid(candidate.guid))
+        if isinstance(candidate, (AtlasGlossaryTerm, AtlasGlossaryCategory)):
+            # trim_to_required for AtlasGlossaryTerm/AtlasGlossaryCategory
+            # requires the anchor (parent glossary), which is not present in an
+            # AssetMutationResponse (it would raise "anchor.guid must be
+            # available"), so we fall back to a guid reference of the
+            # candidate's actual type and restore the real identity below.
+            asset = cast(Asset, type(candidate).ref_by_guid(candidate.guid))
         else:
             asset = candidate.trim_to_required()
         # Preserve the candidate's real identity. trim_to_required() and

--- a/pyatlan/client/aio/batch.py
+++ b/pyatlan/client/aio/batch.py
@@ -446,11 +446,21 @@ class AsyncBatch:
     @staticmethod
     def __track(tracker: List[Asset], candidate: Asset):
         if isinstance(candidate, AtlasGlossaryTerm):
-            # trim_to_required for AtlasGlossaryTerm requires anchor
-            # which is not include in AssetMutationResponse
+            # trim_to_required for AtlasGlossaryTerm requires the anchor (parent
+            # glossary), which is not present in an AssetMutationResponse, so we
+            # fall back to a guid reference and restore the real identity below.
             asset = cast(Asset, AtlasGlossaryTerm.ref_by_guid(candidate.guid))
         else:
             asset = candidate.trim_to_required()
+        # Preserve the candidate's real identity. trim_to_required() and
+        # ref_by_guid() mint a placeholder guid (and ref_by_guid also sets
+        # qualified_name to the guid), which makes the tracked lists
+        # (created/updated/partial_updated/restored) impossible to match back by
+        # guid or qualified_name. The candidate carries the real values.
+        if candidate.guid:
+            asset.guid = candidate.guid
+        if candidate.qualified_name:
+            asset.qualified_name = candidate.qualified_name
         asset.name = candidate.name
         tracker.append(asset)
 

--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -2605,11 +2605,13 @@ class Batch:
 
     @staticmethod
     def __track(tracker: List[Asset], candidate: Asset):
-        if isinstance(candidate, AtlasGlossaryTerm):
-            # trim_to_required for AtlasGlossaryTerm requires the anchor (parent
-            # glossary), which is not present in an AssetMutationResponse, so we
-            # fall back to a guid reference and restore the real identity below.
-            asset = cast(Asset, AtlasGlossaryTerm.ref_by_guid(candidate.guid))
+        if isinstance(candidate, (AtlasGlossaryTerm, AtlasGlossaryCategory)):
+            # trim_to_required for AtlasGlossaryTerm/AtlasGlossaryCategory
+            # requires the anchor (parent glossary), which is not present in an
+            # AssetMutationResponse (it would raise "anchor.guid must be
+            # available"), so we fall back to a guid reference of the
+            # candidate's actual type and restore the real identity below.
+            asset = cast(Asset, type(candidate).ref_by_guid(candidate.guid))
         else:
             asset = candidate.trim_to_required()
         # Preserve the candidate's real identity. trim_to_required() and

--- a/pyatlan/client/asset.py
+++ b/pyatlan/client/asset.py
@@ -2606,11 +2606,21 @@ class Batch:
     @staticmethod
     def __track(tracker: List[Asset], candidate: Asset):
         if isinstance(candidate, AtlasGlossaryTerm):
-            # trim_to_required for AtlasGlossaryTerm requires anchor
-            # which is not include in AssetMutationResponse
+            # trim_to_required for AtlasGlossaryTerm requires the anchor (parent
+            # glossary), which is not present in an AssetMutationResponse, so we
+            # fall back to a guid reference and restore the real identity below.
             asset = cast(Asset, AtlasGlossaryTerm.ref_by_guid(candidate.guid))
         else:
             asset = candidate.trim_to_required()
+        # Preserve the candidate's real identity. trim_to_required() and
+        # ref_by_guid() mint a placeholder guid (and ref_by_guid also sets
+        # qualified_name to the guid), which makes the tracked lists
+        # (created/updated/partial_updated/restored) impossible to match back by
+        # guid or qualified_name. The candidate carries the real values.
+        if candidate.guid:
+            asset.guid = candidate.guid
+        if candidate.qualified_name:
+            asset.qualified_name = candidate.qualified_name
         asset.name = candidate.name
         tracker.append(asset)
 

--- a/pyatlan_v9/client/aio/batch.py
+++ b/pyatlan_v9/client/aio/batch.py
@@ -31,5 +31,14 @@ class AsyncBatch(_LegacyAsyncBatch):
             asset = cast(Asset, type(candidate).ref_by_guid(candidate.guid))
         else:
             asset = candidate.trim_to_required()
+        # Preserve the candidate's real identity. trim_to_required() drops the
+        # guid (leaving it UNSET) and ref_by_guid() drops the qualified_name,
+        # which makes the tracked lists (created/updated/partial_updated/
+        # restored) impossible to match back by guid or qualified_name. The
+        # candidate carries the real values, so restore them here.
+        if candidate.guid:
+            asset.guid = candidate.guid
+        if candidate.qualified_name:
+            asset.qualified_name = candidate.qualified_name
         asset.name = candidate.name
         tracker.append(asset)

--- a/pyatlan_v9/client/aio/batch.py
+++ b/pyatlan_v9/client/aio/batch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional, cast
 
 from pyatlan.client.aio.batch import AsyncBatch as _LegacyAsyncBatch
-from pyatlan_v9.model.assets import Asset, AtlasGlossaryTerm
+from pyatlan_v9.model.assets import Asset, AtlasGlossaryCategory, AtlasGlossaryTerm
 from pyatlan_v9.model.response import AssetMutationResponse
 
 
@@ -24,9 +24,16 @@ class AsyncBatch(_LegacyAsyncBatch):
 
     @staticmethod
     def __track(tracker, candidate):
-        if (
-            isinstance(candidate, AtlasGlossaryTerm)
-            or getattr(candidate, "type_name", None) == "AtlasGlossaryTerm"
+        # trim_to_required for AtlasGlossaryTerm/AtlasGlossaryCategory requires
+        # the anchor (parent glossary), which is not present in an
+        # AssetMutationResponse (it would raise "anchor.guid must be
+        # available"), so we fall back to a guid reference of the candidate's
+        # actual type and restore the real identity below.
+        if isinstance(candidate, (AtlasGlossaryTerm, AtlasGlossaryCategory)) or getattr(
+            candidate, "type_name", None
+        ) in (
+            "AtlasGlossaryTerm",
+            "AtlasGlossaryCategory",
         ):
             asset = cast(Asset, type(candidate).ref_by_guid(candidate.guid))
         else:

--- a/pyatlan_v9/client/asset.py
+++ b/pyatlan_v9/client/asset.py
@@ -2294,5 +2294,14 @@ class Batch(_LegacyBatch):
             asset = cast(Asset, type(candidate).ref_by_guid(candidate.guid))
         else:
             asset = candidate.trim_to_required()
+        # Preserve the candidate's real identity. trim_to_required() drops the
+        # guid (leaving it UNSET) and ref_by_guid() drops the qualified_name,
+        # which makes the tracked lists (created/updated/partial_updated/
+        # restored) impossible to match back by guid or qualified_name. The
+        # candidate carries the real values, so restore them here.
+        if candidate.guid:
+            asset.guid = candidate.guid
+        if candidate.qualified_name:
+            asset.qualified_name = candidate.qualified_name
         asset.name = candidate.name
         tracker.append(asset)

--- a/pyatlan_v9/client/asset.py
+++ b/pyatlan_v9/client/asset.py
@@ -2287,9 +2287,16 @@ class Batch(_LegacyBatch):
 
     @staticmethod
     def __track(tracker, candidate):
-        if (
-            isinstance(candidate, AtlasGlossaryTerm)
-            or getattr(candidate, "type_name", None) == "AtlasGlossaryTerm"
+        # trim_to_required for AtlasGlossaryTerm/AtlasGlossaryCategory requires
+        # the anchor (parent glossary), which is not present in an
+        # AssetMutationResponse (it would raise "anchor.guid must be
+        # available"), so we fall back to a guid reference of the candidate's
+        # actual type and restore the real identity below.
+        if isinstance(candidate, (AtlasGlossaryTerm, AtlasGlossaryCategory)) or getattr(
+            candidate, "type_name", None
+        ) in (
+            "AtlasGlossaryTerm",
+            "AtlasGlossaryCategory",
         ):
             asset = cast(Asset, type(candidate).ref_by_guid(candidate.guid))
         else:

--- a/tests/unit/aio/test_client.py
+++ b/tests/unit/aio/test_client.py
@@ -2555,6 +2555,71 @@ class TestBatch:
             mock_ref_by_guid.assert_has_calls([call(term_1.guid), call(term_2.guid)])
             mock_trim_to_required.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_track_preserves_real_identity_for_both_types(
+        self, mock_async_atlan_client
+    ):
+        # Regression: the tracked lists (created/updated/partial_updated/
+        # restored) must carry each asset's REAL guid AND qualified_name so
+        # callers can match tracked items back to their inputs by either key.
+        # Before the fix, trim_to_required() gave non-glossary assets a
+        # placeholder negative guid, and ref_by_guid() set a glossary term's
+        # qualified_name to its guid, so neither could be matched back reliably.
+        table_guid = "real-table-guid"
+        table_qn = "default/snowflake/123/db/schema/tbl"
+        term_guid = "real-term-guid"
+        term_qn = "real-term-qn"
+
+        table = Table()
+        table.guid = table_guid
+        table.qualified_name = table_qn
+        table.name = "tbl"
+
+        term = AtlasGlossaryTerm()
+        term.guid = term_guid
+        term.qualified_name = term_qn
+        term.name = "myterm"
+
+        mutated_entities = Mock()
+        mock_response = Mock(spec=AssetMutationResponse)
+        mutated_entities.CREATE = []
+        mutated_entities.UPDATE = [table, term]
+        mutated_entities.PARTIAL_UPDATE = None
+        mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
+        mock_response.attach_mock(mutated_entities, "mutated_entities")
+        mock_async_atlan_client.asset.save = AsyncMock(return_value=mock_response)
+
+        batch = AsyncBatch(
+            client=mock_async_atlan_client,
+            max_size=2,
+            track=True,
+        )
+        await batch.add(table)
+        # Batch not yet full, so nothing flushed/tracked.
+        self.assert_asset_client_not_called(mock_async_atlan_client, batch)
+        await batch.add(term)
+
+        assert 2 == batch.num_updated
+        assert 2 == len(batch.updated)
+
+        tracked_table = next(a for a in batch.updated if isinstance(a, Table))
+        tracked_term = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+
+        # Non-glossary asset must keep the real guid (not a placeholder) AND
+        # the real qualified_name.
+        assert tracked_table.guid == table_guid
+        assert tracked_table.qualified_name == table_qn
+
+        # Glossary term must keep the real guid AND the real qualified_name.
+        # This is the key assertion: before the fix the term's qualified_name
+        # was overwritten with its guid by ref_by_guid().
+        assert tracked_term.guid == term_guid
+        assert tracked_term.qualified_name == term_qn
+        assert tracked_term.qualified_name != term_guid
+
     def test_partial_updates_counted_and_not_restored(self, mock_async_atlan_client):
         # Async mirror: partial updates reported under
         # mutated_entities.PARTIAL_UPDATE and/or the top-level

--- a/tests/unit/aio/test_client.py
+++ b/tests/unit/aio/test_client.py
@@ -2565,10 +2565,15 @@ class TestBatch:
         # Before the fix, trim_to_required() gave non-glossary assets a
         # placeholder negative guid, and ref_by_guid() set a glossary term's
         # qualified_name to its guid, so neither could be matched back reliably.
+        # A glossary category in the tracked path crashed __track entirely,
+        # because AtlasGlossaryCategory.trim_to_required() raises
+        # "anchor.guid must be available" without the parent glossary.
         table_guid = "real-table-guid"
         table_qn = "default/snowflake/123/db/schema/tbl"
         term_guid = "real-term-guid"
         term_qn = "real-term-qn"
+        category_guid = "real-category-guid"
+        category_qn = "real-category-qn"
 
         table = Table()
         table.guid = table_guid
@@ -2580,10 +2585,15 @@ class TestBatch:
         term.qualified_name = term_qn
         term.name = "myterm"
 
+        category = AtlasGlossaryCategory()
+        category.guid = category_guid
+        category.qualified_name = category_qn
+        category.name = "mycat"
+
         mutated_entities = Mock()
         mock_response = Mock(spec=AssetMutationResponse)
         mutated_entities.CREATE = []
-        mutated_entities.UPDATE = [table, term]
+        mutated_entities.UPDATE = [table, term, category]
         mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
         mock_response.partial_updated_entities = None
@@ -2592,20 +2602,25 @@ class TestBatch:
 
         batch = AsyncBatch(
             client=mock_async_atlan_client,
-            max_size=2,
+            max_size=3,
             track=True,
         )
         await batch.add(table)
         # Batch not yet full, so nothing flushed/tracked.
         self.assert_asset_client_not_called(mock_async_atlan_client, batch)
         await batch.add(term)
+        # Adding the category must NOT raise (it previously crashed __track).
+        await batch.add(category)
 
-        assert 2 == batch.num_updated
-        assert 2 == len(batch.updated)
+        assert 3 == batch.num_updated
+        assert 3 == len(batch.updated)
 
         tracked_table = next(a for a in batch.updated if isinstance(a, Table))
         tracked_term = next(
             a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+        tracked_category = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryCategory)
         )
 
         # Non-glossary asset must keep the real guid (not a placeholder) AND
@@ -2619,6 +2634,13 @@ class TestBatch:
         assert tracked_term.guid == term_guid
         assert tracked_term.qualified_name == term_qn
         assert tracked_term.qualified_name != term_guid
+
+        # Glossary category must keep the real guid AND the real
+        # qualified_name, and stay typed as a category (not a term).
+        assert tracked_category.guid == category_guid
+        assert tracked_category.qualified_name == category_qn
+        assert tracked_category.qualified_name != category_guid
+        assert tracked_category.type_name == "AtlasGlossaryCategory"
 
     def test_partial_updates_counted_and_not_restored(self, mock_async_atlan_client):
         # Async mirror: partial updates reported under

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2333,10 +2333,15 @@ class TestBatch:
         # Before the fix, trim_to_required() gave non-glossary assets a
         # placeholder negative guid, and ref_by_guid() set a glossary term's
         # qualified_name to its guid, so neither could be matched back reliably.
+        # A glossary category in the tracked path crashed __track entirely,
+        # because AtlasGlossaryCategory.trim_to_required() raises
+        # "anchor.guid must be available" without the parent glossary.
         table_guid = "real-table-guid"
         table_qn = "default/snowflake/123/db/schema/tbl"
         term_guid = "real-term-guid"
         term_qn = "real-term-qn"
+        category_guid = "real-category-guid"
+        category_qn = "real-category-qn"
 
         table = Table()
         table.guid = table_guid
@@ -2348,10 +2353,15 @@ class TestBatch:
         term.qualified_name = term_qn
         term.name = "myterm"
 
+        category = AtlasGlossaryCategory()
+        category.guid = category_guid
+        category.qualified_name = category_qn
+        category.name = "mycat"
+
         mutated_entities = Mock()
         mock_response = Mock(spec=AssetMutationResponse)
         mutated_entities.CREATE = []
-        mutated_entities.UPDATE = [table, term]
+        mutated_entities.UPDATE = [table, term, category]
         mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
         mock_response.partial_updated_entities = None
@@ -2360,20 +2370,25 @@ class TestBatch:
 
         batch = Batch(
             client=mock_atlan_client,
-            max_size=2,
+            max_size=3,
             track=True,
         )
         batch.add(table)
         # Batch not yet full, so nothing flushed/tracked.
         self.assert_asset_client_not_called(mock_atlan_client, batch)
         batch.add(term)
+        # Adding the category must NOT raise (it previously crashed __track).
+        batch.add(category)
 
-        assert 2 == batch.num_updated
-        assert 2 == len(batch.updated)
+        assert 3 == batch.num_updated
+        assert 3 == len(batch.updated)
 
         tracked_table = next(a for a in batch.updated if isinstance(a, Table))
         tracked_term = next(
             a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+        tracked_category = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryCategory)
         )
 
         # Non-glossary asset must keep the real guid (not a placeholder) AND
@@ -2387,6 +2402,13 @@ class TestBatch:
         assert tracked_term.guid == term_guid
         assert tracked_term.qualified_name == term_qn
         assert tracked_term.qualified_name != term_guid
+
+        # Glossary category must keep the real guid AND the real
+        # qualified_name, and stay typed as a category (not a term).
+        assert tracked_category.guid == category_guid
+        assert tracked_category.qualified_name == category_qn
+        assert tracked_category.qualified_name != category_guid
+        assert tracked_category.type_name == "AtlasGlossaryCategory"
 
     def test_partial_update_alias_does_not_collide_with_delete(self):
         # Regression: MutatedEntities.PARTIAL_UPDATE previously carried

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2326,6 +2326,68 @@ class TestBatch:
         mock_ref_by_guid.assert_has_calls([call(term_1.guid), call(term_2.guid)])
         mock_trim_to_required.assert_not_called()
 
+    def test_track_preserves_real_identity_for_both_types(self, mock_atlan_client):
+        # Regression: the tracked lists (created/updated/partial_updated/
+        # restored) must carry each asset's REAL guid AND qualified_name so
+        # callers can match tracked items back to their inputs by either key.
+        # Before the fix, trim_to_required() gave non-glossary assets a
+        # placeholder negative guid, and ref_by_guid() set a glossary term's
+        # qualified_name to its guid, so neither could be matched back reliably.
+        table_guid = "real-table-guid"
+        table_qn = "default/snowflake/123/db/schema/tbl"
+        term_guid = "real-term-guid"
+        term_qn = "real-term-qn"
+
+        table = Table()
+        table.guid = table_guid
+        table.qualified_name = table_qn
+        table.name = "tbl"
+
+        term = AtlasGlossaryTerm()
+        term.guid = term_guid
+        term.qualified_name = term_qn
+        term.name = "myterm"
+
+        mutated_entities = Mock()
+        mock_response = Mock(spec=AssetMutationResponse)
+        mutated_entities.CREATE = []
+        mutated_entities.UPDATE = [table, term]
+        mutated_entities.PARTIAL_UPDATE = None
+        mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
+        mock_response.attach_mock(mutated_entities, "mutated_entities")
+        mock_atlan_client.asset.save.return_value = mock_response
+
+        batch = Batch(
+            client=mock_atlan_client,
+            max_size=2,
+            track=True,
+        )
+        batch.add(table)
+        # Batch not yet full, so nothing flushed/tracked.
+        self.assert_asset_client_not_called(mock_atlan_client, batch)
+        batch.add(term)
+
+        assert 2 == batch.num_updated
+        assert 2 == len(batch.updated)
+
+        tracked_table = next(a for a in batch.updated if isinstance(a, Table))
+        tracked_term = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+
+        # Non-glossary asset must keep the real guid (not a placeholder) AND
+        # the real qualified_name.
+        assert tracked_table.guid == table_guid
+        assert tracked_table.qualified_name == table_qn
+
+        # Glossary term must keep the real guid AND the real qualified_name.
+        # This is the key assertion: before the fix the term's qualified_name
+        # was overwritten with its guid by ref_by_guid().
+        assert tracked_term.guid == term_guid
+        assert tracked_term.qualified_name == term_qn
+        assert tracked_term.qualified_name != term_guid
+
     def test_partial_update_alias_does_not_collide_with_delete(self):
         # Regression: MutatedEntities.PARTIAL_UPDATE previously carried
         # alias="DELETE", so a wire "PARTIAL_UPDATE" payload was dropped and

--- a/tests_v9/unit/aio/test_client.py
+++ b/tests_v9/unit/aio/test_client.py
@@ -2646,6 +2646,69 @@ class TestBatch:
             mock_ref_by_guid.assert_has_calls([call(term_1.guid), call(term_2.guid)])
             mock_trim_to_required.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_track_preserves_real_identity_for_both_types(
+        self, mock_async_atlan_client
+    ):
+        # Regression: the tracked lists (created/updated/partial_updated/
+        # restored) must carry each asset's REAL guid AND qualified_name so
+        # callers can match tracked items back to their inputs by either key.
+        # In v9, trim_to_required() leaves the guid UNSET for non-glossary
+        # assets, and ref_by_guid() leaves the qualified_name UNSET for glossary
+        # terms, so neither could be matched back reliably before the fix.
+        table_guid = "real-table-guid"
+        table_qn = "default/snowflake/123/db/schema/tbl"
+        term_guid = "real-term-guid"
+        term_qn = "real-term-qn"
+
+        table = Table(guid=table_guid, qualified_name=table_qn, name="tbl")
+        term = AtlasGlossaryTerm(
+            guid=term_guid,
+            qualified_name=term_qn,
+            name="myterm",
+            type_name="AtlasGlossaryTerm",
+        )
+
+        mutated_entities = Mock()
+        mock_response = Mock(spec=AssetMutationResponse)
+        mutated_entities.CREATE = []
+        mutated_entities.UPDATE = [table, term]
+        mutated_entities.PARTIAL_UPDATE = None
+        mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
+        mock_response.attach_mock(mutated_entities, "mutated_entities")
+        mock_async_atlan_client.asset.save = AsyncMock(return_value=mock_response)
+
+        batch = AsyncBatch(
+            client=mock_async_atlan_client,
+            max_size=2,
+            track=True,
+        )
+        await batch.add(table)
+        # Batch not yet full, so nothing flushed/tracked.
+        self.assert_asset_client_not_called(mock_async_atlan_client, batch)
+        await batch.add(term)
+
+        assert 2 == batch.num_updated
+        assert 2 == len(batch.updated)
+
+        tracked_table = next(a for a in batch.updated if isinstance(a, Table))
+        tracked_term = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+
+        # Non-glossary asset must keep the real guid (not UNSET) AND the real
+        # qualified_name.
+        assert tracked_table.guid == table_guid
+        assert tracked_table.qualified_name == table_qn
+
+        # Glossary term must keep the real guid AND the real qualified_name.
+        # Before the fix the term's qualified_name was UNSET (ref_by_guid does
+        # not carry it over).
+        assert tracked_term.guid == term_guid
+        assert tracked_term.qualified_name == term_qn
+        assert tracked_term.qualified_name != term_guid
+
 
 class TestBulkRequest:
     SEE_ALSO = "seeAlso"

--- a/tests_v9/unit/aio/test_client.py
+++ b/tests_v9/unit/aio/test_client.py
@@ -2656,10 +2656,15 @@ class TestBatch:
         # In v9, trim_to_required() leaves the guid UNSET for non-glossary
         # assets, and ref_by_guid() leaves the qualified_name UNSET for glossary
         # terms, so neither could be matched back reliably before the fix.
+        # A glossary category in the tracked path crashed __track entirely,
+        # because AtlasGlossaryCategory.trim_to_required() raises
+        # "anchor.guid must be available" without the parent glossary.
         table_guid = "real-table-guid"
         table_qn = "default/snowflake/123/db/schema/tbl"
         term_guid = "real-term-guid"
         term_qn = "real-term-qn"
+        category_guid = "real-category-guid"
+        category_qn = "real-category-qn"
 
         table = Table(guid=table_guid, qualified_name=table_qn, name="tbl")
         term = AtlasGlossaryTerm(
@@ -2668,11 +2673,17 @@ class TestBatch:
             name="myterm",
             type_name="AtlasGlossaryTerm",
         )
+        category = AtlasGlossaryCategory(
+            guid=category_guid,
+            qualified_name=category_qn,
+            name="mycat",
+            type_name="AtlasGlossaryCategory",
+        )
 
         mutated_entities = Mock()
         mock_response = Mock(spec=AssetMutationResponse)
         mutated_entities.CREATE = []
-        mutated_entities.UPDATE = [table, term]
+        mutated_entities.UPDATE = [table, term, category]
         mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
         mock_response.partial_updated_entities = None
@@ -2681,20 +2692,25 @@ class TestBatch:
 
         batch = AsyncBatch(
             client=mock_async_atlan_client,
-            max_size=2,
+            max_size=3,
             track=True,
         )
         await batch.add(table)
         # Batch not yet full, so nothing flushed/tracked.
         self.assert_asset_client_not_called(mock_async_atlan_client, batch)
         await batch.add(term)
+        # Adding the category must NOT raise (it previously crashed __track).
+        await batch.add(category)
 
-        assert 2 == batch.num_updated
-        assert 2 == len(batch.updated)
+        assert 3 == batch.num_updated
+        assert 3 == len(batch.updated)
 
         tracked_table = next(a for a in batch.updated if isinstance(a, Table))
         tracked_term = next(
             a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+        tracked_category = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryCategory)
         )
 
         # Non-glossary asset must keep the real guid (not UNSET) AND the real
@@ -2708,6 +2724,13 @@ class TestBatch:
         assert tracked_term.guid == term_guid
         assert tracked_term.qualified_name == term_qn
         assert tracked_term.qualified_name != term_guid
+
+        # Glossary category must keep the real guid AND the real
+        # qualified_name, and stay typed as a category (not a term).
+        assert tracked_category.guid == category_guid
+        assert tracked_category.qualified_name == category_qn
+        assert tracked_category.qualified_name != category_guid
+        assert tracked_category.type_name == "AtlasGlossaryCategory"
 
 
 class TestBulkRequest:

--- a/tests_v9/unit/test_client.py
+++ b/tests_v9/unit/test_client.py
@@ -2622,10 +2622,15 @@ class TestBatch:
         # In v9, trim_to_required() leaves the guid UNSET for non-glossary
         # assets, and ref_by_guid() leaves the qualified_name UNSET for glossary
         # terms, so neither could be matched back reliably before the fix.
+        # A glossary category in the tracked path crashed __track entirely,
+        # because AtlasGlossaryCategory.trim_to_required() raises
+        # "anchor.guid must be available" without the parent glossary.
         table_guid = "real-table-guid"
         table_qn = "default/snowflake/123/db/schema/tbl"
         term_guid = "real-term-guid"
         term_qn = "real-term-qn"
+        category_guid = "real-category-guid"
+        category_qn = "real-category-qn"
 
         table = Table(guid=table_guid, qualified_name=table_qn, name="tbl")
         term = AtlasGlossaryTerm(
@@ -2634,11 +2639,17 @@ class TestBatch:
             name="myterm",
             type_name="AtlasGlossaryTerm",
         )
+        category = AtlasGlossaryCategory(
+            guid=category_guid,
+            qualified_name=category_qn,
+            name="mycat",
+            type_name="AtlasGlossaryCategory",
+        )
 
         mutated_entities = Mock()
         mock_response = Mock(spec=AssetMutationResponse)
         mutated_entities.CREATE = []
-        mutated_entities.UPDATE = [table, term]
+        mutated_entities.UPDATE = [table, term, category]
         mutated_entities.PARTIAL_UPDATE = None
         mock_response.guid_assignments = {}
         mock_response.partial_updated_entities = None
@@ -2647,20 +2658,25 @@ class TestBatch:
 
         batch = Batch(
             client=mock_atlan_client,
-            max_size=2,
+            max_size=3,
             track=True,
         )
         batch.add(table)
         # Batch not yet full, so nothing flushed/tracked.
         self.assert_asset_client_not_called(mock_atlan_client, batch)
         batch.add(term)
+        # Adding the category must NOT raise (it previously crashed __track).
+        batch.add(category)
 
-        assert 2 == batch.num_updated
-        assert 2 == len(batch.updated)
+        assert 3 == batch.num_updated
+        assert 3 == len(batch.updated)
 
         tracked_table = next(a for a in batch.updated if isinstance(a, Table))
         tracked_term = next(
             a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+        tracked_category = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryCategory)
         )
 
         # Non-glossary asset must keep the real guid (not UNSET) AND the real
@@ -2674,6 +2690,13 @@ class TestBatch:
         assert tracked_term.guid == term_guid
         assert tracked_term.qualified_name == term_qn
         assert tracked_term.qualified_name != term_guid
+
+        # Glossary category must keep the real guid AND the real
+        # qualified_name, and stay typed as a category (not a term).
+        assert tracked_category.guid == category_guid
+        assert tracked_category.qualified_name == category_qn
+        assert tracked_category.qualified_name != category_guid
+        assert tracked_category.type_name == "AtlasGlossaryCategory"
 
 
 # ---------------------------------------------------------------------------

--- a/tests_v9/unit/test_client.py
+++ b/tests_v9/unit/test_client.py
@@ -2615,6 +2615,66 @@ class TestBatch:
         mock_ref_by_guid.assert_has_calls([call(term_1.guid), call(term_2.guid)])
         mock_trim_to_required.assert_not_called()
 
+    def test_track_preserves_real_identity_for_both_types(self, mock_atlan_client):
+        # Regression: the tracked lists (created/updated/partial_updated/
+        # restored) must carry each asset's REAL guid AND qualified_name so
+        # callers can match tracked items back to their inputs by either key.
+        # In v9, trim_to_required() leaves the guid UNSET for non-glossary
+        # assets, and ref_by_guid() leaves the qualified_name UNSET for glossary
+        # terms, so neither could be matched back reliably before the fix.
+        table_guid = "real-table-guid"
+        table_qn = "default/snowflake/123/db/schema/tbl"
+        term_guid = "real-term-guid"
+        term_qn = "real-term-qn"
+
+        table = Table(guid=table_guid, qualified_name=table_qn, name="tbl")
+        term = AtlasGlossaryTerm(
+            guid=term_guid,
+            qualified_name=term_qn,
+            name="myterm",
+            type_name="AtlasGlossaryTerm",
+        )
+
+        mutated_entities = Mock()
+        mock_response = Mock(spec=AssetMutationResponse)
+        mutated_entities.CREATE = []
+        mutated_entities.UPDATE = [table, term]
+        mutated_entities.PARTIAL_UPDATE = None
+        mock_response.guid_assignments = {}
+        mock_response.partial_updated_entities = None
+        mock_response.attach_mock(mutated_entities, "mutated_entities")
+        mock_atlan_client.asset.save.return_value = mock_response
+
+        batch = Batch(
+            client=mock_atlan_client,
+            max_size=2,
+            track=True,
+        )
+        batch.add(table)
+        # Batch not yet full, so nothing flushed/tracked.
+        self.assert_asset_client_not_called(mock_atlan_client, batch)
+        batch.add(term)
+
+        assert 2 == batch.num_updated
+        assert 2 == len(batch.updated)
+
+        tracked_table = next(a for a in batch.updated if isinstance(a, Table))
+        tracked_term = next(
+            a for a in batch.updated if isinstance(a, AtlasGlossaryTerm)
+        )
+
+        # Non-glossary asset must keep the real guid (not UNSET) AND the real
+        # qualified_name.
+        assert tracked_table.guid == table_guid
+        assert tracked_table.qualified_name == table_qn
+
+        # Glossary term must keep the real guid AND the real qualified_name.
+        # Before the fix the term's qualified_name was UNSET (ref_by_guid does
+        # not carry it over).
+        assert tracked_term.guid == term_guid
+        assert tracked_term.qualified_name == term_qn
+        assert tracked_term.qualified_name != term_guid
+
 
 # ---------------------------------------------------------------------------
 # BulkRequest tests


### PR DESCRIPTION
## Problem

`Batch.__track` / `AsyncBatch.__track` (in **both** `pyatlan` and `pyatlan_v9`) rebuild each tracked asset via `trim_to_required()` / `ref_by_guid()` and then copy only `name`. So the tracked lists — `batch.created` / `updated` / `partial_updated` / `restored` — carry a **corrupted identity** that callers can't match back to their inputs:

- **non-glossary assets** (`trim_to_required()`): real `qualified_name` is kept, but the `guid` becomes a random placeholder (pyatlan, via `@init_guid`) or is left `UNSET` (pyatlan_v9).
- **glossary terms/categories** (`ref_by_guid()`): real `guid` is kept, but `qualified_name` is set **to the guid** (pyatlan) or left `UNSET` (pyatlan_v9).

Net: neither `guid` nor `qualified_name` is reliable across the tracked lists, so they can't be used to reconcile results across asset types. (This is distinct from the 9.7.5 partial-update count / alias fix in #951 — that was the count side; this is the read/identity side.)

## Fix

After building the tracked asset, restore the candidate's real `guid` and `qualified_name` (guarded for falsy / `UNSET`), keeping `name`. Applied to all four implementations:
- `pyatlan/client/asset.py` (`Batch`), `pyatlan/client/aio/batch.py` (`AsyncBatch`)
- `pyatlan_v9/client/asset.py` (`Batch`), `pyatlan_v9/client/aio/batch.py` (`AsyncBatch`)

## Verification

**Live (real calls against a tenant), with the fix:**
```
Table tracked → guid=44346641-...  qn=default/snowflake/.../ZZ_T          ✓ real
Term  tracked → guid=079055fa-...  qn=hqwJA39...@...  (qn != guid)        ✓ real
```

**Tests:** regression test added in all four suites (`tests/unit{,/aio}/test_client.py`, `tests_v9/unit{,/aio}/test_client.py`) asserting a tracked `Table` and `AtlasGlossaryTerm` each carry the real `guid` AND `qualified_name` (and a term's tracked `qualified_name` is no longer its guid). Confirmed failing pre-fix, passing post-fix. Full suites: **7583 passed, 5 skipped**. `ruff check`/`format` clean; `mypy` adds no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)