### PR TITLE
feat(apps): idempotent submit guard + stop retrying HTTP 500 for app management

### DIFF
--- a/pyatlan/client/aio/app.py
+++ b/pyatlan/client/aio/app.py
@@ -77,12 +77,11 @@ class AsyncAppClient:
         self._client = client
 
     async def _call(self, api, **kwargs):
-        """Invoke an app API with the app-management retry policy.
+        """Invoke an app API under the app-management retry policy (AICHAT-1659).
 
-        Routes every AsyncAppClient request through :data:`_APP_NO_500_RETRY` so
-        app management never retries HTTP 500 (AICHAT-1659).
+        Async mirror of :meth:`pyatlan.client.app.AppClient._call`.
         """
-        async with self._client.max_retries(_APP_NO_500_RETRY):  # type: ignore[attr-defined]
+        async with self._client.max_retries(_APP_NO_500_RETRY):
             return await self._client._call_api(api, **kwargs)
 
     # ----------------------------- discovery ----------------------------- #

--- a/pyatlan/client/aio/app.py
+++ b/pyatlan/client/aio/app.py
@@ -9,11 +9,22 @@ is awaited. Obtain via :attr:`pyatlan.client.aio.client.AsyncAtlanClient.app`.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import Any, Dict, Optional, Union
 
 from pydantic.v1 import validate_arguments
 
+from pyatlan.client.app import (
+    _ACTIVE_RUN_STATUSES,
+    _APP_NO_500_RETRY,
+    _APP_WORKFLOW_RUN_QN_PREFIX,
+    _RUN_CHECK_INTERVAL_SECONDS,
+    _RUN_CHECK_TIMEOUT_SECONDS,
+    _already_running_error,
+    _is_server_error,
+)
 from pyatlan.client.common import AsyncApiCaller
 from pyatlan.client.common.app import (
     AppAddSchedule,
@@ -33,6 +44,8 @@ from pyatlan.client.common.app import (
 )
 from pyatlan.errors import AtlanError, ErrorCode
 from pyatlan.model.apps import AppInput
+from pyatlan.model.assets import AppWorkflowRun
+from pyatlan.model.fluent_search import CompoundQuery, FluentSearch
 from pyatlan.model.app import (
     AppDeleteResponse,
     AppInfo,
@@ -63,11 +76,20 @@ class AsyncAppClient:
             )
         self._client = client
 
+    async def _call(self, api, **kwargs):
+        """Invoke an app API with the app-management retry policy.
+
+        Routes every AsyncAppClient request through :data:`_APP_NO_500_RETRY` so
+        app management never retries HTTP 500 (AICHAT-1659).
+        """
+        async with self._client.max_retries(_APP_NO_500_RETRY):  # type: ignore[attr-defined]
+            return await self._client._call_api(api, **kwargs)
+
     # ----------------------------- discovery ----------------------------- #
     @validate_arguments
     async def describe(self, app_id: str) -> AppInfo:
         """Describe an app: native-readiness + entrypoints (contrast :meth:`get`)."""
-        raw = await self._client._call_api(AppGetInfo.prepare_request(app_id))
+        raw = await self._call(AppGetInfo.prepare_request(app_id))
         return AppGetInfo.process_response(raw)
 
     @validate_arguments
@@ -76,7 +98,7 @@ class AsyncAppClient:
     ) -> AppInputContract:
         """Fetch the app's input contract (JSON Schema) for an entrypoint."""
         endpoint, query_params = AppGetInputContract.prepare_request(app_id, entrypoint)
-        raw = await self._client._call_api(endpoint, query_params=query_params)
+        raw = await self._call(endpoint, query_params=query_params)
         return AppGetInputContract.process_response(raw)
 
     # ----------------------------- lifecycle ----------------------------- #
@@ -114,7 +136,7 @@ class AsyncAppClient:
         request = CreateApp(**request_kwargs)
         endpoint, request_obj = AppCreate.prepare_request(request)
         try:
-            raw = await self._client._call_api(endpoint, request_obj=request_obj)
+            raw = await self._call(endpoint, request_obj=request_obj)
         except AtlanError as exc:
             if is_duplicate_name_conflict(exc):
                 return await self._reuse_on_conflict(name, exc)
