### PR TITLE
feat(apps): surface billing-strategy on the BigQuery miner builder

### DIFF
--- a/pyatlan/model/apps/bigquery_miner.py
+++ b/pyatlan/model/apps/bigquery_miner.py
@@ -38,6 +38,8 @@ class BigqueryMinerInputs(AppInput):
     """Calculate popularity — Enable popularity metrics generated using mined data."""
     pricing_model: str = Field("on-demand", alias="pricing-model")
     """Pricing Model — Pricing Model configured on BigQuery for running queries"""
+    billing_strategy: str = Field("central", alias="billing-strategy")
+    """Billing Strategy — Where this miner's query history jobs run and get billed. Doesn't change which projects are mined."""
     popularity_window_days: float = Field(30, alias="popularity-window-days")
     """Popularity Window (days) — Number of days to consider for calculating popularity. Maximum allowed value is 30."""
     popularity_exclude_user_config: List[Any] = Field(
@@ -111,6 +113,13 @@ class BigqueryMiner(AppBuilder):
     ) -> "BigqueryMiner":
         """Pricing Model — Pricing Model configured on BigQuery for running queries"""
         self._metadata["pricing-model"] = value
+        return self
+
+    def billing_strategy(
+        self, value: Literal["central", "distributed"]
+    ) -> "BigqueryMiner":
+        """Billing Strategy — Where this miner's query history jobs run and get billed. Doesn't change which projects are mined."""
+        self._metadata["billing_strategy"] = value
         return self
 
     def popularity_window_days(self, value: float) -> "BigqueryMiner":

--- a/tests/unit/apps/test_bigquery_miner.py
+++ b/tests/unit/apps/test_bigquery_miner.py
@@ -17,6 +17,7 @@ def test_bigquery_miner_inputs_defaults():
     assert i.fetch_all_projects_query_history is False
     assert i.calculate_popularity == "true"
     assert i.pricing_model == "on-demand"
+    assert i.billing_strategy == "central"
     assert i.popularity_window_days == 30
     assert i.popularity_exclude_user_config == []
     assert i.control_config_strategy == "default"


### PR DESCRIPTION
The miner gained a billing-strategy field: central (default, today's behaviour) or distributed, which bills each mined project for its own query-history jobs instead of the connection's credential project. Customers create miners through the API, so pyatlan has to carry the key in the same release as the connector.

Hand-written to match generate_apps.py byte for byte rather than regenerated: the generator reads configmaps from a live tenant, and the connector change is not deployed anywhere yet, so a run today would pull the old form and drop the field. Black leaves both files unchanged, so the next real regeneration after deploy is a no-op.

An untouched builder sends billing_strategy "central", matching what the UI form sends — no existing caller changes behaviour.

# ✨ Description

Briefly explain the purpose of this PR and what it covers. Mention any related issues or Jira tickets.

**Jira link:** _[Insert link here]_

---

## 🧩 Type of change

Select all that apply:

- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue) — please include tests! Refer [testing-toolkit 🧪](https://developer.atlan.com/toolkits/testing)
- [ ] 🔄 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧹 Maintenance (chores, cleanup, minor improvements)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📦 Dependency upgrade/downgrade
- [ ] 📚 Documentation updates

---

## ✅ How has this been tested? (e.g. screenshots, logs, workflow links)

Describe how the change was tested. Include:

- Steps to reproduce
- Any relevant screenshots, logs, or links to successful workflow runs
- Details on environment/setup if applicable

---

## 📋 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I’ve performed a self-review of my code
- [ ] I’ve added comments in tricky or complex areas
- [ ] I’ve updated the documentation as needed
- [ ] There are no new warnings from my changes
- [ ] I’ve added tests to cover my changes
- [ ] All new and existing tests pass locally
