### PR TITLE
PARTCON-28: Add INFORMATICA_POWERCENTER connector type

### DIFF
--- a/pyatlan/model/enums.py
+++ b/pyatlan/model/enums.py
@@ -362,6 +362,7 @@ class AtlanConnectorType(str, Enum, metaclass=utils.ExtendableEnumMeta):
     DM = ("dm", AtlanConnectionCategory.DATABASE)
     MODEL = ("model", AtlanConnectionCategory.DATABASE)
     IICS = ("iics", AtlanConnectionCategory.ELT)
+    INFORMATICA_POWERCENTER = ("informatica-powercenter", AtlanConnectionCategory.ELT)
     ABINITIO = ("abinitio", AtlanConnectionCategory.ELT)
     SAP_S4_HANA = ("sap-s4-hana", AtlanConnectionCategory.WAREHOUSE)
     INRIVER = ("inriver", AtlanConnectionCategory.DATABASE)


### PR DESCRIPTION
# ✨ Description

Adds `INFORMATICA_POWERCENTER = ("informatica-powercenter", AtlanConnectionCategory.ELT)` to `AtlanConnectorType`, next to the existing `IICS` entry.

The Informatica PowerCenter connector app creates assets under connection qualified names of the form `default/informatica-powercenter/<epoch>`. atlan-publish-app derives the `category` attribute for partial Connections from this enum (`PARTIAL_CONNECTION_CATEGORY_BY_CONNECTOR` in its constants), so while the slug is missing here those connections get `category = "custom"` and are skipped by category-based UI surfaces. ELT matches the DBT/Fivetran/Matillion/IICS precedent. The frontend registration for the same slug is already merged (atlan-frontend #30540).

**Jira link:** https://linear.app/atlan-epd/issue/PARTCON-28/fix-informatica-icon-rendering-for-pc-process-assets

---

## 🧩 Type of change

- [x] 🚀 New feature (non-breaking change that adds functionality)

---

## ✅ How has this been tested?

- `AtlanConnectorType.INFORMATICA_POWERCENTER.value` → `informatica-powercenter`, `.category.value` → `elt`
- Reverse lookup `AtlanConnectorType("informatica-powercenter")` resolves to the new member
- `pyatlan_v9` picks it up via its `from pyatlan.model.enums import *` re-export, no second edit needed

---

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I've performed a self-review of my code
- [ ] I've added comments in tricky or complex areas (n/a — single enum entry)
- [ ] I've updated the documentation as needed (n/a)
- [x] There are no new warnings from my changes
- [ ] I've added tests to cover my changes (pure enum entry; follows #908 precedent)
- [x] All new and existing tests pass locally