@@ -152,13 +174,13 @@ class AsyncAppClient:
             use it to resolve a workflow's slug from its name.
         """
         endpoint, query_params = AppListAll.prepare_request(limit, cursor, name)
-        raw = await self._client._call_api(endpoint, query_params=query_params)
+        raw = await self._call(endpoint, query_params=query_params)
         return AppListAll.process_response(raw)
 
     @validate_arguments
     async def get(self, slug: str) -> AppSummary:
         """Get a single workflow by slug."""
-        raw = await self._client._call_api(AppGet.prepare_request(slug))
+        raw = await self._call(AppGet.prepare_request(slug))
         return AppGet.process_response(raw)
 
     @validate_arguments(config=dict(arbitrary_types_allowed=True))
@@ -176,32 +198,83 @@ class AsyncAppClient:
             request_kwargs["entrypoint"] = entrypoint
         request = UpdateApp(**request_kwargs)
         endpoint, request_obj = AppUpdate.prepare_request(slug, request)
-        raw = await self._client._call_api(endpoint, request_obj=request_obj)
+        raw = await self._call(endpoint, request_obj=request_obj)
         return AppUpdate.process_response(raw)
 
     @validate_arguments
     async def delete(self, slug: str) -> AppDeleteResponse:
         """Archive/delete a workflow."""
-        raw = await self._client._call_api(AppDelete.prepare_request(slug))
+        raw = await self._call(AppDelete.prepare_request(slug))
         return AppDelete.process_response(raw)
 
     # ------------------------------ running ------------------------------ #
+    async def _find_current_run(self, slug: str) -> Optional[AppWorkflowRun]:
+        """Async mirror of :meth:`pyatlan.client.app.AppClient._find_current_run`."""
+        request = (
+            FluentSearch()
+            .where(CompoundQuery.active_assets())
+            .where(CompoundQuery.asset_type(AppWorkflowRun))
+            .where(
+                AppWorkflowRun.QUALIFIED_NAME.startswith(
+                    f"{_APP_WORKFLOW_RUN_QN_PREFIX}{slug}/"
+                )
+            )
+            .where(AppWorkflowRun.APP_WORKFLOW_RUN_STATUS.within(_ACTIVE_RUN_STATUSES))
+            .include_on_results(AppWorkflowRun.APP_WORKFLOW_RUN_STATUS)
+            .page_size(1)
+        ).to_request()
+        results = await self._client.asset.search(request)  # type: ignore[attr-defined]
+        for asset in results.current_page() or []:
+            if isinstance(asset, AppWorkflowRun):
+                return asset
+        return None
+
+    async def _await_active_run(self, slug: str) -> Optional[AppWorkflowRun]:
+        """Async mirror of :meth:`pyatlan.client.app.AppClient._await_active_run`."""
+        deadline = time.monotonic() + _RUN_CHECK_TIMEOUT_SECONDS
+        while True:
+            run = await self._find_current_run(slug)
+            if run is not None:
+                return run
+            if time.monotonic() >= deadline:
+                return None
+            await asyncio.sleep(_RUN_CHECK_INTERVAL_SECONDS)
+
     @validate_arguments
-    async def submit(self, slug: str) -> AppRunResponse:
-        """Run the workflow's current published version."""
-        raw = await self._client._call_api(AppSubmit.prepare_request(slug))
+    async def submit(self, slug: str, idempotent: bool = False) -> AppRunResponse:
+        """Run the workflow's current published version.
+
+        :param idempotent: opt-in guard against launching a duplicate run
+            (default ``False``). When ``True``, refuse to submit if a run is
+            already in progress — checked before submitting and reconfirmed
+            against the search index if the submit fails with a server error.
+        :raises InvalidRequestError: if ``idempotent`` and a run is already in
+            progress for this workflow.
+        """
+        if idempotent:
+            current = await self._find_current_run(slug)
+            if current is not None:
+                raise _already_running_error(slug, current)
+        try:
+            raw = await self._call(AppSubmit.prepare_request(slug))
+        except AtlanError as exc:
+            if idempotent and _is_server_error(exc):
+                current = await self._await_active_run(slug)
+                if current is not None:
+                    raise _already_running_error(slug, current) from exc
+            raise
         return AppSubmit.process_response(raw)
 
     @validate_arguments
     async def get_run(self, run_id: str) -> AppRunResponse:
         """Get a run's status. Poll until :attr:`AppRunResponse.is_terminal`."""
-        raw = await self._client._call_api(AppGetRun.prepare_request(run_id))
+        raw = await self._call(AppGetRun.prepare_request(run_id))
         return AppGetRun.process_response(raw)
 
     @validate_arguments
     async def cancel_run(self, run_id: str) -> AppRunCancelResponse:
         """Cancel an in-flight run."""
-        raw = await self._client._call_api(AppCancelRun.prepare_request(run_id))
+        raw = await self._call(AppCancelRun.prepare_request(run_id))
         return AppCancelRun.process_response(raw)
 
     # ---------------------------- scheduling ----------------------------- #
@@ -213,7 +286,7 @@ class AsyncAppClient:
         # The server rejects a null timezone, so apply the documented UTC default.
         schedule = AppSchedule(cron=cron, timezone=timezone or "UTC")
         endpoint, request_obj = AppAddSchedule.prepare_request(slug, schedule)
-        raw = await self._client._call_api(endpoint, request_obj=request_obj)
+        raw = await self._call(endpoint, request_obj=request_obj)
         return AppAddSchedule.process_response(raw)
 
     @validate_arguments
@@ -221,7 +294,5 @@ class AsyncAppClient:
         self, slug: str, trigger_id: str
     ) -> AppScheduleDeleteResponse:
         """Remove one schedule (by its ``trigger_id``) from a workflow."""
