### PR TITLE
feat(enums): add PersonaAIAction, AdminAction, TypeDefAction (BLDX-1505)

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -2190,6 +2190,49 @@ class PurposeMetadataAction(str, Enum):
     DETACH_TERMS = "purpose-remove-terms"
 
 
+class PersonaAIAction(str, Enum):
+    APP_READ = "persona-ai-application-read"
+    APP_CREATE = "persona-ai-application-create"
+    APP_UPDATE = "persona-ai-application-update"
+    APP_DELETE = "persona-ai-application-delete"
+    APP_UPDATE_CM = "persona-ai-application-business-update-metadata"
+    APP_ADD_TERMS = "persona-ai-application-add-terms"
+    APP_REMOVE_TERMS = "persona-ai-application-remove-terms"
+    APP_ADD_ATLAN_TAGS = "persona-ai-application-add-classification"
+    APP_REMOVE_ATLAN_TAGS = "persona-ai-application-remove-classification"
+    MODEL_READ = "persona-ai-model-read"
+    MODEL_CREATE = "persona-ai-model-create"
+    MODEL_UPDATE = "persona-ai-model-update"
+    MODEL_DELETE = "persona-ai-model-delete"
+    MODEL_UPDATE_CM = "persona-ai-model-business-update-metadata"
+    MODEL_ADD_TERMS = "persona-ai-model-add-terms"
+    MODEL_REMOVE_TERMS = "persona-ai-model-remove-terms"
+    MODEL_ADD_ATLAN_TAGS = "persona-ai-model-add-classification"
+    MODEL_REMOVE_ATLAN_TAGS = "persona-ai-model-remove-classification"
+
+
+class AdminAction(str, Enum):
+    ADMIN_TASK_CUD = "admin-task-cud"
+    ADMIN_AUDITS = "admin-audits"
+    ADMIN_EXPORT = "admin-export"
+    ADMIN_FEATURE_FLAG_CUD = "admin-featureFlag-cud"
+    ADMIN_IMPORT = "admin-import"
+    ADMIN_PURGE = "admin-purge"
+    ADMIN_REPAIR_INDEX = "admin-repair-index"
+
+
+class TypeDefAction(str, Enum):
+    CREATE = "type-create"
+    READ = "type-read"
+    UPDATE = "type-update"
+    DELETE = "type-delete"
+    ADD_LABEL = "entity-add-label"
+    REMOVE_LABEL = "entity-remove-label"
+    ADD_RELATIONSHIP = "add-relationship"
+    UPDATE_RELATIONSHIP = "update-relationship"
+    REMOVE_RELATIONSHIP = "remove-relationship"
+
+
 class QueryParserSourceType(str, Enum):
     ANSI = "ansi"
     BIGQUERY = "bigquery"

