### PR TITLE
fix: bound bulk AuditSearch offset-paging fallback within a timestamp bucket (BLDX-1549)

### DIFF
--- a/pyatlan/model/aio/audit.py
+++ b/pyatlan/model/aio/audit.py
@@ -2,7 +2,8 @@
 # Copyright 2025 Atlan Pte. Ltd.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, Set
+from datetime import datetime
+from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, Set, Union
 
 from pydantic.v1 import ValidationError, parse_obj_as
 
@@ -53,6 +54,11 @@ class AsyncAuditSearchResults:
         self._first_record_creation_time = -2
         self._last_record_creation_time = -2
         self._processed_entity_keys: Set[str] = set()
+        # See AuditSearchResults: the offset fallback offsets WITHIN a single
+        # `created` timestamp bucket (bounded) rather than over the whole result
+        # set, so from_ + size can never exceed ES's max_result_window (BLDX-1549).
+        self._max_processed_ts: Optional[datetime] = None
+        self._count_at_max_ts: int = 0
 
     @property
     def aggregations(self) -> Optional[Aggregation]:
@@ -89,9 +95,17 @@ class AsyncAuditSearchResults:
             # in a previous page of results.
             # If it has,then exclude it from the current results;
             # otherwise, we may encounter duplicate audit entity records.
-            self._processed_entity_keys.update(
-                entity.event_key for entity in self._entity_audits
-            )
+            for entity in self._entity_audits:
+                if entity.event_key in self._processed_entity_keys:
+                    continue
+                self._processed_entity_keys.add(entity.event_key)
+                # Maintain the max-timestamp bucket used by the offset fallback.
+                ts = entity.created
+                if self._max_processed_ts is None or ts > self._max_processed_ts:
+                    self._max_processed_ts = ts
+                    self._count_at_max_ts = 1
+                elif ts == self._max_processed_ts:
+                    self._count_at_max_ts += 1
         return await self._get_next_page() if self._entity_audits else False
 
     async def _get_next_page(self):
@@ -154,43 +168,50 @@ class AsyncAuditSearchResults:
                 rewritten_filters.append(filter_)
 
         if self._first_record_creation_time != self._last_record_creation_time:
+            # The page spans multiple `created` timestamps: advance the window past
+            # the last one and reset the offset — the normal fast path.
             rewritten_filters.append(
                 self._get_paging_timestamp_query(self._last_record_creation_time)
             )
-            if isinstance(query, Bool):
-                rewritten_query = Bool(
-                    filter=rewritten_filters,
-                    must=query.must,
-                    must_not=query.must_not,
-                    should=query.should,
-                    boost=query.boost,
-                    minimum_should_match=query.minimum_should_match,
-                )
-            else:
-                # If a Term, Range, etc query type is found
-                # in the DSL, append it to the Bool `filter`.
-                rewritten_filters.append(query)
-                rewritten_query = Bool(filter=rewritten_filters)
-            self._criteria.dsl.from_ = 0
-            self._criteria.dsl.query = rewritten_query
+            from_ = 0
         else:
-            # Ensure that when switching to offset-based paging, if the first and last record timestamps are the same,
-            # we do not include a created timestamp filter (ie: Range(field='__timestamp', gte=VALUE)) in the query.
-            # Instead, ensure the search runs with only SortItem(field='__timestamp', order=<SortOrder.ASCENDING>).
-            # Failing to do so can lead to incomplete results (less than the approximate count) when running the search
-            # with a small page size.
-            if isinstance(query, Bool):
-                for filter_ in query.filter:
-                    if self._is_paging_timestamp_query(filter_):
-                        query.filter.remove(filter_)
+            # The page collapsed to a single `created` timestamp (or netted <= 1 new
+            # record after dedup), so the window cannot be advanced by timestamp.
+            # Keep the timestamp filter pinned to that timestamp and offset only
+            # WITHIN its bucket, so `from_` is bounded by the number of audits that
+            # share one timestamp — `from_ + size` can never exceed ES's
+            # max_result_window. Dedup via `_processed_entity_keys` still guards
+            # against boundary overlap.
+            #
+            # Previously this offset was `len(self._processed_entity_keys)` over the
+            # whole result set with the timestamp filter dropped, which Elasticsearch
+            # rejected once > 10,000 audits had been processed (BLDX-1549:
+            # "Result window is too large ... but was [43504]").
+            if self._max_processed_ts is not None:
+                rewritten_filters.append(
+                    self._get_paging_timestamp_query(self._max_processed_ts)
+                )
+            from_ = self._count_at_max_ts
 
