### PR TITLE
feat: SqlInsightJoin.creator() with miner-identical qualifiedName

### DIFF
--- a/pyatlan/generator/templates/methods/asset/sql_insight_join.jinja2
+++ b/pyatlan/generator/templates/methods/asset/sql_insight_join.jinja2
@@ -1,0 +1,83 @@
+
+    @staticmethod
+    def generate_qualified_name(
+        *,
+        source_qualified_name: str,
+        joined_qualified_name: str,
+        column_pairs: List[Dict[str, str]],
+        join_type: Union[SqlInsightJoinType, str] = SqlInsightJoinType.INNER,
+    ) -> str:
+        """
+        Derive the deterministic qualifiedName for a SqlInsightJoin, identical to
+        the SQL-Intelligence miner's formula — so a human-confirmed join and a
+        later mined observation of the same join converge on one entity instead
+        of duplicating:
+
+        ``source_qn || '/join/' || md5(joined_qn || '|' || sorted_pairs || '|' || join_type)``
+
+        where ``sorted_pairs`` joins ``SOURCE=JOINED`` bare column names with
+        commas, ordered by source column.
+
+        :param source_qualified_name: unique name of the source (left) dataset
+        :param joined_qualified_name: unique name of the joined (right) dataset
+        :param column_pairs: join keys as dicts with bare (unqualified) column
+            names, e.g. ``[{"source_column": "ACCOUNT_ID", "joined_column": "ACCOUNTID"}]``
+        :param join_type: type of the join (INNER, LEFT, RIGHT, FULL, CROSS)
+        :returns: the deterministic qualifiedName for the join entity
+        """
+        join_type_value = (
+            join_type.value
+            if isinstance(join_type, SqlInsightJoinType)
+            else str(join_type)
+        )
+        sorted_pairs = ",".join(
+            f"{pair['source_column']}={pair['joined_column']}"
+            for pair in sorted(column_pairs, key=lambda pair: pair["source_column"])
+        )
+        digest = hashlib.md5(  # noqa: S324 (miner-compatible identity, not crypto)
+            f"{joined_qualified_name}|{sorted_pairs}|{join_type_value}".encode()
+        ).hexdigest()
+        return f"{source_qualified_name}/join/{digest}"
+
+    @classmethod
+    @init_guid
+    def creator(
+        cls,
+        *,
+        source_dataset: SQL,
+        joined_dataset: SQL,
+        column_pairs: List[Dict[str, str]],
+        join_type: SqlInsightJoinType = SqlInsightJoinType.INNER,
+        cardinality: SqlInsightJoinCardinality = SqlInsightJoinCardinality.MANY_TO_ONE,
+        when_to_use: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> SqlInsightJoin:
+        """
+        Create a SqlInsightJoin between two SQL datasets, carrying both the
+        string qualified-name attributes (read by metadata-lakehouse consumers)
+        and the dataset relationship edges (rendered on the asset page) — plus a
+        deterministic, miner-identical qualifiedName so repeated confirmation or
+        a later mined observation converges on the same entity.
+
+        :param source_dataset: source (left) dataset, e.g.
+            ``Table.ref_by_qualified_name(...)`` or a search result — must carry
+            its real type (Table / View / MaterialisedView) and qualifiedName
+        :param joined_dataset: joined (right) dataset, same requirements
+        :param column_pairs: join keys as dicts with bare (unqualified) column
+            names, e.g. ``[{"source_column": "ACCOUNT_ID", "joined_column": "ACCOUNTID"}]``
+        :param join_type: type of the join (defaults to INNER)
+        :param cardinality: cardinality of the join (defaults to MANY_TO_ONE)
+        :param when_to_use: optional guidance on when this join should be used
+        :param name: optional display name (defaults to "<SOURCE> JOIN <JOINED>")
+        :returns: the minimal request to create the SqlInsightJoin
+        """
+        attributes = SqlInsightJoin.Attributes.creator(
+            source_dataset=source_dataset,
+            joined_dataset=joined_dataset,
+            column_pairs=column_pairs,
+            join_type=join_type,
+            cardinality=cardinality,
+            when_to_use=when_to_use,
+            name=name,
+        )
+        return cls(attributes=attributes)

--- a/pyatlan/generator/templates/methods/attribute/sql_insight_join.jinja2
+++ b/pyatlan/generator/templates/methods/attribute/sql_insight_join.jinja2
@@ -1,0 +1,68 @@
+
+        @classmethod
+        @init_guid
+        def creator(
+            cls,
+            *,
+            source_dataset: SQL,
+            joined_dataset: SQL,
+            column_pairs: List[Dict[str, str]],
+            join_type: SqlInsightJoinType = SqlInsightJoinType.INNER,
+            cardinality: SqlInsightJoinCardinality = SqlInsightJoinCardinality.MANY_TO_ONE,
+            when_to_use: Optional[str] = None,
+            name: Optional[str] = None,
+        ) -> SqlInsightJoin.Attributes:
+            validate_required_fields(
+                ["source_dataset", "joined_dataset", "column_pairs"],
+                [source_dataset, joined_dataset, column_pairs],
+            )
+            source_qualified_name = source_dataset.qualified_name
+            joined_qualified_name = joined_dataset.qualified_name
+            validate_required_fields(
+                ["source_dataset.qualified_name", "joined_dataset.qualified_name"],
+                [source_qualified_name, joined_qualified_name],
+            )
+            for pair in column_pairs:
+                if (
+                    not isinstance(pair, dict)
+                    or not pair.get("source_column")
+                    or not pair.get("joined_column")
+                ):
+                    raise ValueError(
+                        "each column pair must be a dict with non-empty "
+                        "'source_column' and 'joined_column' bare column names"
+                    )
+            return SqlInsightJoin.Attributes(
+                name=name
+                or (
+                    f"{source_qualified_name.rsplit('/', 1)[-1]} JOIN "  # type: ignore[union-attr]
+                    f"{joined_qualified_name.rsplit('/', 1)[-1]}"  # type: ignore[union-attr]
+                ),
+                qualified_name=SqlInsightJoin.generate_qualified_name(
+                    source_qualified_name=source_qualified_name,  # type: ignore[arg-type]
+                    joined_qualified_name=joined_qualified_name,  # type: ignore[arg-type]
+                    column_pairs=column_pairs,
+                    join_type=join_type,
+                ),
+                sql_insight_join_source_dataset_qualified_name=source_qualified_name,
+                sql_insight_join_joined_dataset_qualified_name=joined_qualified_name,
+                sql_insight_join_type=join_type,
+                sql_insight_join_cardinality=cardinality,
+                sql_insight_join_when_to_use=when_to_use,
+                sql_insight_join_column_pairs=[
+                    SqlInsightJoinColumnPair(
+                        sql_insight_join_column_pair_source_column_qualified_name=(
+                            f"{source_qualified_name}/{pair['source_column']}"
+                        ),
+                        sql_insight_join_column_pair_joined_column_qualified_name=(
+                            f"{joined_qualified_name}/{pair['joined_column']}"
+                        ),
+                    )
+                    for pair in column_pairs
+                ],
+                # A human-declared join has no observed usage: never claim any.
+                sql_insight_join_query_count=0,
+                sql_insight_join_unique_users=0,
+                sql_insight_source_dataset=source_dataset,
+                sql_insight_joined_dataset=joined_dataset,
+            )

--- a/pyatlan/model/assets/core/sql_insight_join.py
+++ b/pyatlan/model/assets/core/sql_insight_join.py
@@ -4,20 +4,105 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime
-from typing import ClassVar, List, Optional
+from typing import ClassVar, Dict, List, Optional, Union
 
 from pydantic.v1 import Field, validator
 
 from pyatlan.model.enums import SqlInsightJoinCardinality, SqlInsightJoinType
 from pyatlan.model.fields.atlan_fields import KeywordField, NumericField, RelationField
 from pyatlan.model.structs import PopularityInsights, SqlInsightJoinColumnPair
+from pyatlan.utils import init_guid, validate_required_fields
 
 from .sql_insight import SqlInsight
 
 
 class SqlInsightJoin(SqlInsight):
     """Description"""
+
+    @staticmethod
+    def generate_qualified_name(
+        *,
+        source_qualified_name: str,
+        joined_qualified_name: str,
+        column_pairs: List[Dict[str, str]],
+        join_type: Union[SqlInsightJoinType, str] = SqlInsightJoinType.INNER,
+    ) -> str:
+        """
+        Derive the deterministic qualifiedName for a SqlInsightJoin, identical to
+        the SQL-Intelligence miner's formula — so a human-confirmed join and a
+        later mined observation of the same join converge on one entity instead
+        of duplicating:
+
+        ``source_qn || '/join/' || md5(joined_qn || '|' || sorted_pairs || '|' || join_type)``
+
+        where ``sorted_pairs`` joins ``SOURCE=JOINED`` bare column names with
+        commas, ordered by source column.
+
+        :param source_qualified_name: unique name of the source (left) dataset
+        :param joined_qualified_name: unique name of the joined (right) dataset
+        :param column_pairs: join keys as dicts with bare (unqualified) column
+            names, e.g. ``[{"source_column": "ACCOUNT_ID", "joined_column": "ACCOUNTID"}]``
+        :param join_type: type of the join (INNER, LEFT, RIGHT, FULL, CROSS)
+        :returns: the deterministic qualifiedName for the join entity
+        """
+        join_type_value = (
+            join_type.value
+            if isinstance(join_type, SqlInsightJoinType)
+            else str(join_type)
+        )
+        sorted_pairs = ",".join(
+            f"{pair['source_column']}={pair['joined_column']}"
+            for pair in sorted(column_pairs, key=lambda pair: pair["source_column"])
+        )
+        digest = hashlib.md5(  # noqa: S324 (miner-compatible identity, not crypto)
+            f"{joined_qualified_name}|{sorted_pairs}|{join_type_value}".encode()
+        ).hexdigest()
+        return f"{source_qualified_name}/join/{digest}"
+
+    @classmethod
+    @init_guid
+    def creator(
+        cls,
+        *,
+        source_dataset: SQL,
+        joined_dataset: SQL,
+        column_pairs: List[Dict[str, str]],
+        join_type: SqlInsightJoinType = SqlInsightJoinType.INNER,
+        cardinality: SqlInsightJoinCardinality = SqlInsightJoinCardinality.MANY_TO_ONE,
+        when_to_use: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> SqlInsightJoin:
+        """
+        Create a SqlInsightJoin between two SQL datasets, carrying both the
+        string qualified-name attributes (read by metadata-lakehouse consumers)
+        and the dataset relationship edges (rendered on the asset page) — plus a
+        deterministic, miner-identical qualifiedName so repeated confirmation or
+        a later mined observation converges on the same entity.
+
+        :param source_dataset: source (left) dataset, e.g.
+            ``Table.ref_by_qualified_name(...)`` or a search result — must carry
+            its real type (Table / View / MaterialisedView) and qualifiedName
+        :param joined_dataset: joined (right) dataset, same requirements
+        :param column_pairs: join keys as dicts with bare (unqualified) column
+            names, e.g. ``[{"source_column": "ACCOUNT_ID", "joined_column": "ACCOUNTID"}]``
+        :param join_type: type of the join (defaults to INNER)
+        :param cardinality: cardinality of the join (defaults to MANY_TO_ONE)
+        :param when_to_use: optional guidance on when this join should be used
+        :param name: optional display name (defaults to "<SOURCE> JOIN <JOINED>")
+        :returns: the minimal request to create the SqlInsightJoin
+        """
+        attributes = SqlInsightJoin.Attributes.creator(
+            source_dataset=source_dataset,
+            joined_dataset=joined_dataset,
+            column_pairs=column_pairs,
+            join_type=join_type,
+            cardinality=cardinality,
+            when_to_use=when_to_use,
+            name=name,
+        )
+        return cls(attributes=attributes)
 
     type_name: str = Field(default="SqlInsightJoin", allow_mutation=False)
 
@@ -352,6 +437,74 @@ class SqlInsightJoin(SqlInsight):
         sql_insight_joined_dataset: Optional[SQL] = Field(
             default=None, description=""
         )  # relationship
+
+        @classmethod
+        @init_guid
+        def creator(
+            cls,
+            *,
+            source_dataset: SQL,
+            joined_dataset: SQL,
+            column_pairs: List[Dict[str, str]],
+            join_type: SqlInsightJoinType = SqlInsightJoinType.INNER,
+            cardinality: SqlInsightJoinCardinality = SqlInsightJoinCardinality.MANY_TO_ONE,
+            when_to_use: Optional[str] = None,
+            name: Optional[str] = None,
+        ) -> SqlInsightJoin.Attributes:
+            validate_required_fields(
+                ["source_dataset", "joined_dataset", "column_pairs"],
+                [source_dataset, joined_dataset, column_pairs],
+            )
+            source_qualified_name = source_dataset.qualified_name
+            joined_qualified_name = joined_dataset.qualified_name
+            validate_required_fields(
+                ["source_dataset.qualified_name", "joined_dataset.qualified_name"],
+                [source_qualified_name, joined_qualified_name],
+            )
+            for pair in column_pairs:
+                if (
+                    not isinstance(pair, dict)
+                    or not pair.get("source_column")
+                    or not pair.get("joined_column")
+                ):
+                    raise ValueError(
+                        "each column pair must be a dict with non-empty "
+                        "'source_column' and 'joined_column' bare column names"
+                    )
+            return SqlInsightJoin.Attributes(
+                name=name
+                or (
+                    f"{source_qualified_name.rsplit('/', 1)[-1]} JOIN "  # type: ignore[union-attr]
+                    f"{joined_qualified_name.rsplit('/', 1)[-1]}"  # type: ignore[union-attr]
+                ),
+                qualified_name=SqlInsightJoin.generate_qualified_name(
+                    source_qualified_name=source_qualified_name,  # type: ignore[arg-type]
+                    joined_qualified_name=joined_qualified_name,  # type: ignore[arg-type]
+                    column_pairs=column_pairs,
+                    join_type=join_type,
+                ),
+                sql_insight_join_source_dataset_qualified_name=source_qualified_name,
+                sql_insight_join_joined_dataset_qualified_name=joined_qualified_name,
+                sql_insight_join_type=join_type,
+                sql_insight_join_cardinality=cardinality,
+                sql_insight_join_when_to_use=when_to_use,
+                sql_insight_join_column_pairs=[
+                    SqlInsightJoinColumnPair(
+                        sql_insight_join_column_pair_source_column_qualified_name=(
+                            f"{source_qualified_name}/{pair['source_column']}"
+                        ),
+                        sql_insight_join_column_pair_joined_column_qualified_name=(
+                            f"{joined_qualified_name}/{pair['joined_column']}"
+                        ),
+                    )
+                    for pair in column_pairs
+                ],
+                # A human-declared join has no observed usage: never claim any.
+                sql_insight_join_query_count=0,
+                sql_insight_join_unique_users=0,
+                sql_insight_source_dataset=source_dataset,
+                sql_insight_joined_dataset=joined_dataset,
+            )
 
     attributes: SqlInsightJoin.Attributes = Field(
         default_factory=lambda: SqlInsightJoin.Attributes(),

--- a/tests/integration/sql_insight_join_test.py
+++ b/tests/integration/sql_insight_join_test.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Atlan Pte. Ltd.
+from typing import Generator
+
+import pytest
+
+from pyatlan.client.atlan import AtlanClient
+from pyatlan.model.assets import Connection, Database, Schema, SqlInsightJoin, Table
+from pyatlan.model.enums import (
+    AtlanConnectorType,
+    SqlInsightJoinCardinality,
+    SqlInsightJoinType,
+)
+from tests.integration.client import TestId, delete_asset
+from tests.integration.connection_test import create_connection
+
+MODULE_NAME = TestId.make_unique("SQL_INSIGHT_JOIN")
+
+DATABASE_NAME = f"test_db_{MODULE_NAME}"
+SCHEMA_NAME = f"test_schema_{MODULE_NAME}"
+SOURCE_TABLE_NAME = f"test_gl_balances_{MODULE_NAME}"
+JOINED_TABLE_NAME = f"test_dsmt_product_{MODULE_NAME}"
+COLUMN_PAIRS = [{"source_column": "PRODUCT_ID", "joined_column": "PRODUCT_ID"}]
+WHEN_TO_USE = "Enrich GL balance rows with product hierarchy (SDK integration test)"
+
+
+@pytest.fixture(scope="module")
+def connection(client: AtlanClient) -> Generator[Connection, None, None]:
+    result = create_connection(
+        client=client, name=MODULE_NAME, connector_type=AtlanConnectorType.SNOWFLAKE
+    )
+    yield result
+    delete_asset(client, guid=result.guid, asset_type=Connection)
+
+
+@pytest.fixture(scope="module")
+def database(
+    client: AtlanClient, connection: Connection
+) -> Generator[Database, None, None]:
+    assert connection.qualified_name
+    to_create = Database.creator(
+        name=DATABASE_NAME, connection_qualified_name=connection.qualified_name
+    )
+    result = client.asset.save(to_create).assets_created(asset_type=Database)[0]
+    yield result
+    delete_asset(client, guid=result.guid, asset_type=Database)
+
+
+@pytest.fixture(scope="module")
+def schema(client: AtlanClient, database: Database) -> Generator[Schema, None, None]:
+    assert database.qualified_name
+    to_create = Schema.creator(
+        name=SCHEMA_NAME, database_qualified_name=database.qualified_name
+    )
+    result = client.asset.save(to_create).assets_created(asset_type=Schema)[0]
+    yield result
+    delete_asset(client, guid=result.guid, asset_type=Schema)
+
+
+@pytest.fixture(scope="module")
+def source_table(client: AtlanClient, schema: Schema) -> Generator[Table, None, None]:
+    assert schema.qualified_name
+    to_create = Table.creator(
+        name=SOURCE_TABLE_NAME, schema_qualified_name=schema.qualified_name
+    )
+    result = client.asset.save(to_create).assets_created(asset_type=Table)[0]
+    yield result
+    delete_asset(client, guid=result.guid, asset_type=Table)
+
+
+@pytest.fixture(scope="module")
+def joined_table(client: AtlanClient, schema: Schema) -> Generator[Table, None, None]:
+    assert schema.qualified_name
+    to_create = Table.creator(
+        name=JOINED_TABLE_NAME, schema_qualified_name=schema.qualified_name
+    )
+    result = client.asset.save(to_create).assets_created(asset_type=Table)[0]
+    yield result
+    delete_asset(client, guid=result.guid, asset_type=Table)
+
+
+@pytest.fixture(scope="module")
+def sql_insight_join(
+    client: AtlanClient, source_table: Table, joined_table: Table
+) -> Generator[SqlInsightJoin, None, None]:
+    to_create = SqlInsightJoin.creator(
+        source_dataset=source_table,
+        joined_dataset=joined_table,
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+        cardinality=SqlInsightJoinCardinality.MANY_TO_ONE,
+        when_to_use=WHEN_TO_USE,
+    )
+    response = client.asset.save(to_create)
+    result = response.assets_created(asset_type=SqlInsightJoin)[0]
+    yield result
+    delete_asset(client, guid=result.guid, asset_type=SqlInsightJoin)
+
+
+def test_sql_insight_join(
+    client: AtlanClient,
+    source_table: Table,
+    joined_table: Table,
+    sql_insight_join: SqlInsightJoin,
+):
+    assert sql_insight_join
+    assert sql_insight_join.guid
+    # deterministic, miner-identical identity
+    assert sql_insight_join.qualified_name == SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=source_table.qualified_name or "",
+        joined_qualified_name=joined_table.qualified_name or "",
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+    )
+    assert sql_insight_join.name == f"{SOURCE_TABLE_NAME} JOIN {JOINED_TABLE_NAME}"
+
+
+def test_sql_insight_join_read_back_carries_both_anchorings(
+    client: AtlanClient,
+    source_table: Table,
+    joined_table: Table,
+    sql_insight_join: SqlInsightJoin,
+):
+    assert sql_insight_join.guid
+    retrieved = client.asset.get_by_guid(
+        sql_insight_join.guid,
+        asset_type=SqlInsightJoin,
+        ignore_relationships=False,
+    )
+    # string attributes (read by metadata-lakehouse consumers)
+    assert (
+        retrieved.sql_insight_join_source_dataset_qualified_name
+        == source_table.qualified_name
+    )
+    assert (
+        retrieved.sql_insight_join_joined_dataset_qualified_name
+        == joined_table.qualified_name
+    )
+    assert retrieved.sql_insight_join_type == SqlInsightJoinType.LEFT
+    assert (
+        retrieved.sql_insight_join_cardinality == SqlInsightJoinCardinality.MANY_TO_ONE
+    )
+    assert retrieved.sql_insight_join_when_to_use == WHEN_TO_USE
+    # a human-declared join must not claim observed usage
+    assert retrieved.sql_insight_join_query_count == 0
+    assert retrieved.sql_insight_join_unique_users == 0
+    pairs = retrieved.sql_insight_join_column_pairs
+    assert pairs
+    pair = pairs[0]
+    assert pair.sql_insight_join_column_pair_source_column_qualified_name == (
+        f"{source_table.qualified_name}/PRODUCT_ID"
+    )
+    # relationship edges live server-side (rendered on the asset page) — a row
+    # missing these is store-visible but invisible on the asset page.
+    source_edge = retrieved.attributes.sql_insight_source_dataset
+    joined_edge = retrieved.attributes.sql_insight_joined_dataset
+    assert source_edge is not None and source_edge.guid == source_table.guid
+    assert joined_edge is not None and joined_edge.guid == joined_table.guid
+
+
+def test_sql_insight_join_upsert_converges_on_same_entity(
+    client: AtlanClient,
+    source_table: Table,
+    joined_table: Table,
+    sql_insight_join: SqlInsightJoin,
+):
+    # Re-confirming the same join must update the existing entity (same guid),
+    # never duplicate it — identity is the derived qualifiedName.
+    again = SqlInsightJoin.creator(
+        source_dataset=source_table,
+        joined_dataset=joined_table,
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+        cardinality=SqlInsightJoinCardinality.MANY_TO_ONE,
+        when_to_use=f"{WHEN_TO_USE} (re-confirmed)",
+    )
+    response = client.asset.save(again)
+    assert not response.assets_created(asset_type=SqlInsightJoin)
+    updated = response.assets_updated(asset_type=SqlInsightJoin)
+    assert len(updated) == 1
+    assert updated[0].guid == sql_insight_join.guid

--- a/tests/unit/model/sql_insight_join_test.py
+++ b/tests/unit/model/sql_insight_join_test.py
@@ -1,0 +1,215 @@
+import json
+
+import pytest
+
+from pyatlan.model.assets import SqlInsightJoin, Table, View
+from pyatlan.model.enums import SqlInsightJoinCardinality, SqlInsightJoinType
+
+SOURCE_QUALIFIED_NAME = (
+    "default/snowflake/1780005299/AI_DEMO/BANKING_FPNA_RAW_ORAAS/GL_BALANCES"
+)
+JOINED_QUALIFIED_NAME = (
+    "default/snowflake/1780005299/AI_DEMO/BANKING_FPNA_RAW_REFDATA/DSMT_PRODUCT"
+)
+COLUMN_PAIRS = [{"source_column": "PRODUCT_ID", "joined_column": "PRODUCT_ID"}]
+# Digest of a real, miner-written SqlInsightJoin row: the creator's
+# qualifiedName derivation must stay byte-identical to the SQL-Intelligence
+# miner so human-confirmed and mined joins converge on one entity.
+LIVE_MINER_DIGEST = "1b92c9836aa403b330bbecd843460af7"
+JOIN_QUALIFIED_NAME = f"{SOURCE_QUALIFIED_NAME}/join/{LIVE_MINER_DIGEST}"
+
+
+def _source():
+    return Table.ref_by_qualified_name(SOURCE_QUALIFIED_NAME)
+
+
+def _joined():
+    return Table.ref_by_qualified_name(JOINED_QUALIFIED_NAME)
+
+
+@pytest.mark.parametrize(
+    "source_dataset, joined_dataset, column_pairs, message",
+    [
+        (None, _joined(), COLUMN_PAIRS, "source_dataset is required"),
+        (_source(), None, COLUMN_PAIRS, "joined_dataset is required"),
+        (_source(), _joined(), None, "column_pairs is required"),
+        (_source(), _joined(), [], "column_pairs cannot be an empty list"),
+    ],
+)
+def test_creator_with_missing_parameters_raise_value_error(
+    source_dataset, joined_dataset, column_pairs, message: str
+):
+    with pytest.raises(ValueError, match=message):
+        SqlInsightJoin.creator(
+            source_dataset=source_dataset,
+            joined_dataset=joined_dataset,
+            column_pairs=column_pairs,
+        )
+
+
+def test_creator_with_dataset_missing_qualified_name_raises_value_error():
+    with pytest.raises(ValueError, match="qualified_name cannot be blank"):
+        SqlInsightJoin.creator(
+            source_dataset=Table(),
+            joined_dataset=_joined(),
+            column_pairs=COLUMN_PAIRS,
+        )
+
+
+@pytest.mark.parametrize(
+    "column_pairs",
+    [
+        [{"source_column": "A"}],
+        [{"joined_column": "B"}],
+        [{"source_column": "", "joined_column": "B"}],
+        [{"source_column": "A", "joined_column": ""}],
+        ["A=B"],
+    ],
+)
+def test_creator_with_invalid_column_pairs_raises_value_error(column_pairs):
+    with pytest.raises(ValueError, match="each column pair must be a dict"):
+        SqlInsightJoin.creator(
+            source_dataset=_source(),
+            joined_dataset=_joined(),
+            column_pairs=column_pairs,
+        )
+
+
+def test_creator():
+    join = SqlInsightJoin.creator(
+        source_dataset=_source(),
+        joined_dataset=_joined(),
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+        cardinality=SqlInsightJoinCardinality.MANY_TO_ONE,
+    )
+
+    # identity converges with the miner-written row (byte-exact digest)
+    assert join.qualified_name == JOIN_QUALIFIED_NAME
+    assert join.name == "GL_BALANCES JOIN DSMT_PRODUCT"
+    assert join.sql_insight_join_source_dataset_qualified_name == SOURCE_QUALIFIED_NAME
+    assert join.sql_insight_join_joined_dataset_qualified_name == JOINED_QUALIFIED_NAME
+    assert join.sql_insight_join_type == SqlInsightJoinType.LEFT
+    assert join.sql_insight_join_cardinality == SqlInsightJoinCardinality.MANY_TO_ONE
+    # a human-declared join has no observed usage
+    assert join.sql_insight_join_query_count == 0
+    assert join.sql_insight_join_unique_users == 0
+    # column-pair struct carries fully-qualified column names
+    pair = join.sql_insight_join_column_pairs[0]
+    assert (
+        pair.sql_insight_join_column_pair_source_column_qualified_name
+        == f"{SOURCE_QUALIFIED_NAME}/PRODUCT_ID"
+    )
+    assert (
+        pair.sql_insight_join_column_pair_joined_column_qualified_name
+        == f"{JOINED_QUALIFIED_NAME}/PRODUCT_ID"
+    )
+    # both relationship edges are anchored to the passed datasets
+    assert join.attributes.sql_insight_source_dataset.qualified_name == (
+        SOURCE_QUALIFIED_NAME
+    )
+    assert join.attributes.sql_insight_joined_dataset.qualified_name == (
+        JOINED_QUALIFIED_NAME
+    )
+
+
+def test_creator_with_optional_parameters():
+    join = SqlInsightJoin.creator(
+        source_dataset=_source(),
+        joined_dataset=_joined(),
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+        when_to_use="Enrich GL balance rows with product hierarchy",
+        name="My custom join name",
+    )
+
+    assert join.name == "My custom join name"
+    assert (
+        join.sql_insight_join_when_to_use
+        == "Enrich GL balance rows with product hierarchy"
+    )
+    # custom name must not change the derived identity
+    assert join.qualified_name == JOIN_QUALIFIED_NAME
+
+
+def test_creator_serialization_carries_both_anchorings():
+    join = SqlInsightJoin.creator(
+        source_dataset=_source(),
+        joined_dataset=View.ref_by_qualified_name(JOINED_QUALIFIED_NAME),
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+    )
+    request = json.loads(join.json(by_alias=True, exclude_unset=True))
+    attributes = request["attributes"]
+    # string attributes (read by metadata-lakehouse consumers)
+    assert attributes["sqlInsightJoinSourceDatasetQualifiedName"] == (
+        SOURCE_QUALIFIED_NAME
+    )
+    assert attributes["sqlInsightJoinColumnPairs"][0][
+        "sqlInsightJoinColumnPairSourceColumnQualifiedName"
+    ] == (f"{SOURCE_QUALIFIED_NAME}/PRODUCT_ID")
+    # relationship edges (rendered on the asset page) with concrete types
+    assert attributes["sqlInsightSourceDataset"]["typeName"] == "Table"
+    assert attributes["sqlInsightJoinedDataset"]["typeName"] == "View"
+    assert attributes["sqlInsightJoinQueryCount"] == 0
+    assert attributes["sqlInsightJoinUniqueUsers"] == 0
+
+
+def test_generate_qualified_name_is_pair_order_invariant():
+    pairs = [
+        {"source_column": "B_COL", "joined_column": "X"},
+        {"source_column": "A_COL", "joined_column": "Y"},
+    ]
+    forward = SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=SOURCE_QUALIFIED_NAME,
+        joined_qualified_name=JOINED_QUALIFIED_NAME,
+        column_pairs=pairs,
+        join_type=SqlInsightJoinType.INNER,
+    )
+    reordered = SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=SOURCE_QUALIFIED_NAME,
+        joined_qualified_name=JOINED_QUALIFIED_NAME,
+        column_pairs=list(reversed(pairs)),
+        join_type=SqlInsightJoinType.INNER,
+    )
+    assert forward == reordered
+
+
+def test_generate_qualified_name_accepts_enum_or_string_join_type():
+    from_enum = SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=SOURCE_QUALIFIED_NAME,
+        joined_qualified_name=JOINED_QUALIFIED_NAME,
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+    )
+    from_string = SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=SOURCE_QUALIFIED_NAME,
+        joined_qualified_name=JOINED_QUALIFIED_NAME,
+        column_pairs=COLUMN_PAIRS,
+        join_type="LEFT",
+    )
+    assert from_enum == from_string == JOIN_QUALIFIED_NAME
+
+
+def test_generate_qualified_name_varies_by_join_type():
+    left = SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=SOURCE_QUALIFIED_NAME,
+        joined_qualified_name=JOINED_QUALIFIED_NAME,
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.LEFT,
+    )
+    inner = SqlInsightJoin.generate_qualified_name(
+        source_qualified_name=SOURCE_QUALIFIED_NAME,
+        joined_qualified_name=JOINED_QUALIFIED_NAME,
+        column_pairs=COLUMN_PAIRS,
+        join_type=SqlInsightJoinType.INNER,
+    )
+    assert left != inner
+
+
+def test_updater():
+    join = SqlInsightJoin.updater(
+        qualified_name=JOIN_QUALIFIED_NAME, name="GL_BALANCES JOIN DSMT_PRODUCT"
+    )
+    assert join.qualified_name == JOIN_QUALIFIED_NAME
+    assert join.name == "GL_BALANCES JOIN DSMT_PRODUCT"


