### PR TITLE
feat(apps): asset-export-basic export-empty-custom-metadata toggle (CSA-589)

### DIFF
--- a/pyatlan/model/apps/csa_uber_asset_export_basic.py
+++ b/pyatlan/model/apps/csa_uber_asset_export_basic.py
@@ -42,6 +42,10 @@ class CsaUberAssetExportBasicInputs(AppInput):
     """Include data products? — Whether data products (and their domains) should be exported too."""
     include_archived: bool = Field(False, alias="include-archived")
     """Include archived? — Whether to include archived assets in the export (Yes) or only active assets (No)."""
+    export_empty_custom_metadata: str = Field(
+        "true", alias="export-empty-custom-metadata"
+    )
+    """Export Empty Custom Metadata? — Emit a column for every custom metadata attribute defined on the tenant, even when no exported asset has a value for it. Turning this off emits only attributes that carry a value somewhere in the export."""
 
 
 class CsaUberAssetExportBasic(AppBuilder):
@@ -214,6 +218,13 @@ class CsaUberAssetExportBasic(AppBuilder):
     def include_archived(self, enabled: bool = True) -> "CsaUberAssetExportBasic":
         """Include archived? — Whether to include archived assets in the export (Yes) or only active assets (No)."""
         self._metadata["include-archived"] = enabled
+        return self
+
+    def export_empty_custom_metadata(
+        self, value: Literal["true", "false"]
+    ) -> "CsaUberAssetExportBasic":
+        """Export Empty Custom Metadata? — Emit a column for every custom metadata attribute defined on the tenant, even when no exported asset has a value for it. Turning this off emits only attributes that carry a value somewhere in the export."""
+        self._metadata["export-empty-custom-metadata"] = value
         return self
 
 

--- a/tests/unit/apps/test_csa_uber_asset_export_basic.py
+++ b/tests/unit/apps/test_csa_uber_asset_export_basic.py
@@ -19,6 +19,7 @@ def test_csa_uber_asset_export_basic_inputs_defaults():
     assert i.include_glossaries is False
     assert i.include_products is False
     assert i.include_archived is False
+    assert i.export_empty_custom_metadata == "true"
 
 
 def test_csa_uber_asset_export_basic_builder_payload():


### PR DESCRIPTION
## What

Regenerates the `csa-uber-asset-export-basic` app model from the app's latest UI configmap so pyatlan exposes the newly released **`export-empty-custom-metadata`** toggle.

- `CsaUberAssetExportBasicInputs`: new typed field `export_empty_custom_metadata: str` (alias `export-empty-custom-metadata`, default `"true"`).
- `CsaUberAssetExportBasic`: new builder method `export_empty_custom_metadata("true"|"false")`.
- Generated test asserts the default.

## Why (CSA-589)

Asset Export (Basic) only emitted a custom-metadata column when at least one asset in scope held a value for that attribute, so attributes defined-but-unfilled on the tenant were dropped from the export. The app now emits a column for every defined custom-metadata attribute (matching the legacy V2 behaviour) behind this toggle — released app-side. This PR brings the pyatlan typed input + builder in sync so callers can set the flag.

## Scope

Only `csa_uber_asset_export_basic.py` + its test change — regenerated in isolation from the app's configmap, so no other app modules are touched.

## Testing

- `pytest tests/unit/apps/` — 153 passed
- `ruff check` / `ruff format` — clean