-            # Always ensure that the offset is set to the length of the processed assets
-            # instead of the default (start + size), as the default may skip some assets
-            # and result in incomplete results (less than the approximate count)
-            self._criteria.dsl.from_ = len(self._processed_entity_keys)
+        if isinstance(query, Bool):
+            rewritten_query = Bool(
+                filter=rewritten_filters,
+                must=query.must,
+                must_not=query.must_not,
+                should=query.should,
+                boost=query.boost,
+                minimum_should_match=query.minimum_should_match,
+            )
+        else:
+            # If a Term, Range, etc query type is found
+            # in the DSL, append it to the Bool `filter`.
+            rewritten_filters.append(query)
+            rewritten_query = Bool(filter=rewritten_filters)
+        self._criteria.dsl.from_ = from_
+        self._criteria.dsl.query = rewritten_query
 
     @staticmethod
-    def _get_paging_timestamp_query(last_timestamp: int) -> Query:
+    def _get_paging_timestamp_query(last_timestamp: Union[int, datetime]) -> Query:
         """
         Get timestamp query for paging based on the last record's timestamp.
 

--- a/pyatlan/model/audit.py
+++ b/pyatlan/model/audit.py
@@ -262,6 +262,13 @@ class AuditSearchResults(Iterable):
         self._first_record_creation_time = -2
         self._last_record_creation_time = -2
         self._processed_entity_keys: Set[str] = set()
+        # Track the greatest `created` timestamp seen among processed audits and
+        # how many processed audits share it. The timestamp-paging offset fallback
+        # offsets WITHIN this single-timestamp bucket (bounded) rather than over the
+        # whole result set — so `from_ + size` can never exceed ES's max_result_window
+        # (BLDX-1549: the old `from_ = len(processed)` crashed past 10,000 audits).
+        self._max_processed_ts: Optional[datetime] = None
+        self._count_at_max_ts: int = 0
 
     @property
     def aggregations(self) -> Optional[Aggregation]:
@@ -298,9 +305,17 @@ class AuditSearchResults(Iterable):
             # in a previous page of results.
             # If it has,then exclude it from the current results;
             # otherwise, we may encounter duplicate audit entity records.
-            self._processed_entity_keys.update(
-                entity.event_key for entity in self._entity_audits
-            )
+            for entity in self._entity_audits:
+                if entity.event_key in self._processed_entity_keys:
+                    continue
+                self._processed_entity_keys.add(entity.event_key)
+                # Maintain the max-timestamp bucket used by the offset fallback.
+                ts = entity.created
+                if self._max_processed_ts is None or ts > self._max_processed_ts:
+                    self._max_processed_ts = ts
+                    self._count_at_max_ts = 1
+                elif ts == self._max_processed_ts:
+                    self._count_at_max_ts += 1
         return self._get_next_page() if self._entity_audits else False
 
     def _get_next_page(self):
@@ -363,43 +378,50 @@ class AuditSearchResults(Iterable):
                 rewritten_filters.append(filter_)
 
         if self._first_record_creation_time != self._last_record_creation_time:
+            # The page spans multiple `created` timestamps: advance the window past
+            # the last one and reset the offset — the normal fast path.
             rewritten_filters.append(
                 self._get_paging_timestamp_query(self._last_record_creation_time)
             )
-            if isinstance(query, Bool):
-                rewritten_query = Bool(
-                    filter=rewritten_filters,
-                    must=query.must,
-                    must_not=query.must_not,
-                    should=query.should,
-                    boost=query.boost,
-                    minimum_should_match=query.minimum_should_match,
-                )
-            else:
-                # If a Term, Range, etc query type is found
-                # in the DSL, append it to the Bool `filter`.
-                rewritten_filters.append(query)
-                rewritten_query = Bool(filter=rewritten_filters)
-            self._criteria.dsl.from_ = 0
-            self._criteria.dsl.query = rewritten_query
+            from_ = 0
         else:
-            # Ensure that when switching to offset-based paging, if the first and last record timestamps are the same,
-            # we do not include a created timestamp filter (ie: Range(field='__timestamp', gte=VALUE)) in the query.
-            # Instead, ensure the search runs with only SortItem(field='__timestamp', order=<SortOrder.ASCENDING>).
-            # Failing to do so can lead to incomplete results (less than the approximate count) when running the search
-            # with a small page size.
-            if isinstance(query, Bool):
-                for filter_ in query.filter:
-                    if self._is_paging_timestamp_query(filter_):
-                        query.filter.remove(filter_)
+            # The page collapsed to a single `created` timestamp (or netted <= 1 new
+            # record after dedup), so the window cannot be advanced by timestamp.
+            # Keep the timestamp filter pinned to that timestamp and offset only
+            # WITHIN its bucket, so `from_` is bounded by the number of audits that
+            # share one timestamp — `from_ + size` can never exceed ES's
+            # max_result_window. Dedup via `_processed_entity_keys` still guards
+            # against boundary overlap.
+            #
+            # Previously this offset was `len(self._processed_entity_keys)` over the
+            # whole result set with the timestamp filter dropped, which Elasticsearch
+            # rejected once > 10,000 audits had been processed (BLDX-1549:
+            # "Result window is too large ... but was [43504]").
+            if self._max_processed_ts is not None:
+                rewritten_filters.append(
+                    self._get_paging_timestamp_query(self._max_processed_ts)
+                )
+            from_ = self._count_at_max_ts
 
-            # Always ensure that the offset is set to the length of the processed assets
-            # instead of the default (start + size), as the default may skip some assets
-            # and result in incomplete results (less than the approximate count)
-            self._criteria.dsl.from_ = len(self._processed_entity_keys)
+        if isinstance(query, Bool):
+            rewritten_query = Bool(
+                filter=rewritten_filters,
+                must=query.must,
+                must_not=query.must_not,
+                should=query.should,
+                boost=query.boost,
+                minimum_should_match=query.minimum_should_match,
+            )
+        else:
+            # If a Term, Range, etc query type is found
+            # in the DSL, append it to the Bool `filter`.
+            rewritten_filters.append(query)
+            rewritten_query = Bool(filter=rewritten_filters)
+        self._criteria.dsl.from_ = from_
+        self._criteria.dsl.query = rewritten_query
 
     @staticmethod
-    def _get_paging_timestamp_query(last_timestamp: int) -> Query:
+    def _get_paging_timestamp_query(last_timestamp: Union[int, datetime]) -> Query:
         return Range(field="created", gte=last_timestamp)
 
     @staticmethod

--- a/tests/unit/aio/test_audit_search.py
+++ b/tests/unit/aio/test_audit_search.py
@@ -15,7 +15,7 @@ from pyatlan.model.aio.audit import AsyncAuditSearchResults
 from pyatlan.model.audit import AuditSearchRequest
 from pyatlan.model.enums import SortOrder
 from pyatlan.model.fluent_search import DSL
-from pyatlan.model.search import Bool, SortItem, Term
+from pyatlan.model.search import Bool, Range, SortItem, Term
 
 SEARCH_RESPONSES_DIR = Path(__file__).parent.parent / "data" / "search_responses"
 AUDIT_SEARCH_PAGING_JSON = "audit_search_paging.json"
@@ -179,3 +179,49 @@ async def test_audit_search_pagination(
             ),
         ):
             await client.search(criteria=audit_search_request, bulk=True)
+
+
+# --- BLDX-1549: async bulk AuditSearch must not blow past ES max_result_window
+def _async_bulk_results_in_collapse_state(processed=10500, count_at_max_ts=7):
+    dsl = DSL(
+        query=Bool(filter=[Term(field="entityId", value="some-guid")]),
+        sort=[],
+        size=300,
+        from_=0,
+    )
+    criteria = AuditSearchRequest(dsl=dsl)
+    client = Mock(spec=AsyncApiCaller)
+    client._call_api = AsyncMock()
+    results = AsyncAuditSearchResults(
+        client=client,
+        criteria=criteria,
+        start=0,
+        size=300,
+        entity_audits=[],
+        count=50000,
+        bulk=True,
+    )
+    results._processed_entity_keys = {f"k{i}" for i in range(processed)}
+    results._max_processed_ts = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    results._count_at_max_ts = count_at_max_ts
+    results._first_record_creation_time = results._last_record_creation_time = -2
+    return results, criteria
+
+
+def test_async_bulk_offset_fallback_is_bounded_within_timestamp_bucket():
+    """BLDX-1549 (async): offset fallback must stay within a single timestamp
+    bucket, so from_ + size never exceeds ES's 10,000 max_result_window."""
+    results, criteria = _async_bulk_results_in_collapse_state(
+        processed=10500, count_at_max_ts=7
+    )
+    results._prepare_query_for_timestamp_paging(criteria.dsl.query)
+    assert criteria.dsl.from_ == 7
+    assert criteria.dsl.from_ != 10500
+    assert criteria.dsl.from_ + criteria.dsl.size <= 10000
+    gte = [
+        f
+        for f in criteria.dsl.query.filter
+        if isinstance(f, Range) and f.field == "created" and f.gte is not None
+    ]
+    assert len(gte) == 1
+    assert gte[0].gte == results._max_processed_ts