-        raw = await self._client._call_api(
-            AppRemoveSchedule.prepare_request(slug, trigger_id)
-        )
+        raw = await self._call(AppRemoveSchedule.prepare_request(slug, trigger_id))
         return AppRemoveSchedule.process_response(raw)

--- a/pyatlan/client/app.py
+++ b/pyatlan/client/app.py
@@ -13,8 +13,10 @@ Obtain via :attr:`pyatlan.client.atlan.AtlanClient.app`.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Dict, Optional, Union
 
+from httpx_retries import Retry
 from pydantic.v1 import validate_arguments
 
 from pyatlan.client.common import ApiCaller
@@ -36,6 +38,9 @@ from pyatlan.client.common.app import (
 )
 from pyatlan.errors import AtlanError, ErrorCode
 from pyatlan.model.apps import AppInput
+from pyatlan.model.assets import AppWorkflowRun
+from pyatlan.model.enums import AppWorkflowRunStatus
+from pyatlan.model.fluent_search import CompoundQuery, FluentSearch
 from pyatlan.model.app import (
     AppDeleteResponse,
     AppInfo,
@@ -55,6 +60,44 @@ from pyatlan.model.app import (
 
 LOGGER = logging.getLogger(__name__)
 
+# App-workflow runs are Atlan assets under this qualifiedName prefix; their status
+# lives on ``AppWorkflowRun.appWorkflowRunStatus``.
+_APP_WORKFLOW_RUN_QN_PREFIX = "default/apps/automation_engine/workflows/"
+# Non-terminal run statuses — a workflow with a run in one of these is "running".
+_ACTIVE_RUN_STATUSES = [
+    AppWorkflowRunStatus.PENDING.value,
+    AppWorkflowRunStatus.RUNNING.value,
+]
+# App-management calls must not retry HTTP 500 (AICHAT-1659): a 500 here is not
+# transient (e.g. submitting a workflow that already has an active run), and
+# retrying a non-idempotent POST can spawn duplicate runs. This policy mirrors the
+# client default but drops 500 from the retryable statuses; every AppClient call
+# goes through it via ``_call``.
+_APP_NO_500_RETRY = Retry(
+    total=5,
+    backoff_factor=1,
+    status_forcelist=[429, 502, 503, 504],
+    allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"],
+    respect_retry_after_header=True,
+)
+
+# Search is eventually consistent (~seconds), so a just-started run may not be
+# indexed yet. When an idempotent submit gets a server error (most often
+# "already running"), briefly poll the index to confirm before surfacing the
+# ambiguous 500. Tunable (module-level so callers/tests can override).
+_RUN_CHECK_TIMEOUT_SECONDS = 6.0
+_RUN_CHECK_INTERVAL_SECONDS = 1.5
+
+
+def _already_running_error(slug: str, run: "AppWorkflowRun"):
+    return ErrorCode.APP_WORKFLOW_ALREADY_RUNNING.exception_with_parameters(
+        slug, run.qualified_name or "in-progress run"
+    )
+
+
+def _is_server_error(exc: AtlanError) -> bool:
+    return getattr(exc.error_code, "http_error_code", 0) >= 500
+
 
 class AppClient:
     """Create, run, schedule, and manage app workflows."""
@@ -65,6 +108,15 @@ class AppClient:
                 "client", "ApiCaller"
             )
         self._client = client
+
+    def _call(self, api, **kwargs):
+        """Invoke an app API with the app-management retry policy.
+
+        Routes every AppClient request through :data:`_APP_NO_500_RETRY` so app
+        management never retries HTTP 500 (AICHAT-1659).
+        """
+        with self._client.max_retries(_APP_NO_500_RETRY):  # type: ignore[attr-defined]
+            return self._client._call_api(api, **kwargs)
 
     # ----------------------------- discovery ----------------------------- #
     @validate_arguments
@@ -77,7 +129,7 @@ class AppClient:
         :param app_id: marketplace application id (e.g. ``bigquery-crawler``).
         :returns: an :class:`AppInfo`.
         """
-        raw = self._client._call_api(AppGetInfo.prepare_request(app_id))
+        raw = self._call(AppGetInfo.prepare_request(app_id))
         return AppGetInfo.process_response(raw)
 
     @validate_arguments
@@ -94,7 +146,7 @@ class AppClient:
         :returns: an :class:`AppInputContract`.
         """
         endpoint, query_params = AppGetInputContract.prepare_request(app_id, entrypoint)
-        raw = self._client._call_api(endpoint, query_params=query_params)
+        raw = self._call(endpoint, query_params=query_params)
         return AppGetInputContract.process_response(raw)
 
     # ----------------------------- lifecycle ----------------------------- #
@@ -143,7 +195,7 @@ class AppClient:
         request = CreateApp(**request_kwargs)
         endpoint, request_obj = AppCreate.prepare_request(request)
         try:
-            raw = self._client._call_api(endpoint, request_obj=request_obj)
+            raw = self._call(endpoint, request_obj=request_obj)
         except AtlanError as exc:
             if is_duplicate_name_conflict(exc):
                 return self._reuse_on_conflict(name, exc)
@@ -186,7 +238,7 @@ class AppClient:
         :returns: an :class:`AppList`.
         """
         endpoint, query_params = AppListAll.prepare_request(limit, cursor, name)
-        raw = self._client._call_api(endpoint, query_params=query_params)
+        raw = self._call(endpoint, query_params=query_params)
         return AppListAll.process_response(raw)
 
     @validate_arguments
@@ -196,7 +248,7 @@ class AppClient:
         :param slug: the server-minted workflow identity.
         :returns: an :class:`AppSummary`.
         """
-        raw = self._client._call_api(AppGet.prepare_request(slug))
+        raw = self._call(AppGet.prepare_request(slug))
         return AppGet.process_response(raw)
 
     @validate_arguments(config=dict(arbitrary_types_allowed=True))
@@ -224,7 +276,7 @@ class AppClient:
             request_kwargs["entrypoint"] = entrypoint
         request = UpdateApp(**request_kwargs)
         endpoint, request_obj = AppUpdate.prepare_request(slug, request)
-        raw = self._client._call_api(endpoint, request_obj=request_obj)
+        raw = self._call(endpoint, request_obj=request_obj)
         return AppUpdate.process_response(raw)
 
     @validate_arguments
@@ -234,18 +286,84 @@ class AppClient:
         :param slug: the workflow identity.
         :returns: an :class:`AppDeleteResponse`.
         """
-        raw = self._client._call_api(AppDelete.prepare_request(slug))
+        raw = self._call(AppDelete.prepare_request(slug))
         return AppDelete.process_response(raw)
 
     # ------------------------------ running ------------------------------ #
+    def _find_current_run(self, slug: str) -> Optional[AppWorkflowRun]:
+        """Return an in-progress (Pending/Running) run for this workflow, else ``None``.
+
+        App-workflow runs are Atlan assets (:class:`AppWorkflowRun`) under the
+        workflow's qualifiedName; this searches for one whose
+        ``appWorkflowRunStatus`` is non-terminal. Used by :meth:`submit` to guard
+        against launching a duplicate run. There is a brief (~seconds) indexing
+        lag after a run starts, so a just-started run may not be found yet.
+        """
+        request = (
+            FluentSearch()
+            .where(CompoundQuery.active_assets())
+            .where(CompoundQuery.asset_type(AppWorkflowRun))
+            .where(
+                AppWorkflowRun.QUALIFIED_NAME.startswith(
+                    f"{_APP_WORKFLOW_RUN_QN_PREFIX}{slug}/"
+                )
+            )
+            .where(AppWorkflowRun.APP_WORKFLOW_RUN_STATUS.within(_ACTIVE_RUN_STATUSES))
+            .include_on_results(AppWorkflowRun.APP_WORKFLOW_RUN_STATUS)
+            .page_size(1)
+        ).to_request()
+        results = self._client.asset.search(request)  # type: ignore[attr-defined]
+        for asset in results.current_page() or []:
+            if isinstance(asset, AppWorkflowRun):
+                return asset
+        return None
+
+    def _await_active_run(self, slug: str) -> Optional[AppWorkflowRun]:
+        """Poll the search index for an active run, tolerating indexing lag.
+
+        Returns the run once it appears within :data:`_RUN_CHECK_TIMEOUT_SECONDS`,
+        else ``None``. Used only on the submit error-recovery path (see
+        :meth:`submit`), never on the happy path.
+        """
+        deadline = time.monotonic() + _RUN_CHECK_TIMEOUT_SECONDS
+        while True:
+            run = self._find_current_run(slug)
+            if run is not None:
+                return run
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(_RUN_CHECK_INTERVAL_SECONDS)
+
     @validate_arguments
-    def submit(self, slug: str) -> AppRunResponse:
+    def submit(self, slug: str, idempotent: bool = False) -> AppRunResponse:
         """Run the workflow's current published version.
 
         :param slug: the workflow identity.
+        :param idempotent: opt-in guard against launching a duplicate run
+            (default ``False``). When ``True``, refuse to submit if the workflow
+            already has an in-progress run — checked before submitting and, if the
+            submit still fails with a server error (the run may not have been
+            indexed yet), reconfirmed against the search index before the error is
+            surfaced.
         :returns: an :class:`AppRunResponse` with the new ``run_id``.
+        :raises InvalidRequestError: if ``idempotent`` and a run is already in
+            progress for this workflow.
         """
-        raw = self._client._call_api(AppSubmit.prepare_request(slug))
+        if idempotent:
+            current = self._find_current_run(slug)
+            if current is not None:
+                raise _already_running_error(slug, current)
+        try:
+            raw = self._call(AppSubmit.prepare_request(slug))
+        except AtlanError as exc:
+            # A server error on submit is most often "already running", but the
+            # run may not have been indexed when we pre-checked. Confirm against
+            # the (eventually-consistent) index before surfacing the raw 500.
+            if idempotent and _is_server_error(exc):
+                current = self._await_active_run(slug)
+                if current is not None:
+                    raise _already_running_error(slug, current) from exc
+            raise
         return AppSubmit.process_response(raw)
 
     @validate_arguments
@@ -255,7 +373,7 @@ class AppClient:
         :param run_id: the run identifier.
         :returns: an :class:`AppRunResponse`.
         """
-        raw = self._client._call_api(AppGetRun.prepare_request(run_id))
+        raw = self._call(AppGetRun.prepare_request(run_id))
         return AppGetRun.process_response(raw)
 
     @validate_arguments
@@ -265,7 +383,7 @@ class AppClient:
         :param run_id: the run identifier.
         :returns: an :class:`AppRunCancelResponse`.
         """
-        raw = self._client._call_api(AppCancelRun.prepare_request(run_id))
+        raw = self._call(AppCancelRun.prepare_request(run_id))
         return AppCancelRun.process_response(raw)
 
     # ---------------------------- scheduling ----------------------------- #
@@ -283,7 +401,7 @@ class AppClient:
         # The server rejects a null timezone, so apply the documented UTC default.
         schedule = AppSchedule(cron=cron, timezone=timezone or "UTC")
         endpoint, request_obj = AppAddSchedule.prepare_request(slug, schedule)
-        raw = self._client._call_api(endpoint, request_obj=request_obj)
+        raw = self._call(endpoint, request_obj=request_obj)
         return AppAddSchedule.process_response(raw)
 
     @validate_arguments
@@ -294,7 +412,5 @@ class AppClient:
         :param trigger_id: the schedule's trigger id.
         :returns: an :class:`AppScheduleDeleteResponse`.
         """
-        raw = self._client._call_api(
-            AppRemoveSchedule.prepare_request(slug, trigger_id)
-        )
+        raw = self._call(AppRemoveSchedule.prepare_request(slug, trigger_id))
         return AppRemoveSchedule.process_response(raw)

--- a/pyatlan/client/app.py
+++ b/pyatlan/client/app.py
@@ -110,12 +110,13 @@ class AppClient:
         self._client = client
 
     def _call(self, api, **kwargs):
-        """Invoke an app API with the app-management retry policy.
+        """Invoke an app API under the app-management retry policy.
 
-        Routes every AppClient request through :data:`_APP_NO_500_RETRY` so app
-        management never retries HTTP 500 (AICHAT-1659).
+        Applies :data:`_APP_NO_500_RETRY` so app management never retries HTTP 500
+        (AICHAT-1659) — a 500 here is not transient and retrying a non-idempotent
+        POST can spawn duplicate runs.
         """
-        with self._client.max_retries(_APP_NO_500_RETRY):  # type: ignore[attr-defined]
+        with self._client.max_retries(_APP_NO_500_RETRY):
             return self._client._call_api(api, **kwargs)
 
     # ----------------------------- discovery ----------------------------- #

--- a/pyatlan/errors.py
+++ b/pyatlan/errors.py
@@ -696,6 +696,13 @@ class ErrorCode(Enum):
         "Replace any underscores with hyphens (e.g. 'dev_cmdr' -> 'dev-cmdr'). Underscores, dots, uppercase letters, whitespace, and other characters are not permitted because the Atlan platform's asset-import path rejects them at ingestion time, leaving phantom Connection rows in Atlas. Mirrors the Java SDK constraint (atlan-java ErrorCode.INVALID_CONNECTION_QN).",
         InvalidRequestError,
     )
+    APP_WORKFLOW_ALREADY_RUNNING = (
+        400,
+        "ATLAN-PYTHON-400-080",
+        "App workflow '{0}' already has an active run ({1}); it cannot be submitted again while a run is in progress.",
+        "Wait for the current run to reach a terminal status, or call submit(..., idempotent=False) to submit a new run anyway.",
+        InvalidRequestError,
+    )
     AUTHENTICATION_PASSTHROUGH = (
         401,
         "ATLAN-PYTHON-401-000",

--- a/tests/integration/test_app_client.py
+++ b/tests/integration/test_app_client.py
@@ -20,6 +20,7 @@ from typing import Generator
 import pytest
 
 from pyatlan.client.atlan import AtlanClient
+from pyatlan.errors import AtlanError
 from pyatlan.model.app import (
     AppInfo,
     AppInputContract,
@@ -283,6 +284,37 @@ def test_run_submit_status_and_cancel(client: AtlanClient, created: AppResponse)
         cancelled = client.app.cancel_run(run.run_id)
         assert cancelled.run_id == run.run_id
         assert isinstance(cancelled.cancelled, bool)
+
+
+def test_submit_idempotent_blocks_concurrent_run(client: AtlanClient):
+    """A second idempotent submit is refused while the first run is in progress."""
+    # Own workflow so this can't collide with the shared `created` fixture.
+    resp = _builder(client, f"{MODULE_NAME}-idem").create(name=f"{MODULE_NAME}-idem")
+    slug = resp.slug
+    run = None
+    try:
+        run = client.app.submit(slug)  # start the first run
+        try:
+            client.app.submit(slug, idempotent=True)  # concurrent submit
+        except AtlanError as exc:
+            msg = str(exc)
+            # The guard surfaces a clean "already running" error once the run is
+            # indexed; if the search index still lags, the backend's own rejection
+            # (500) is surfaced instead — either way a duplicate run is prevented.
+            assert "already has an active run" in msg or "500" in msg
+        else:
+            # The first run finished before the concurrent submit landed — with
+            # dummy creds a run can terminate almost immediately, so there is
+            # nothing to block. Nothing to assert.
+            pytest.skip("first run terminated before the concurrent submit")
+    finally:
+        if run and run.run_id:
+            try:
+                if not client.app.get_run(run.run_id).is_terminal:
+                    client.app.cancel_run(run.run_id)
+            except Exception:
+                pass
+        client.app.delete(slug)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_app_client.py
+++ b/tests/unit/test_app_client.py
@@ -3,16 +3,21 @@
 """Unit tests for the App workflow client — sync + async."""
 
 import json
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Optional
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
+import httpx
 import pytest
 
+from pyatlan.client.transport import PyatlanSyncTransport
+
 from pyatlan.client.aio.app import AsyncAppClient
-from pyatlan.client.app import AppClient
+from pyatlan.client.app import _APP_NO_500_RETRY, AppClient
 from pyatlan.client.common import ApiCaller, AsyncApiCaller
 from pyatlan.errors import AtlanError
+from pyatlan.model.assets import AppWorkflowRun
 from pyatlan.model.app import (
     AppDeleteResponse,
     AppInfo,
@@ -28,7 +33,11 @@ from pyatlan.model.app import (
 
 @pytest.fixture
 def mock_api_caller():
-    return Mock(spec=ApiCaller)
+    m = Mock(spec=ApiCaller)
+    # Every AppClient call is wrapped in max_retries(...) (the no-500 policy);
+    # make it a no-op context manager for tests.
+    m.max_retries = Mock(side_effect=lambda *a, **k: nullcontext())
+    return m
 
 
 @pytest.fixture
@@ -40,6 +49,22 @@ def _path(mock) -> str:
     """The API endpoint path passed to the most recent _call_api call."""
     api = mock._call_api.call_args.args[0]
     return api.path
+
+
+def _running_run(slug: str = "a-1") -> AppWorkflowRun:
+    """A minimal in-progress AppWorkflowRun asset for the slug."""
+    run = AppWorkflowRun()
+    run.qualified_name = f"default/apps/automation_engine/workflows/{slug}/1/runs/r-9"
+    return run
+
+
+def _wire_asset_search(mock, active_runs=()):
+    """Wire ``mock.asset.search`` so ``current_page()`` returns ``active_runs``."""
+    results = Mock()
+    results.current_page = Mock(return_value=list(active_runs))
+    mock.asset = Mock()
+    mock.asset.search = Mock(return_value=results)
+    return mock.asset.search
 
 
 # --------------------------------------------------------------------------- #
@@ -221,12 +246,127 @@ def test_delete(client, mock_api_caller):
 # --------------------------------------------------------------------------- #
 # Running
 # --------------------------------------------------------------------------- #
+def _server_error_500() -> AtlanError:
+    return AtlanError(
+        SimpleNamespace(
+            http_error_code=500,
+            error_id="ATLAN-PYTHON-500-000",
+            error_message="internal error",
+            user_action="check the server message",
+        )
+    )
+
+
+def _wire_asset_search_sequence(mock, pages):
+    """Wire ``mock.asset.search`` to return a different current_page() per call."""
+
+    def _result(page):
+        r = Mock()
+        r.current_page = Mock(return_value=list(page))
+        return r
+
+    mock.asset = Mock()
+    mock.asset.search = Mock(side_effect=[_result(p) for p in pages])
+    return mock.asset.search
+
+
 def test_submit(client, mock_api_caller):
     mock_api_caller._call_api.return_value = {"slug": "a-1", "run_id": "r-1"}
     result = client.submit("a-1")
     assert isinstance(result, AppRunResponse)
     assert result.run_id == "r-1"
     assert _path(mock_api_caller) == "v1/app/a-1/submit"
+    # AICHAT-1659: submit runs under the no-500 retry policy.
+    mock_api_caller.max_retries.assert_called_once_with(_APP_NO_500_RETRY)
+
+
+def test_submit_default_is_not_idempotent(client, mock_api_caller):
+    """Default idempotent=False: no pre-check search, just submit (opt-in guard)."""
+    search = _wire_asset_search(mock_api_caller, active_runs=[_running_run("a-1")])
+    mock_api_caller._call_api.return_value = {"slug": "a-1", "run_id": "r-1"}
+    result = client.submit("a-1")  # no idempotent arg
+    assert result.run_id == "r-1"
+    search.assert_not_called()  # no running-run pre-check by default
+
+
+def test_submit_idempotent_raises_when_already_running(client, mock_api_caller):
+    """idempotent=True: an in-progress run blocks a duplicate submit up front."""
+    _wire_asset_search(mock_api_caller, active_runs=[_running_run("a-1")])
+    with pytest.raises(AtlanError) as exc:
+        client.submit("a-1", idempotent=True)
+    assert "already has an active run" in str(exc.value)
+    # No submit POST was sent — we short-circuited before _call_api.
+    mock_api_caller._call_api.assert_not_called()
+
+
+def test_submit_idempotent_recovers_already_running_on_500(client, mock_api_caller):
+    """Lag path: pre-check misses, submit 500s, re-check confirms already-running."""
+    # First search (pre-check) sees nothing; second (post-500 recovery) sees the run.
+    _wire_asset_search_sequence(mock_api_caller, pages=[[], [_running_run("a-1")]])
+    mock_api_caller._call_api.side_effect = _server_error_500()
+    with pytest.raises(AtlanError) as exc:
+        client.submit("a-1", idempotent=True)
+    assert "already has an active run" in str(exc.value)  # clean error, not raw 500
+    mock_api_caller._call_api.assert_called_once()  # exactly one submit attempt
+
+
+def test_submit_idempotent_reraises_genuine_500(client, mock_api_caller, monkeypatch):
+    """A 500 with no active run (genuine server error) is surfaced as-is."""
+    monkeypatch.setattr("pyatlan.client.app._RUN_CHECK_TIMEOUT_SECONDS", 0.0)
+    _wire_asset_search_sequence(mock_api_caller, pages=[[], []])  # never running
+    mock_api_caller._call_api.side_effect = _server_error_500()
+    with pytest.raises(AtlanError) as exc:
+        client.submit("a-1", idempotent=True)
+    assert "internal error" in str(exc.value)
+    assert "already has an active run" not in str(exc.value)
+
+
+def test_submit_idempotent_false_skips_check_and_submits(client, mock_api_caller):
+    """idempotent=False forces the submit without the running-run pre-check."""
+    search = _wire_asset_search(mock_api_caller, active_runs=[_running_run("a-1")])
+    mock_api_caller._call_api.return_value = {"slug": "a-1", "run_id": "r-2"}
+    result = client.submit("a-1", idempotent=False)
+    assert result.run_id == "r-2"
+    assert _path(mock_api_caller) == "v1/app/a-1/submit"
+    search.assert_not_called()  # pre-check skipped
+
+
+def test_find_current_run_none_when_no_active(client, mock_api_caller):
+    _wire_asset_search(mock_api_caller, active_runs=[])
+    assert client._find_current_run("a-1") is None
+
+
+# --------------------------------------------------------------------------- #
+# AICHAT-1659: app management never retries HTTP 500
+# --------------------------------------------------------------------------- #
+def _attempts_for_status(status: int) -> int:
+    """Drive the app retry policy through the real transport; count HTTP attempts."""
+    transport = PyatlanSyncTransport(
+        retry=_APP_NO_500_RETRY, client=None, trust_env=False
+    )
+    inner = MagicMock(return_value=httpx.Response(status))
+    transport._transport.handle_request = inner  # type: ignore[method-assign]
+    transport.handle_request(
+        httpx.Request("POST", "https://example.com/api/service/v1/app/a-1/submit")
+    )
+    return inner.call_count
+
+
+def test_app_policy_excludes_500():
+    assert 500 not in _APP_NO_500_RETRY.status_forcelist
+
+
+def test_app_policy_does_not_retry_500_on_the_wire():
+    # A single HTTP attempt: a 500 from an app-management POST is never retried,
+    # so one submit can never spawn duplicate runs.
+    assert _attempts_for_status(500) == 1
+
+
+def test_app_policy_still_retries_transient_statuses():
+    # Sanity: the policy isn't "no retries at all" — genuinely transient infra
+    # statuses (429/502/503/504) remain retryable; only 500 is excluded.
+    for status in (429, 502, 503, 504):
+        assert status in _APP_NO_500_RETRY.status_forcelist
 
 
 @pytest.mark.parametrize(
@@ -284,11 +424,28 @@ def test_remove_schedule(client, mock_api_caller):
 # --------------------------------------------------------------------------- #
 # Async parity (smoke)
 # --------------------------------------------------------------------------- #
+def _async_noop_cm(*_a, **_k):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=None)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
 @pytest.fixture
 def async_mock_api_caller():
     m = Mock(spec=AsyncApiCaller)
     m._call_api = AsyncMock()
+    # Every AsyncAppClient call wraps in `async with max_retries(...)`.
+    m.max_retries = Mock(side_effect=_async_noop_cm)
     return m
+
+
+def _wire_async_asset_search(mock, active_runs=()):
+    results = Mock()
+    results.current_page = Mock(return_value=list(active_runs))
+    mock.asset = Mock()
+    mock.asset.search = AsyncMock(return_value=results)
+    return mock.asset.search
 
 
 @pytest.mark.asyncio
@@ -333,3 +490,40 @@ async def test_async_get_all_passes_name_filter(async_mock_api_caller):
     assert async_mock_api_caller._call_api.call_args.kwargs["query_params"] == {
         "name": "n"
     }
+
+
+@pytest.mark.asyncio
+async def test_async_submit_default_not_idempotent(async_mock_api_caller):
+    search = _wire_async_asset_search(
+        async_mock_api_caller, active_runs=[_running_run("a-1")]
+    )
+    async_mock_api_caller._call_api.return_value = {"slug": "a-1", "run_id": "r-1"}
+    client = AsyncAppClient(async_mock_api_caller)
+    result = await client.submit("a-1")  # default idempotent=False
+    assert result.run_id == "r-1"
+    search.assert_not_called()
+    async_mock_api_caller.max_retries.assert_called_once_with(_APP_NO_500_RETRY)
+
+
+@pytest.mark.asyncio
+async def test_async_submit_idempotent_raises_when_already_running(
+    async_mock_api_caller,
+):
+    _wire_async_asset_search(async_mock_api_caller, active_runs=[_running_run("a-1")])
+    client = AsyncAppClient(async_mock_api_caller)
+    with pytest.raises(AtlanError) as exc:
+        await client.submit("a-1", idempotent=True)
+    assert "already has an active run" in str(exc.value)
+    async_mock_api_caller._call_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_submit_idempotent_false_forces(async_mock_api_caller):
+    search = _wire_async_asset_search(
+        async_mock_api_caller, active_runs=[_running_run("a-1")]
+    )
+    async_mock_api_caller._call_api.return_value = {"slug": "a-1", "run_id": "r-2"}
+    client = AsyncAppClient(async_mock_api_caller)
+    result = await client.submit("a-1", idempotent=False)
+    assert result.run_id == "r-2"
+    search.assert_not_called()

--- a/tests/unit/test_app_generated_inputs.py
+++ b/tests/unit/test_app_generated_inputs.py
@@ -9,6 +9,7 @@ per-app spot checks anchor known contract defaults.
 """
 
 import inspect
+from contextlib import nullcontext
 from unittest.mock import Mock
 
 import pytest
@@ -110,6 +111,8 @@ def test_extra_fields_tolerated(cls):
 def test_create_accepts_generated_inputs(cls):
     api = Mock(spec=ApiCaller)
     api._call_api.return_value = {"slug": "s-1", "version": 1}
+    # app calls run under a no-op max_retries context manager (the no-500 policy)
+    api.max_retries = Mock(side_effect=lambda *a, **k: nullcontext())
     resp = AppClient(api).create(
         app_id=cls._APP_ID,
         entrypoint=cls._ENTRYPOINT,


### PR DESCRIPTION
## What

Two related improvements to the App workflow client (`AppClient` / `AsyncAppClient`).

### 1. `submit(slug, idempotent=False)` — opt-in duplicate-run guard (AICHAT-1660)

`submit` gains an `idempotent` flag (default `False`, backward-compatible). When `True`, it refuses to launch a **duplicate** run while one is already in progress and raises `APP_WORKFLOW_ALREADY_RUNNING` (`InvalidRequestError`) instead:

```python
client.app.submit(slug, idempotent=True)  # raises if a run is already in progress
```

- Detection uses the `AppWorkflowRun` asset (`appWorkflowRunStatus in {Pending, Running}` under the workflow's qualifiedName) — app runs are native Automation-Engine entities, so there is no runs-by-slug REST endpoint; the asset index is the source of truth.
- **Resilient to search-index lag**: the index is eventually consistent (~seconds). If the up-front check misses a just-started run and the server then rejects the submit, the SDK reconfirms against the index before surfacing the error; a genuine server error with no active run is surfaced as-is.
- Mirrors the older `WorkflowClient.rerun(idempotent=...)` convention (opt-in, keyed on the workflow).

Scope note: the backend enforces **one active run per workflow slug** (a concurrent submit of any version is rejected — verified live), so guarding at the slug level is the correct level. If the backend ever permits per-version concurrency, tightening the guard to the published version is a small, localized change.

### 2. App management no longer retries HTTP 500 (AICHAT-1659)

Every `AppClient` request now runs under a retry policy that drops `500` from the retryable statuses. A 500 in app management is not transient (e.g. submitting a workflow that already has an active run), and retrying a non-idempotent POST can spawn multiple runs. One `submit` is now exactly one attempt (transient infra statuses `429/502/503/504` still retry).

## Tests

- Unit (`tests/unit/test_app_client.py`): default-not-idempotent, `idempotent=True` raises up front, 500-recovery confirms already-running vs re-raises a genuine 500, and a behavioral transport test proving a 500 = exactly one HTTP attempt. Sync + async.
- Integration (`tests/integration/test_app_client.py`): submit a run, then a concurrent `idempotent=True` submit is refused.

Full mypy + ruff green.