### PR DESCRIPTION
Linear: [AICHAT-1529](https://linear.app/atlan-epd/issue/AICHAT-1529)

## What

Adds a typed **`SqlInsightJoin.creator()`** (previously only `updater()` existed — the inherited `Asset.creator` raises `NotImplementedError`), so SDK callers can author human-confirmed SQL-Intelligence join relationships without hand-building raw Atlas payloads. First consumer: the Atlan MCP server's `upsert_sql_insight_join` tool (agent-toolkit-internal #438), which currently posts a hand-rolled dict through the private `client._call_api` — it will switch to this creator + `client.asset.save()`.

## Design

- **`SqlInsightJoin.generate_qualified_name(...)`** — public, deterministic identity: `source_qn/join/md5(joined_qn|sorted_pairs|join_type)`, **byte-identical to the SQL-Intelligence miner** (validated against a real mined row: digest `1b92c983…` reproduced exactly). A human-confirmed join and a later mined observation of the same join therefore **converge on one entity** instead of duplicating. Pair-order invariant; accepts enum or string `join_type`.
- **`creator(source_dataset, joined_dataset, column_pairs, join_type, cardinality, when_to_use, name)`** — writes **dual anchoring**: the string qualified-name attributes + `sqlInsightJoinColumnPairs` (read by metadata-lakehouse consumers) **and** both `sqlInsightSourceDataset` / `sqlInsightJoinedDataset` relationship edges (rendered on the asset page's Usage & Intelligence tab). A row missing the edges is store-visible but invisible on the asset page.
- **Honest stats:** `sqlInsightJoinQueryCount` / `sqlInsightJoinUniqueUsers` pinned to 0 — a human-declared join has no observed usage and must never claim any.
- Datasets are passed as typed refs (`Table.ref_by_qualified_name(...)` / search results) so the edges carry **concrete** type names — Atlas rejects mistyped refs (observed live: a lineage `Process` sharing a View's qualifiedName).

## How

Added via the **generator templates** (`methods/asset/sql_insight_join.jinja2` + `methods/attribute/sql_insight_join.jinja2`, modeled on the `DataQualityRule`/`DataProduct` pattern), with the generated `pyatlan/model/assets/core/sql_insight_join.py` synchronized — so the next full typedef regeneration reproduces the same code.

## Tests

- **17 unit** (`tests/unit/model/sql_insight_join_test.py`): required/blank/invalid-pair validation, byte-exact digest golden vs a live mined row, default + custom naming, serialization carries both anchorings with concrete edge types, identity invariants (pair order, enum-vs-string, join-type sensitivity), updater.
- **3 integration** (`tests/integration/sql_insight_join_test.py`): create via creator → miner-identical QN; read-back carries string attrs **and live relationship edges** (guid-matched); re-confirming **upserts the same guid** (converges, never duplicates). Needs a live tenant, per the usual integration marks/fixtures.
- Full unit-model suite: **973 passed**. mypy clean, pre-commit (ruff check/format) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)