--- a/tests/unit/model/test_policy_action_enums.py
+++ b/tests/unit/model/test_policy_action_enums.py
@@ -1,0 +1,91 @@
+"""Tests for policy-action enums added for the Admin Export utility (BLDX-1505).
+
+These mirror the Java SDK enums in `com.atlan.model.enums`. The Admin Export
+utility reads policy actions from the metadata lakehouse as raw Ranger slugs
+(the enum *value*) and converts each to its enum *name* to preserve legacy
+output parity, so the slug -> name mapping must match the Java SDK exactly.
+"""
+
+import pytest
+
+from pyatlan.model.enums import AdminAction, PersonaAIAction, TypeDefAction
+
+# Slug (Ranger value) -> enum name, copied verbatim from the Java SDK enums.
+PERSONA_AI_ACTIONS = {
+    "persona-ai-application-read": "APP_READ",
+    "persona-ai-application-create": "APP_CREATE",
+    "persona-ai-application-update": "APP_UPDATE",
+    "persona-ai-application-delete": "APP_DELETE",
+    "persona-ai-application-business-update-metadata": "APP_UPDATE_CM",
+    "persona-ai-application-add-terms": "APP_ADD_TERMS",
+    "persona-ai-application-remove-terms": "APP_REMOVE_TERMS",
+    "persona-ai-application-add-classification": "APP_ADD_ATLAN_TAGS",
+    "persona-ai-application-remove-classification": "APP_REMOVE_ATLAN_TAGS",
+    "persona-ai-model-read": "MODEL_READ",
+    "persona-ai-model-create": "MODEL_CREATE",
+    "persona-ai-model-update": "MODEL_UPDATE",
+    "persona-ai-model-delete": "MODEL_DELETE",
+    "persona-ai-model-business-update-metadata": "MODEL_UPDATE_CM",
+    "persona-ai-model-add-terms": "MODEL_ADD_TERMS",
+    "persona-ai-model-remove-terms": "MODEL_REMOVE_TERMS",
+    "persona-ai-model-add-classification": "MODEL_ADD_ATLAN_TAGS",
+    "persona-ai-model-remove-classification": "MODEL_REMOVE_ATLAN_TAGS",
+}
+
+ADMIN_ACTIONS = {
+    "admin-task-cud": "ADMIN_TASK_CUD",
+    "admin-audits": "ADMIN_AUDITS",
+    "admin-export": "ADMIN_EXPORT",
+    "admin-featureFlag-cud": "ADMIN_FEATURE_FLAG_CUD",
+    "admin-import": "ADMIN_IMPORT",
+    "admin-purge": "ADMIN_PURGE",
+    "admin-repair-index": "ADMIN_REPAIR_INDEX",
+}
+
+TYPE_DEF_ACTIONS = {
+    "type-create": "CREATE",
+    "type-read": "READ",
+    "type-update": "UPDATE",
+    "type-delete": "DELETE",
+    "entity-add-label": "ADD_LABEL",
+    "entity-remove-label": "REMOVE_LABEL",
+    "add-relationship": "ADD_RELATIONSHIP",
+    "update-relationship": "UPDATE_RELATIONSHIP",
+    "remove-relationship": "REMOVE_RELATIONSHIP",
+}
+
+
+@pytest.mark.parametrize(
+    ("enum_cls", "expected"),
+    [
+        (PersonaAIAction, PERSONA_AI_ACTIONS),
+        (AdminAction, ADMIN_ACTIONS),
+        (TypeDefAction, TYPE_DEF_ACTIONS),
+    ],
+)
+def test_enum_members_match_java_sdk(enum_cls, expected):
+    """Every member's (value -> name) pair matches the Java SDK, with no extras."""
+    actual = {member.value: member.name for member in enum_cls}
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("enum_cls", "expected"),
+    [
+        (PersonaAIAction, PERSONA_AI_ACTIONS),
+        (AdminAction, ADMIN_ACTIONS),
+        (TypeDefAction, TYPE_DEF_ACTIONS),
+    ],
+)
+def test_slug_resolves_to_enum_name(enum_cls, expected):
+    """Slug -> name lookup (what the Admin Export utility relies on)."""
+    for slug, name in expected.items():
+        assert enum_cls(slug).name == name
+
+
+def test_enums_are_str_backed():
+    """Values serialize as their raw Ranger slug (str, Enum)."""
+    assert isinstance(PersonaAIAction.APP_READ, str)
+    assert PersonaAIAction.APP_READ == "persona-ai-application-read"
+    assert AdminAction.ADMIN_EXPORT == "admin-export"
+    assert TypeDefAction.ADD_RELATIONSHIP == "add-relationship"


### PR DESCRIPTION
## What

Adds three policy-action enums to `pyatlan.model.enums`, mirroring the Java SDK enums in `com.atlan.model.enums` and matching the shape of the existing `PersonaMetadataAction` / `DataAction`:

- **`PersonaAIAction`** — 18 members covering all `persona-ai-application-*` and `persona-ai-model-*` Ranger slugs (read/create/update/delete/business-update-metadata/add-terms/remove-terms/add-classification/remove-classification).
- **`AdminAction`** — 7 members covering the `admin-*` slugs.
- **`TypeDefAction`** — 9 members covering the `type-*`, `entity-*-label`, and `*-relationship` slugs.

## Why

The CSA Uber App **Admin Export** utility exports a tenant's personas/purposes/policies via pyatlan. Policy actions are read in bulk from the metadata lakehouse as raw Ranger slugs, then converted to enum **names** to preserve legacy output parity. That conversion works for every category except AI, because pyatlan had no `PersonaAIAction` enum, so AI slugs stayed unconverted. A temporary hand-coded fallback for these slugs auto-defers to the real enum once it exists.

Per the issue thread, `AdminAction` and `TypeDefAction` were requested alongside `PersonaAIAction`.

## Source of truth

Ported verbatim from the latest `atlan-java` `main`:
- `com/atlan/model/enums/PersonaAIAction.java`
- `com/atlan/model/enums/AdminAction.java`
- `com/atlan/model/enums/TypeDefAction.java`

Value → name parity with the Java SDK is **exact** (18 / 7 / 9) and locked by unit tests.

## Tests

`tests/unit/model/test_policy_action_enums.py` (7 tests) asserts the full slug → name mapping against the Java SDK for all three enums, plus the slug→name lookup the export utility relies on. Lint + format clean.

Closes BLDX-1505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)