--- a/tests/unit/test_audit_search.py
+++ b/tests/unit/test_audit_search.py
@@ -12,7 +12,7 @@ from pyatlan.errors import InvalidRequestError
 from pyatlan.model.audit import AuditSearchRequest, AuditSearchResults
 from pyatlan.model.enums import SortOrder
 from pyatlan.model.fluent_search import DSL
-from pyatlan.model.search import Bool, SortItem, Term
+from pyatlan.model.search import Bool, Range, SortItem, Term
 
 SEARCH_RESPONSES_DIR = Path(__file__).parent / "data" / "search_responses"
 AUDIT_SEARCH_PAGING_JSON = "audit_search_paging.json"
@@ -173,3 +173,79 @@ def test_audit_search_pagination(
 
     mock_logger.reset_mock()
     mock_api_caller.reset_mock()
+
+
+# --- BLDX-1549: bulk AuditSearch must not blow past ES max_result_window ------
+def _bulk_results_in_collapse_state(processed=10500, count_at_max_ts=7):
+    """An AuditSearchResults mid-bulk-scan whose latest page collapsed to a
+    single `created` timestamp (first == last) after >10k audits processed —
+    the exact state that triggered the offset fallback in prod."""
+    dsl = DSL(
+        query=Bool(filter=[Term(field="entityId", value="some-guid")]),
+        sort=[],
+        size=300,
+        from_=0,
+    )
+    criteria = AuditSearchRequest(dsl=dsl)
+    results = AuditSearchResults(
+        client=Mock(spec=ApiCaller),
+        criteria=criteria,
+        start=0,
+        size=300,
+        entity_audits=[],
+        count=50000,
+        bulk=True,
+    )
+    results._processed_entity_keys = {f"k{i}" for i in range(processed)}
+    results._max_processed_ts = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    results._count_at_max_ts = count_at_max_ts
+    # A page netting <= 1 new record after dedup leaves first == last (sentinel).
+    results._first_record_creation_time = results._last_record_creation_time = -2
+    return results, criteria
+
+
+def _gte_created_filters(query):
+    return [
+        f
+        for f in query.filter
+        if isinstance(f, Range) and f.field == "created" and f.gte is not None
+    ]
+
+
+def test_bulk_offset_fallback_is_bounded_within_timestamp_bucket():
+    """BLDX-1549: with >10k audits processed, the timestamp-paging offset
+    fallback must offset WITHIN the current timestamp bucket (bounded), keeping
+    the timestamp filter — never `len(processed)` over the whole result set,
+    which pushed from_ + size past ES's 10,000 max_result_window and crashed with
+    'Result window is too large ... [43504]'."""
+    results, criteria = _bulk_results_in_collapse_state(
+        processed=10500, count_at_max_ts=7
+    )
+
+    results._prepare_query_for_timestamp_paging(criteria.dsl.query)
+
+    # offset is the per-timestamp count, NOT the whole processed set (the old bug)
+    assert criteria.dsl.from_ == 7
+    assert criteria.dsl.from_ != 10500
+    # and it stays within the ES result window
+    assert criteria.dsl.from_ + criteria.dsl.size <= 10000
+    # the timestamp filter is retained, pinned to the max processed timestamp
+    gte = _gte_created_filters(criteria.dsl.query)
+    assert len(gte) == 1
+    assert gte[0].gte == results._max_processed_ts
+
+
+def test_bulk_paging_advances_window_on_distinct_timestamps():
+    """Fast path unchanged: a page spanning multiple timestamps advances the
+    window (gte = last record's created) and resets the offset to 0."""
+    results, criteria = _bulk_results_in_collapse_state()
+    t_last = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    results._first_record_creation_time = datetime(2026, 6, 30, tzinfo=timezone.utc)
+    results._last_record_creation_time = t_last
+
+    results._prepare_query_for_timestamp_paging(criteria.dsl.query)
+
+    assert criteria.dsl.from_ == 0
+    gte = _gte_created_filters(criteria.dsl.query)
+    assert len(gte) == 1
+    assert gte[0].gte == t_last


### PR DESCRIPTION
## What & why

Fixes **BLDX-1549** (Mastercard, Sev2). A scheduled "Asset Change Notification" run died: its bulk audit query for newly-created assets was rejected by Elasticsearch with

```
Result window is too large, from + size must be less than or equal to: [10000] but was [43504]
```

— an uncaught `pyatlan.errors.ApiError`, pod exit 1.

### Root cause
Bulk `AuditSearch` pages by `created` timestamp (ASC) with dedup. When a page collapses to a **single timestamp** — or nets ≤1 new record after dedup (`first == last`) — it can't advance by timestamp, so it fell back to **offset paging with the timestamp filter removed** and `from_ = len(self._processed_entity_keys)`. Once >10,000 audits had been processed, `from_ + size > 10000` → ES 400. (Mastercard: `43504 = 43204 + 300`.)

## The fix

In the offset fallback, **keep the timestamp filter pinned to the current timestamp and offset only _within that timestamp's bucket_** (`from_ = number of processed audits sharing the max created`):

- `from_` is now bounded by a single timestamp's population → `from_ + size` can never exceed ES's `max_result_window`.
- Dedup via `_processed_entity_keys` still guards boundary overlap.
- The multi-timestamp fast path (`from_=0`, advance window) is unchanged.
- Applied to **both** `AuditSearchResults` (sync) and `AsyncAuditSearchResults` (async) — the async path had the identical bug.

## Tests

New tests drive the real `_prepare_query_for_timestamp_paging` at the failing state (>10k processed + collapse): `from_` is now the per-bucket count (not `len(processed)`), stays ≤ 10000, and retains the `gte` filter — sync + async — plus a guard that the multi-timestamp path is unchanged. Existing pagination test unaffected. `qa-checks` clean (ruff + mypy; only the pre-existing `pkg/utils.py` mypy errors remain).

## Caveat

This bounds the offset to a single-timestamp bucket — correct unless >10,000 audit events share the exact same millisecond `created` (implausible). A fully unbounded fix would need `search_after` cursor paging, which the DSL doesn't support today — worth a follow-up. The sibling index-search / search-log paths share the identical fallback and could get the same guard in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)